### PR TITLE
Move runtime config to separate file

### DIFF
--- a/.devcontainer/dev_install
+++ b/.devcontainer/dev_install
@@ -3,8 +3,8 @@
 
 cd /workspace
 
-corepack prepare pnpm@9.12.3 --activate
-echo "Updating npm..."
+corepack prepare pnpm@9.13.2 --activate
+echo "Updating pnpm..."
 npm install -g pnpm
 
 echo "Install static web server..."

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 npm-debug.log
 yarn-error.log
 
+# Runtime config
+public/config.js
+
 # Environment files
 **/*.env
 

--- a/run.js
+++ b/run.js
@@ -77,31 +77,22 @@ function getBrowserDir(distDir) {
 }
 
 /**
- * Inject the settings into the index file in the appropriate output directory.
+ * Write the settings into the config file in the appropriate output directory.
  *
  * @param {Object} settings - The configuration settings to write.
- * @throws {Error} If the output directory or the index file does not exist.
+ * @throws {Error} If the output directory does not exist.
  */
 function writeSettings(settings) {
-  let outputDir = DEV_MODE ? 'src' : getBrowserDir('dist');
+  const outputDir = DEV_MODE ? 'public' : getBrowserDir('dist');
 
   // Ensure the output directory exists
   if (!fs.existsSync(outputDir)) {
     throw new Error(`Output directory not found: ${outputDir}`);
   }
 
-  // Ensure the index file exists
-  const indexPath = path.join(outputDir, 'index.html');
-  if (!fs.existsSync(indexPath)) {
-    throw new Error(`Index file not found: ${indexPath}`);
-  }
-
-  // Inject the configuration settings into the index file
+  const configPath = path.join(outputDir, 'config.js');
   const configScript = `window.config = ${JSON.stringify(settings)}`;
-  const indexFile = fs
-    .readFileSync(indexPath, 'utf8')
-    .replace(/window\.config = {[^}]*}/, configScript);
-  fs.writeFileSync(indexPath, indexFile, 'utf8');
+  fs.writeFileSync(configPath, configScript, 'utf8');
 }
 
 /**
@@ -142,7 +133,7 @@ function addHostEntry(name, ip) {
 /**
  * Run the development server on the specified host and port.
  */
-function runDevServer(host, port, logLevel, baseUrl, basicAuth, ssl, sslCert, sslKey) {
+function runDevServer(host, port, ssl, sslCert, sslKey, logLevel, baseUrl, basicAuth) {
   console.log('Running the development server...');
 
   if (baseUrl === `http://${host}:${port}`) {
@@ -194,7 +185,7 @@ function runDevServer(host, port, logLevel, baseUrl, basicAuth, ssl, sslCert, ss
  * It is assumed that the application has already been built
  * and that the "serve" package is installed globally.
  */
-function runProdServer(host, port, logLevel) {
+function runProdServer(host, port, ssl, sslCert, sslKey, logLevel) {
   console.log('Running the production server...');
 
   const distDir = getBrowserDir(path.join(__dirname, 'dist'));
@@ -238,14 +229,14 @@ function main() {
   console.log('Runtime settings =', settings);
 
   const {
-    base_url: baseUrl,
-    basic_auth: basicAuth,
     host,
     port,
-    log_level: logLevel,
     ssl,
     ssl_cert,
     ssl_key,
+    log_level: logLevel,
+    base_url: baseUrl,
+    basic_auth: basicAuth,
   } = settings;
 
   if (!host || !port) {
@@ -270,12 +261,12 @@ function main() {
   (DEV_MODE ? runDevServer : runProdServer)(
     host,
     port,
-    logLevel,
-    baseUrl,
-    basicAuth,
     ssl,
     ssl_cert,
     ssl_key,
+    logLevel,
+    baseUrl,
+    basicAuth,
   );
 }
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,8 +1,7 @@
-import { Component, inject } from '@angular/core';
+import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { SiteFooterComponent } from '@app/portal/features/site-footer/site-footer.component';
 import { SiteHeaderComponent } from '@app/portal/features/site-header/site-header.component';
-import { ConfigService } from '@app/shared/services/config.service';
 
 /**
  * This is the root component of the application.
@@ -12,10 +11,4 @@ import { ConfigService } from '@app/shared/services/config.service';
   imports: [RouterOutlet, SiteHeaderComponent, SiteFooterComponent],
   templateUrl: './app.component.html',
 })
-export class AppComponent {
-  title = 'data-portal';
-
-  #config = inject(ConfigService);
-
-  massUrl = this.#config.massUrl; // just to show that we can access the config service
-}
+export class AppComponent {}

--- a/src/app/portal/features/home-page/home-page.component.html
+++ b/src/app/portal/features/home-page/home-page.component.html
@@ -15,3 +15,7 @@
   Infrastructure initiative (NFDI) and by the contributing institutions.<br />More at
   www.ghga.de.
 </p>
+<p>
+  Just to show that we can access the config, this is the MASS URL:
+  <code>{{ massUrl }}</code>
+</p>

--- a/src/app/portal/features/home-page/home-page.component.ts
+++ b/src/app/portal/features/home-page/home-page.component.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
+import { ConfigService } from '@app/shared/services/config.service';
 
 /**
  * This is the home page component
@@ -8,4 +9,8 @@ import { Component } from '@angular/core';
   imports: [],
   templateUrl: './home-page.component.html',
 })
-export class HomePageComponent {}
+export class HomePageComponent {
+  #config = inject(ConfigService);
+
+  massUrl = this.#config.massUrl; // just to show that we can access the config service
+}

--- a/src/index.html
+++ b/src/index.html
@@ -6,9 +6,7 @@
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
-    <script>
-      window.config = {"base_url":"http://127.0.0.1:8080","mass_url":"/api/mass","metldata_url":"/api/metldata"};
-    </script>
+    <script src="config.js" defer></script>
   </head>
 
   <body class="mat-typography">


### PR DESCRIPTION
I had injected the runtime configuration into the index.html file before in order to avoid the overhead of fetching an additional file from the server. However, since the configuration changes between the different development modes, this would cause unnecessary changes of the index file which is part of the repository. Removing the file from the repository and copying it from a template instead would have been an option. However, the index file is part of the Angular boilerplate that is managed by ng, therefore I decided to better keep it in the repository. So I reverted back to a very simple and clean solution that loads the configuration from a separate file, even if this is not the most efficient.

This PR also adapts the production Dockerfile to this change and to the use of pnmp instead of npm.