### PR TITLE
Adding a PageNotFound Component.

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -52,4 +52,12 @@ export const routes: Routes = [
         (m) => m.ConfirmTotpComponent,
       ),
   },
+  {
+    path: '**',
+    loadComponent: () =>
+      import('../app/portal/features/page-not-found/page-not-found.component').then(
+        (m) => m.PageNotFoundComponent,
+      ),
+    title: 'GHGA | Page not found',
+  },
 ];

--- a/src/app/portal/features/page-not-found/page-not-found.component.html
+++ b/src/app/portal/features/page-not-found/page-not-found.component.html
@@ -1,0 +1,11 @@
+<h1>Page not found</h1>
+<p class="text-justify">
+  Sorry we can't see, to find the page you're looking for. If the problem persists,
+  please tell us (<a
+    class="mt-10"
+    target="_blank"
+    rel="noreferrer noopener"
+    href="https://www.ghga.de/about-us/contact"
+    ><mat-icon inline="true" class="align-middle">email</mat-icon></a
+  >).
+</p>

--- a/src/app/portal/features/page-not-found/page-not-found.component.spec.ts
+++ b/src/app/portal/features/page-not-found/page-not-found.component.spec.ts
@@ -1,0 +1,39 @@
+/**
+ * Test the home page component
+ * @copyright The GHGA Authors
+ * @license Apache-2.0
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ActivatedRoute } from '@angular/router';
+import { PageNotFoundComponent } from './page-not-found.component';
+
+describe('PageNotFoundComponent', () => {
+  let component: PageNotFoundComponent;
+  let fixture: ComponentFixture<PageNotFoundComponent>;
+
+  const fakeActivatedRoute = {
+    snapshot: { data: {} },
+  } as ActivatedRoute;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PageNotFoundComponent],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: fakeActivatedRoute,
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PageNotFoundComponent);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/portal/features/page-not-found/page-not-found.component.ts
+++ b/src/app/portal/features/page-not-found/page-not-found.component.ts
@@ -1,0 +1,19 @@
+/**
+ * PageNotFound component
+ * @copyright The GHGA Authors
+ * @license Apache-2.0
+ */
+
+import { Component } from '@angular/core';
+import { MatIcon } from '@angular/material/icon';
+
+/**
+ * This is the PageNotFound Component. It gets displayed if the router cannot resolve a route.
+ */
+@Component({
+  selector: 'app-page-not-found',
+  imports: [MatIcon],
+  templateUrl: './page-not-found.component.html',
+  styleUrl: './page-not-found.component.scss',
+})
+export class PageNotFoundComponent {}


### PR DESCRIPTION
Adding a PageNotFound Component and using it in the router for routes, that cannot be resolved otherwise.