### PR TITLE
Support more modes for running the dev server (GSI-1233)

### DIFF
--- a/.devcontainer/create_cert
+++ b/.devcontainer/create_cert
@@ -2,18 +2,24 @@
 
 # create self-signed certificate for testing with the browser
 
-BASE_URL=${BASE_URL:-https://data.staging.ghga.dev}
-HOST=${BASE_URL#https://}
 CERTFILE=cert.pem
 KEYFILE=key.pem
 
 cd /workspace/.devcontainer
 
 if ! test -f "$CERTFILE" || ! test -f "$KEYFILE"; then
+  URL=${data_portal_base_url}
+  echo "URL=$URL"
+  HOST=$(echo "$URL" | awk -F[/:] '{print $4}')
+  if [ -z "$HOST" ] || [ "$HOST" == "localhost" ] || [ "$HOST" == "127.0.0.1" ]; then
+    HOST="data.staging.ghga.dev"
+  fi
   echo "Creating self-signed certificate for $HOST"
-  openssl req -x509 -newkey rsa:4096 -nodes \
-    -out "ca-$CERTFILE" -keyout "ca-$KEYFILE" \
-    -subj "/CN=$HOST" -days 356
+  if ! test -f "ca-$CERTFILE" || ! test -f "ca-$KEYFILE"; then
+    openssl req -x509 -newkey rsa:4096 -nodes \
+      -out "ca-$CERTFILE" -keyout "ca-$KEYFILE" \
+      -subj "/CN=$HOST" -days 356
+  fi
   openssl req -newkey rsa:4096 -nodes \
     -out "req-$CERTFILE" -keyout "$KEYFILE" \
     -subj "/CN=$HOST"
@@ -27,6 +33,6 @@ extendedKeyUsage=serverAuth" > "ca.ext"
     -in "req-$CERTFILE" -out "$CERTFILE" \
     -CAcreateserial -days 356 \
     -extfile ca.ext
-  rm -f "req-$CERTFILE" "ca-$KEYFILE" ca.ext "ca-${CERTFILE%.pem}.srl"
+  rm -f "req-$CERTFILE" ca.ext "ca-${CERTFILE%.pem}.srl"
   echo "Add ca-$CERTFILE to your browser's trusted certificates"
 fi

--- a/.devcontainer/dev_launcher
+++ b/.devcontainer/dev_launcher
@@ -2,15 +2,5 @@
 
 cd /workspace
 
-# allow passing modes as arguments
-if [ "$1" = "staging" ]; then
-  export data_portal_base_url="https://data.staging.ghga.dev"
-  if [[ "$2" = *:* ]]; then
-    export data_portal_basic_auth="$2"
-  fi
-elif [ "$1" = "msw" ]; then
-  export data_portal_base_url="http://127.0.0.1:8080"
-fi
-
 # start the development server
-./run.js --dev
+./run.js --dev "$@"

--- a/README.md
+++ b/README.md
@@ -12,30 +12,42 @@ dev_launcher
 
 Once the server is running, open your browser and navigate to `http://localhost:8080/`. The application will automatically reload whenever you modify any of the source files.
 
-By default, this will not use a proxy configuration and the API will be provided via the mock service worker.
+By default, this will not use a proxy configuration; the API will be provided via the mock service worker, and the authentication will be faked as well.
 
 If you want to test the application against the backend provided by the staging deployment, then run:
 
 ```bash
-dev_launcher staging
+dev_launcher --with-backend
 ```
 
-In this case, a proxy configuration will be used that proxies all API endpoints to the staging environment, while the application itself is still served by the development server. You can change the name of the staging backend via the environment variable `data_portal_base_url`.
+In this case, a proxy configuration will be used that proxies all API endpoints to the staging environment, while the application itself is still served by the development server. You can change the name of the staging backend via the environment variable `data_portal_base_url`; by default it will be `data.staging.ghga.dev`.
 
-If you change the hosts file on your host computer so that localhost points to `data.staging.ghga.dev`, then this setup also allows testing authentication using the real OIDC provider. You need to point your browser to `https://data.staging.ghga.dev` in this case. The development server will serve the application via SSL in this setup, using the certificate created in `.devcontainer/cert.pem`. You can add the corresponding CA certificate `.devcontainer/ca-cert.pem` to the trusted certificates of your development computer or web browser to avoid the warnings when loading the page.
+If the staging backend requires an additional Basic authentication, you can set it in the environment variable `data_portal_basic_auth`.
 
-If the staging backend requires an additional Basic authentication, you can set it in the environment variable `data_portal_basic_auth` or pass it on the command line like this:
+If you want to test authentication using the real OIDC provider, then run:
 
 ```bash
-dev_launcher staging username:password
+dev_launcher --with-oidc
 ```
 
-In order to make the OIDC and basic authentication work, you also need to add a `.devcontainer/local.env` file like this, with the proper credentials:
+The development server will serve the application via SSL in this mode, using the certificate created in `.devcontainer/cert.pem`. You should add the corresponding CA certificate `.devcontainer/ca-cert.pem` to the trusted certificates of your development computer or web browser to avoid the warnings when loading the page.
+
+In this mode, the `data_portal_oidc_client_id` and the other OIDC settings must be set properly as required by the OIDC provider.
+
+You will also need to changed the hosts file on your host computer so that localhost points to the staging backend. If you use the default staging backend, then you can browse the application at `https://data.staging.ghga.dev`.
+
+To test against the real backend and with the real OIDC provider, you can start the development server like this:
+
+```bash
+dev_launcher --with-backend --with-oidc
+```
+
+It is recommended to put the necessary settings, particularly the credentials that should be kept secret, in the `local.env` file inside the `.devcontainer` directory. It should look something like this:
 
 ```env
 data_portal_base_url=https://data.staging.ghga.dev
 data_portal_basic_auth=USERNAME:PASSWORD
-data_portal_oidc_client_id=OIDC_DEV_CLIENT_ID
+data_portal_oidc_client_id=THE_OIDC_CLIENT_ID
 ```
 
 ## Code scaffolding

--- a/proxy.conf.js
+++ b/proxy.conf.js
@@ -43,7 +43,7 @@ const useProxy = !target.startsWith('http://127.');
 const config = {};
 
 if (useProxy) {
-  console.log('Configuring proxy server...');
+  console.log(`Running proxy server with target ${target}...`);
   config['/api'] = {
     target,
     changeOrigin: true,

--- a/proxy.conf.js
+++ b/proxy.conf.js
@@ -43,7 +43,7 @@ const useProxy = !target.startsWith('http://127.');
 const config = {};
 
 if (useProxy) {
-  console.log(`Running proxy server with target ${target}...`);
+  console.log(`\nRunning proxy server with target: ${target}`);
   config['/api'] = {
     target,
     changeOrigin: true,
@@ -52,6 +52,10 @@ if (useProxy) {
     logLevel: 'debug',
     configure,
   };
+}
+
+if (baseUrl && !baseUrl.startsWith('http://127.')) {
+  console.log(`\n\x1b[33mPlease point your browser to: ${baseUrl}\x1b[0m\n`);
 }
 
 export default config;

--- a/run.js
+++ b/run.js
@@ -173,6 +173,8 @@ function runDevServer(host, port, ssl, sslCert, sslKey, logLevel, baseUrl, basic
     console.log(`Your host computer should resolve ${hostname} to ${host}.`);
   }
 
+  console.log('Please point your browser to', baseUrl);
+
   // export settings used in the proxy config
   process.env.data_portal_base_url = baseUrl;
   if (basicAuth) {
@@ -264,11 +266,13 @@ function main() {
   let adapted = false;
   if (DEV) {
     msg += ' in development mode';
-    if (WITH_BACKEND) {
+    if (WITH_BACKEND || WITH_OIDC) {
       if (!baseUrl || baseUrl.startsWith('http://127.')) {
         settings.base_url = baseUrl = DEFAULT_BACKEND;
         adapted = true;
       }
+    }
+    if (WITH_BACKEND) {
       msg += ` with ${baseUrl.split('://')[1] || baseUrl} as backend`;
     } else {
       msg += ' with mock API';

--- a/run.js
+++ b/run.js
@@ -173,7 +173,7 @@ function runDevServer(host, port, ssl, sslCert, sslKey, logLevel, baseUrl, basic
     console.log(`Your host computer should resolve ${hostname} to ${host}.`);
   }
 
-  console.log('Please point your browser to', baseUrl);
+  console.log('Please point your browser to:', baseUrl);
 
   // export settings used in the proxy config
   process.env.data_portal_base_url = baseUrl;

--- a/src/app/shared/services/config.service.ts
+++ b/src/app/shared/services/config.service.ts
@@ -19,6 +19,8 @@ interface Config {
   oidc_token_url: string;
   oidc_userinfo_url: string;
   oidc_use_discovery: boolean;
+  mock_api: boolean;
+  mock_oidc: boolean;
 }
 
 declare global {

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,7 @@ import { appConfig } from './app/app.config';
  * Start the application
  */
 async function startApp() {
-  if (isDevMode()) {
+  if (isDevMode() && (window.config.mock_api || window.config.mock_oidc)) {
     const { worker } = await import('./mocks/setup');
     await worker.start({ waitUntilReady: true });
   }

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -6,124 +6,168 @@
 
 import { http, HttpResponse, RequestHandler } from 'msw';
 import { handlers as authHandlers } from './auth';
-import { responses, ResponseValue } from './responses';
+import { responses as apiResponses, ResponseValue } from './responses';
 
 /**
- * This module takes a list of static responses for different endpoints and
+ * Create request handlers for the given responses
+ *
+ * This function takes a list of static responses for different endpoints and
  * converts it into a list of response handlers that can be used to setup MSW.
+ * @param responses - a list of static responses
+ * @returns a list of request handlers
  */
+function createHandlersForResponses(responses: {
+  [endpoint: string]: ResponseValue;
+}): RequestHandler[] {
+  const handlers: RequestHandler[] = [];
 
-/**
- * List of handlers for REST endpoints
- */
-export const handlers: RequestHandler[] = [...authHandlers];
+  type ResponseMap = { [params: string]: ResponseValue };
 
-type ResponseMap = { [params: string]: ResponseValue };
+  const groupedResponses: { [endpoint: string]: ResponseMap } = {};
 
-const groupedResponses: { [endpoint: string]: ResponseMap } = {};
-
-/**
- * Collect responses with different query parameters for the same endpoint
- */
-Object.keys(responses).forEach((endpoint) => {
-  let method, url, params;
-  [method, url] = endpoint.split(' ');
-  method = method.toLowerCase();
-  if (!/^(get|post|patch|put|delete)$/.test(method)) {
-    console.error('Invalid endpoint in fake data:', endpoint);
-    return;
-  }
-  [url, params] = url.split('?');
-  let bareEndpoint = `${method} ${url}`;
-  let responseMap = groupedResponses[bareEndpoint];
-  if (!responseMap) {
-    groupedResponses[bareEndpoint] = responseMap = {};
-  }
-  responseMap[params || '*'] = responses[endpoint];
-});
-
-/**
-  Find the response with the most matching parameters
-  @param request - the request that should be matched
-  @param responseMap - the map of responses to choose from
-  @returns the query string that matches the most parameters
- */
-async function getMatchingParamString(request: Request, responseMap: ResponseMap) {
-  const paramStrings = Object.keys(responseMap);
-  if (paramStrings.length < 2) {
-    return paramStrings[0];
-  }
-  // combine parameters from query string and body
-  const requestParams = new URL(request.url).searchParams;
-  const method = request.method.toLowerCase();
-  if (/post|patch|put|delete/.test(method)) {
-    try {
-      const bodyParams = await request.json();
-      Object.entries(bodyParams).forEach(([key, value]) => {
-        const paramValue = typeof value === 'string' ? value : JSON.stringify(value);
-        requestParams.set(key, paramValue);
-      });
-    } catch {}
-  }
-  // find the response with the most matching parameters
-  let bestParamString: string | null = null;
-  let bestNumParams = 0;
-  let bestStringLen = 0;
-  Object.keys(responseMap).forEach((paramString) => {
-    const params = new URLSearchParams(paramString);
-    const numParams = Array.from(requestParams.keys()).reduce(
-      (num, param) => num + (params.get(param) === requestParams.get(param) ? 1 : 0),
-      0,
-    );
-    if (
-      bestParamString === null ||
-      numParams > bestNumParams ||
-      (numParams === bestNumParams && paramString.length < bestStringLen)
-    ) {
-      bestParamString = paramString;
-      bestNumParams = numParams;
-      bestStringLen = paramString.length;
-    }
-  });
-  return bestParamString;
-}
-
-// create request handlers for the different endpoints
-Object.keys(groupedResponses).forEach((endpoint) => {
-  let method, url;
-  [method, url] = endpoint.split(' ');
-  const responseMap = groupedResponses[endpoint];
   /**
-   * Resolver for the given endpoint
-   * @param options - an options object containing the request
-   * @param options.request - the request object
-   * @returns - a response
+   * Collect responses with different query parameters for the same endpoint
    */
-  const resolver = async ({ request }: { request: Request }) => {
-    const paramString = await getMatchingParamString(request, responseMap);
-    let response = responseMap[paramString || '*'];
-    if (response === undefined) {
-      console.debug('Not mocking', url);
+  Object.keys(responses).forEach((endpoint) => {
+    let method, url, params;
+    [method, url] = endpoint.split(' ');
+    method = method.toLowerCase();
+    if (!/^(get|post|patch|put|delete)$/.test(method)) {
+      console.error('Invalid endpoint in fake data:', endpoint);
       return;
     }
-    if (Object.keys(responseMap).length > 1) {
-      console.debug('Using mock data for params', paramString);
+    [url, params] = url.split('?');
+    let bareEndpoint = `${method} ${url}`;
+    let responseMap = groupedResponses[bareEndpoint];
+    if (!responseMap) {
+      groupedResponses[bareEndpoint] = responseMap = {};
     }
-    let status = 200;
-    if (typeof response === 'number') {
-      status = response;
-      response = undefined;
-    } else if (/post/.test(method)) {
-      status = 201;
-    } else if (/patch|put|delete/.test(method)) {
-      status = 204;
+    responseMap[params || '*'] = responses[endpoint];
+  });
+
+  /**
+   * Find the response with the most matching parameters
+   * @param request - the request that should be matched
+   * @param responseMap - the map of responses to choose from
+   * @returns the query string that matches the most parameters
+   */
+  async function getMatchingParamString(request: Request, responseMap: ResponseMap) {
+    const paramStrings = Object.keys(responseMap);
+    if (paramStrings.length < 2) {
+      return paramStrings[0];
     }
-    return HttpResponse.json(response || undefined, { status });
-  };
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const handler = (http as any)[method];
-  if (!handler) {
-    console.error('Unsupported method:', method);
+    // combine parameters from query string and body
+    const requestParams = new URL(request.url).searchParams;
+    const method = request.method.toLowerCase();
+    if (/post|patch|put|delete/.test(method)) {
+      try {
+        const bodyParams = await request.json();
+        Object.entries(bodyParams).forEach(([key, value]) => {
+          const paramValue = typeof value === 'string' ? value : JSON.stringify(value);
+          requestParams.set(key, paramValue);
+        });
+      } catch {}
+    }
+    // find the response with the most matching parameters
+    let bestParamString: string | null = null;
+    let bestNumParams = 0;
+    let bestStringLen = 0;
+    Object.keys(responseMap).forEach((paramString) => {
+      const params = new URLSearchParams(paramString);
+      const numParams = Array.from(requestParams.keys()).reduce(
+        (num, param) => num + (params.get(param) === requestParams.get(param) ? 1 : 0),
+        0,
+      );
+      if (
+        bestParamString === null ||
+        numParams > bestNumParams ||
+        (numParams === bestNumParams && paramString.length < bestStringLen)
+      ) {
+        bestParamString = paramString;
+        bestNumParams = numParams;
+        bestStringLen = paramString.length;
+      }
+    });
+    return bestParamString;
   }
-  handlers.push(handler.call(http, url, resolver));
-});
+
+  /**
+   * Create request handlers for the different endpoints
+   */
+  Object.keys(groupedResponses).forEach((endpoint) => {
+    let method, url;
+    [method, url] = endpoint.split(' ');
+    const responseMap = groupedResponses[endpoint];
+    /**
+     * Resolver for the given endpoint
+     * @param options - an options object containing the request
+     * @param options.request - the request object
+     * @returns - a response
+     */
+    const resolver = async ({ request }: { request: Request }) => {
+      const paramString = await getMatchingParamString(request, responseMap);
+      let response = responseMap[paramString || '*'];
+      if (response === undefined) {
+        console.debug('Not mocking', request.url);
+        return;
+      }
+      if (Object.keys(responseMap).length > 1) {
+        console.debug('Using mock data for params', paramString);
+      }
+      let status = 200;
+      if (typeof response === 'number') {
+        status = response;
+        response = undefined;
+      } else if (/post/.test(method)) {
+        status = 201;
+      } else if (/patch|put|delete/.test(method)) {
+        status = 204;
+      }
+      return HttpResponse.json(response || undefined, { status });
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const handler = (http as any)[method];
+    if (!handler) {
+      console.error('Unsupported method:', method);
+    }
+    handlers.push(handler.call(http, url, resolver));
+  });
+
+  return handlers;
+}
+
+/**
+ * Create handlers that forward the given path
+ * @param path - the path to forward
+ * @returns a list of request handlers for this path
+ */
+function noMockHandler(path: string): RequestHandler[] {
+  return [
+    http.get(path, () => undefined),
+    http.delete(path, () => undefined),
+    http.patch(path, () => undefined),
+    http.post(path, () => undefined),
+    http.put(path, () => undefined),
+  ];
+}
+
+/**
+ * Create list of all response handlers for MSW
+ */
+
+export const handlers: RequestHandler[] = [];
+
+const config = window.config;
+
+if (config.mock_oidc) {
+  handlers.push(...authHandlers);
+} else {
+  handlers.push(...noMockHandler('/api/auth/*'));
+  handlers.push(...noMockHandler(config.oidc_authority_url + '*'));
+}
+
+if (config.mock_api) {
+  handlers.push(...createHandlersForResponses(apiResponses));
+} else {
+  handlers.push(...noMockHandler('/*'));
+}

--- a/src/mocks/responses.ts
+++ b/src/mocks/responses.ts
@@ -9,13 +9,11 @@ import { metadataGlobalSummary, searchResults } from './data';
 export type ResponseValue = undefined | number | object;
 
 /**
- * MSW responses to be returned for various endpoints.
+ * MSW responses to be returned for various endpoints of our API.
  *
  * The property names must contain a method and a URL separated by a space
  * and the values can be undefined (do not mock this endpoint)
  * a number (use it as response status), or an object (return it as JSON).
- *
- * The responses are automatically converted into
  */
 
 export const responses: { [endpoint: string]: ResponseValue } = {


### PR DESCRIPTION
This PR makes the `run.js` script a bit more flexible. Besides running the production server, it can now run the dev server in four different modes:
- with mock API and fake authentication
- with real backend, but fake authentication
- with real OIDC provider, but mock backend
- with real backend and OIDC provider

The dev server is activated by passing the `--dev` option. The `dev_launcher` script calls the `run.js` script with this option, while passing on any other options.

See also the update documentation in the README file.
