### PR TITLE
Add work package service

### DIFF
--- a/.devcontainer/data-portal.yaml
+++ b/.devcontainer/data-portal.yaml
@@ -14,6 +14,7 @@ base_url: http://127.0.0.1:8080
 auth_url: /api/auth
 mass_url: /api/mass
 metldata_url: /api/metldata
+wps_url: /api/wps
 
 oidc_client_id: ghga-dev-client
 oidc_authority_url: https://login.aai.lifescience-ri.eu/oidc/

--- a/data-portal.default.yaml
+++ b/data-portal.default.yaml
@@ -16,6 +16,7 @@ base_url: http://127.0.0.1:8080
 auth_url: /api/auth
 mass_url: /api/mass
 metldata_url: /api/metldata
+wps_url: /api/wps
 
 oidc_client_id: ghga-client
 oidc_redirect_url: oauth/callback

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -200,6 +200,7 @@ const config: JestConfigWithTsJest = {
 
   // Indicates whether each individual test should be reported during the run
   // verbose: undefined,
+  verbose: true,
 
   // An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
   // watchPathIgnorePatterns: [],

--- a/src/app/shared/services/config.service.spec.ts
+++ b/src/app/shared/services/config.service.spec.ts
@@ -13,6 +13,7 @@ const mockConfig = {
   auth_url: '/test/auth',
   mass_url: '/test/mass',
   metldata_url: '/test/metldata',
+  wps_url: '/test/wps',
   oidc_client_id: 'test-oidc-client-id',
   oidc_redirect_url: 'test/redirect',
   oidc_scope: 'some scope',

--- a/src/app/shared/services/config.service.ts
+++ b/src/app/shared/services/config.service.ts
@@ -11,6 +11,7 @@ interface Config {
   auth_url: string;
   mass_url: string;
   metldata_url: string;
+  wps_url: string;
   oidc_client_id: string;
   oidc_redirect_url: string;
   oidc_scope: string;
@@ -92,6 +93,14 @@ export class ConfigService {
    */
   get metldataUrl(): string {
     return sansEndSlash(this.#config.metldata_url);
+  }
+
+  /**
+   * Gets the WPS URL from the config object.
+   * @returns the WPS URL sans end slash
+   */
+  get wpsUrl(): string {
+    return sansEndSlash(this.#config.wps_url);
   }
 
   /**

--- a/src/app/work-packages/models/dataset.ts
+++ b/src/app/work-packages/models/dataset.ts
@@ -1,0 +1,18 @@
+/**
+ * Dataset model
+ * @copyright The GHGA Authors
+ * @license Apache-2.0
+ */
+
+export interface DatasetFile {
+  id: string;
+  extension: string;
+}
+
+export interface Dataset {
+  id: string;
+  title: string;
+  description: string;
+  stage: 'download' | 'upload';
+  files: DatasetFile[];
+}

--- a/src/app/work-packages/models/workPackage.ts
+++ b/src/app/work-packages/models/workPackage.ts
@@ -1,0 +1,17 @@
+/**
+ * Work package model
+ * @copyright The GHGA Authors
+ * @license Apache-2.0
+ */
+
+export interface WorkPackage {
+  dataset_id: string;
+  file_ids: string[] | null;
+  type: 'download' | 'upload';
+  user_public_crypt4gh_key: string;
+}
+
+export interface WorkPackageResponse {
+  id: string;
+  token: string;
+}

--- a/src/app/work-packages/services/work-package.service.spec.ts
+++ b/src/app/work-packages/services/work-package.service.spec.ts
@@ -1,0 +1,127 @@
+/**
+ * Test test work package service
+ * @copyright The GHGA Authors
+ * @license Apache-2.0
+ */
+
+import { TestBed } from '@angular/core/testing';
+
+import { provideHttpClient } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { computed, signal } from '@angular/core';
+import { AuthService } from '@app/auth/services/auth.service';
+import { ConfigService } from '@app/shared/services/config.service';
+import { Dataset } from '../models/dataset';
+import { WorkPackage, WorkPackageResponse } from '../models/workPackage';
+import { WorkPackageService } from './work-package.service';
+
+const TEST_DATASET: Dataset = {
+  id: 'test-dataset-id',
+  title: 'dataset-title',
+  description: 'dataset-description',
+  stage: 'download',
+  files: [],
+};
+
+const TEST_WORK_PACKAGE: WorkPackage = {
+  dataset_id: 'test-dataset-id',
+  file_ids: ['file-id-1', 'file-id-2'],
+  type: 'download',
+  user_public_crypt4gh_key: 'test-crypt4gh-key',
+};
+
+const TEST_WORK_PACKAGE_RESPONSE: WorkPackageResponse = {
+  id: 'test-work-package-id',
+  token: 'test-work-package-token',
+};
+
+/**
+ * Mock the config service as needed for the work package service
+ */
+class MockConfigService {
+  wpsUrl = 'http://mock.dev/wps';
+}
+
+const userId = signal<string | null>(null); // can be used by the test
+
+/**
+ * Mock the auth service as needed for the work package service
+ */
+class MockAuthService {
+  user = computed(() => ({ id: userId() }));
+}
+
+describe('WorkPackageService', () => {
+  let service: WorkPackageService;
+  let httpMock: HttpTestingController;
+  let testBed: TestBed;
+
+  beforeEach(() => {
+    testBed = TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: ConfigService, useClass: MockConfigService },
+        { provide: AuthService, useClass: MockAuthService },
+        WorkPackageService,
+      ],
+    });
+    service = TestBed.inject(WorkPackageService);
+    httpMock = TestBed.inject(HttpTestingController);
+    userId.set(null); // not logged in
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should return an error when not logged in and datasets are fetched', async () => {
+    userId.set(null);
+    testBed.flushEffects();
+    expect(service.datasetsAreLoading()).toBe(true);
+    expect(service.datasetsError()).toBe(undefined);
+    expect(service.datasets()).toEqual([]);
+    await Promise.resolve(); // wait for loader to return
+    expect(service.datasetsAreLoading()).toBe(false);
+    const error = service.datasetsError();
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe('User not authenticated');
+    expect(service.datasets()).toEqual([]);
+  });
+
+  it('should get the datasets of an authenticated user', async () => {
+    expect(service.datasetsAreLoading()).toBe(true);
+    expect(service.datasetsError()).toBe(undefined);
+    expect(service.datasets()).toEqual([]);
+    userId.set('test-user-id');
+    testBed.flushEffects();
+    expect(service.datasetsAreLoading()).toBe(true);
+    expect(service.datasetsError()).toBe(undefined);
+    expect(service.datasets()).toEqual([]);
+    const req = httpMock.expectOne('http://mock.dev/wps/users/test-user-id/datasets');
+    expect(req.request.method).toBe('GET');
+    req.flush([TEST_DATASET]);
+    await Promise.resolve(); // wait for loader to return
+    expect(service.datasetsAreLoading()).toBe(false);
+    expect(service.datasetsError()).toBe(undefined);
+    expect(service.datasets()).toEqual([TEST_DATASET]);
+  });
+
+  it('should create a work package for download', (done) => {
+    service.createWorkPackage(TEST_WORK_PACKAGE).subscribe((response) => {
+      expect(response).toEqual(TEST_WORK_PACKAGE_RESPONSE);
+      done();
+    });
+    const req = httpMock.expectOne('http://mock.dev/wps/work-packages');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toBe(TEST_WORK_PACKAGE);
+    req.flush(TEST_WORK_PACKAGE_RESPONSE);
+  });
+});

--- a/src/app/work-packages/services/work-package.service.ts
+++ b/src/app/work-packages/services/work-package.service.ts
@@ -1,0 +1,79 @@
+/**
+ * Service handling the work packages.
+ * @copyright The GHGA Authors
+ * @license Apache-2.0
+ */
+
+import { HttpClient } from '@angular/common/http';
+import { computed, inject, Injectable, Signal } from '@angular/core';
+import { rxResource } from '@angular/core/rxjs-interop';
+import { AuthService } from '@app/auth/services/auth.service';
+import { ConfigService } from '@app/shared/services/config.service';
+import { map, Observable } from 'rxjs';
+import { Dataset } from '../models/dataset';
+import { WorkPackage, WorkPackageResponse } from '../models/workPackage';
+
+/**
+ * Work package service
+ */
+@Injectable({ providedIn: 'root' })
+export class WorkPackageService {
+  #http = inject(HttpClient);
+
+  #config = inject(ConfigService);
+  #wpsUrl = this.#config.wpsUrl;
+  #usersUrl = `${this.#wpsUrl}/users`;
+  #workPackagesUrl = `${this.#wpsUrl}/work-packages`;
+
+  #auth = inject(AuthService);
+  #userId = computed<string | null>(() => this.#auth.user()?.id || null);
+
+  /**
+   * Internal resource for loading datasets
+   */
+  #datasets = rxResource<Dataset[], string | null>({
+    request: this.#userId,
+    loader: ({ request: userId }) => {
+      if (!userId) {
+        throw new Error('User not authenticated');
+      }
+      return (
+        this.#http
+          .get<Dataset[]>(`${this.#usersUrl}/${userId}/datasets`)
+          // for now, this only covers downloads
+          .pipe(map((datasets) => datasets.filter(({ stage }) => stage == 'download')))
+      );
+    },
+  }).asReadonly();
+
+  /**
+   * The list of datasets belonging to the logged in user
+   */
+  datasets: Signal<Dataset[]> = computed(() => this.#datasets.value() ?? []);
+
+  /**
+   * Whether the datasets list is loading as a signal
+   */
+  datasetsAreLoading: Signal<boolean> = this.#datasets.isLoading;
+
+  /**
+   * The dataset list error as a signal
+   */
+  datasetsError: Signal<unknown> = this.#datasets.error;
+
+  /**
+   * Create a work package for download
+   * @param workPackage - the work package to be created
+   * @returns a response with the work package id and the download token
+   */
+  createWorkPackage(workPackage: WorkPackage): Observable<WorkPackageResponse> {
+    if (
+      !workPackage ||
+      workPackage.type !== 'download' ||
+      !workPackage.user_public_crypt4gh_key
+    ) {
+      throw new Error('Invalid work package');
+    }
+    return this.#http.post<WorkPackageResponse>(this.#workPackagesUrl, workPackage);
+  }
+}


### PR DESCRIPTION
This PR adds the Angular service with the two methods needed to interact with the work package service on the backend:
- find all datasets for which work packages can be created
- create a work package

The first one is usable via three corresponding signals, but I kept the return value of the second one as an observable, so you need to subscribe. A resource does not seem to be the right paradigm here, and converting to a promise or signal doesn't look very appealing either. So I suggest we stick to observables for mutations.

The PR also shows how we can simplify the code using an rxResource, and how to test it. This is a bit tricky - you need to use the new and hardly known flushEffects if the service is not running in the context of a component. Also, waiting for a tick was needed to get the results from the loader.