### PR TITLE
Memorize location before login in session storage

### DIFF
--- a/src/app/auth/services/auth.service.ts
+++ b/src/app/auth/services/auth.service.ts
@@ -456,6 +456,7 @@ export class AuthService {
     sessionStorage.removeItem('afterLogin');
     if (
       !path ||
+      !path.startsWith('/') ||
       ['/oauth/callback', '/register', '/setup-totp', '/confirm-totp'].some((p) =>
         path!.startsWith(p),
       )

--- a/src/app/auth/services/auth.service.ts
+++ b/src/app/auth/services/auth.service.ts
@@ -452,16 +452,16 @@ export class AuthService {
    * Redirect back to the original page after login
    */
   redirectAfterLogin() {
-    let afterLogin = sessionStorage.getItem('afterLogin');
+    let path = sessionStorage.getItem('afterLogin');
     sessionStorage.removeItem('afterLogin');
     if (
-      !afterLogin ||
-      ['/oauth/callback', '/register', '/setup-totp', '/confirm-totp'].some((path) =>
-        afterLogin!.startsWith(path),
+      !path ||
+      ['/oauth/callback', '/register', '/setup-totp', '/confirm-totp'].some((p) =>
+        path!.startsWith(p),
       )
     ) {
-      afterLogin = '/';
+      path = '/';
     }
-    this.#router.navigate([afterLogin]);
+    this.#router.navigate([path]);
   }
 }

--- a/src/app/auth/services/auth.service.ts
+++ b/src/app/auth/services/auth.service.ts
@@ -31,8 +31,6 @@ export class AuthService {
   #csrf = inject(CsrfService);
   #userSignal = signal<User | null | undefined>(undefined);
 
-  #redirectAfterLogin = '/';
-
   #oidcUserManager: OidcUserManager;
 
   #authUrl = this.#config.authUrl;
@@ -156,7 +154,7 @@ export class AuthService {
    * to the authorization endpoint of the OIDC provider.
    */
   async login(): Promise<void> {
-    this.#redirectAfterLogin = location.pathname;
+    sessionStorage.setItem('afterLogin', location.pathname);
     this.#oidcUserManager.signinRedirect();
   }
 
@@ -215,7 +213,7 @@ export class AuthService {
         await this.#oidcUserManager.removeUser();
         this.#userSignal.set(null);
         this.#csrf.token = null;
-        this.#redirectAfterLogin = '/';
+        sessionStorage.removeItem('afterLogin');
         this.#router.navigate(['/']);
       });
     }
@@ -454,6 +452,16 @@ export class AuthService {
    * Redirect back to the original page after login
    */
   redirectAfterLogin() {
-    this.#router.navigate([this.#redirectAfterLogin]);
+    let afterLogin = sessionStorage.getItem('afterLogin');
+    sessionStorage.removeItem('afterLogin');
+    if (
+      !afterLogin ||
+      ['/oauth/callback', '/register', '/setup-totp', '/confirm-totp'].some((path) =>
+        afterLogin!.startsWith(path),
+      )
+    ) {
+      afterLogin = '/';
+    }
+    this.#router.navigate([afterLogin]);
   }
 }


### PR DESCRIPTION
Since the login process includes redirections and reloading of the page, we need to memorize the original page before login in the session storage.