### PR TITLE
Pin devcontainer base and fix issue with Node 22.12

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,16 +1,19 @@
-FROM mcr.microsoft.com/devcontainers/typescript-node:1-22-bookworm
+FROM mcr.microsoft.com/devcontainers/typescript-node:1.1.8-22-bookworm
 
 RUN apt update && apt install -y dnsutils
 
-# Add some useful bash aliases
+# Add some useful bash aliases:
 RUN echo "alias ll='ls -al'" >> /home/node/.bash_aliases
 
-# Add local npm scripts to the path
+# Add local npm scripts to the path:
 RUN echo "export PATH=\$PATH:/workspace/node_modules/.bin" >> /home/node/.bashrc
 
 # Copy install and launcher script to bin:
 COPY ./dev_install /usr/local/sbin
 COPY ./dev_launcher /usr/local/bin
+
+# Currently the proxy middleware is not working properly with require(esm):
+ENV NODE_OPTIONS="--no-experimental-require-module"
 
 # Don't shut down after the process ends:
 CMD ["sleep", "infinity"]


### PR DESCRIPTION
- The base docker image for the devcontainer was not pinned to an exact version, which means developers could end up using node 22.9 or node 22.12 depending on the time they built the devcontainer image.
- node 22.12 introduced the experimental require(esm) feature which throws an error when the http proxy middleware loads the configuration from proxy.conf.js.
- This PR pins the devcontainer base image to version 1.1.8 which uses node 22.12.
- Therefore this PR also explicitly disables the require(esm) feature using the `NODE_OPTIONS` env var.
- This PR also includes minor updates to pnpm and Angular.
