### PR TITLE
Do not use staging URL if not needed

### DIFF
--- a/proxy.conf.js
+++ b/proxy.conf.js
@@ -3,6 +3,7 @@
 const baseUrl = process.env.data_portal_base_url;
 const basicAuth = process.env.data_portal_basic_auth;
 const checkCert = !process.env.data_portal_ignore_cert;
+const proxyHint = process.env.data_portal_proxy_hint;
 
 // filter out standard headers
 function filterHeaders(headers) {
@@ -54,8 +55,8 @@ if (useProxy) {
   };
 }
 
-if (baseUrl && !baseUrl.startsWith('http://127.')) {
-  console.log(`\n\x1b[33mPlease point your browser to: ${baseUrl}\x1b[0m\n`);
+if (proxyHint) {
+  console.log(`\n\x1b[33m${proxyHint}\x1b[0m\n`);
 }
 
 export default config;

--- a/run.js
+++ b/run.js
@@ -267,8 +267,25 @@ function main() {
   if (DEV) {
     msg += ' in development mode';
     if (WITH_BACKEND || WITH_OIDC) {
-      if (!baseUrl || baseUrl.startsWith('http://127.')) {
+      if (
+        !baseUrl ||
+        baseUrl.startsWith('http://127.') ||
+        baseUrl.startsWith('http://localhost')
+      ) {
         settings.base_url = baseUrl = DEFAULT_BACKEND;
+        settings.port = port = 443;
+        settings.ssl = ssl = true;
+        adapted = true;
+      }
+    } else {
+      if (
+        baseUrl &&
+        !baseUrl.startsWith('http:127.') &&
+        !baseUrl.startsWith('http://localhost')
+      ) {
+        settings.base_url = baseUrl = 'http://127.0.0.1:8080';
+        settings.port = port = 8080;
+        settings.ssl = ssl = false;
         adapted = true;
       }
     }


### PR DESCRIPTION
If running without backend and fake OIDC, set base URL to localhost even if configurated differently.

Only show the hint to open the browser with the staging URL when needed.