### PR TITLE
Barebones implementation of single dataset view

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -10,7 +10,11 @@ import {
   provideExperimentalZonelessChangeDetection,
 } from '@angular/core';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
-import { provideRouter, TitleStrategy } from '@angular/router';
+import {
+  provideRouter,
+  TitleStrategy,
+  withComponentInputBinding,
+} from '@angular/router';
 import { provideHttpCache, withHttpCacheInterceptor } from '@ngneat/cashew';
 
 import { withFetch } from '@angular/common/http';
@@ -20,7 +24,7 @@ import { routes, TemplatePageTitleStrategy } from './app.routes';
 export const appConfig: ApplicationConfig = {
   providers: [
     provideExperimentalZonelessChangeDetection(),
-    provideRouter(routes),
+    provideRouter(routes, withComponentInputBinding()),
     { provide: TitleStrategy, useClass: TemplatePageTitleStrategy },
     provideHttpClient(
       withFetch(),

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -27,6 +27,14 @@ export const routes: Routes = [
       ),
     title: 'Browse Datasets',
   },
+  {
+    path: 'browse/:id',
+    loadComponent: () =>
+      import(
+        './metadata/features/dataset-details-page/dataset-details-page.component'
+      ).then((m) => m.DatasetDetailsPageComponent),
+    title: 'Details for Dataset #id',
+  },
   // routes used in the authentication flows
   {
     path: 'oauth/callback',
@@ -69,7 +77,7 @@ export const routes: Routes = [
       import('../app/portal/features/page-not-found/page-not-found.component').then(
         (m) => m.PageNotFoundComponent,
       ),
-    title: 'GHGA | Page not found',
+    title: 'Page not found',
   },
 ];
 

--- a/src/app/metadata/features/dataset-details-page/dataset-details-page.component.html
+++ b/src/app/metadata/features/dataset-details-page/dataset-details-page.component.html
@@ -1,0 +1,438 @@
+<div>
+  @if (details().accession !== '') {
+    <div class="mb-2 flex items-center justify-between">
+      <button mat-icon-button (click)="goBack()">
+        <mat-icon>keyboard_return</mat-icon>
+      </button>
+      <a mat-raised-button><mat-icon>key</mat-icon>Request Access</a>
+    </div>
+    <div>
+      <h3>{{ details().title }}</h3>
+      <p class="mb-0 text-base">Dataset ID | {{ id() }}</p>
+      @if (details().ega_accession !== '') {
+        <p class="text-base">EGA ID | {{ details().ega_accession }}</p>
+      }
+      <p class="mt-4 text-sm">
+        Study Type |
+        @if (study().types.length > 0) {
+          @for (type of study().types; track $index) {
+            <mat-chip class="small-chips">{{ type | underscoreToSpace }}</mat-chip
+            >{{ ' ' }}
+          }
+        } @else {
+          <mat-chip class="small-chips">None</mat-chip>
+        }
+      </p>
+      <p class="text-sm">
+        Dataset Type |
+        @if (details().types.length > 0) {
+          @for (type of details().types; track $index) {
+            <mat-chip class="small-chips">{{ type }}</mat-chip
+            >{{ ' ' }}
+          }
+        } @else {
+          <mat-chip class="small-chips">None</mat-chip>
+        }
+      </p>
+    </div>
+    <div class="my-4">
+      <p class="flex items-center text-sm text-primary">
+        <mat-icon>description</mat-icon><strong>&nbsp;Description</strong>
+      </p>
+      <div class="border-y border-primary pt-2">
+        @for (par of details().description.split('\\n'); track $index) {
+          <p class="text-sm">{{ par }}</p>
+        }
+      </div>
+    </div>
+    <mat-tab-group mat-stretch-tabs="false" mat-align-tabs="center" dynamicHeight>
+      <mat-tab
+        ><ng-template mat-tab-label
+          ><span class="flex items-center text-primary">
+            <mat-icon>book_2</mat-icon>
+            &nbsp;Study
+          </span>
+        </ng-template>
+        <div class="p-4">
+          @if (study().ega_accession) {
+            <a
+              mat-stroked-button
+              class="float-right"
+              [href]="'https://ega-archive.org/datasets/' + study().ega_accession"
+              target="_blank"
+              rel="noopener noreferrer"
+              ><mat-icon>open_in_new</mat-icon>Visit EGA Study Page</a
+            >
+          }
+          <h4 class="inline-flex items-center">
+            <span
+              class="inline-flex items-center rounded bg-primary/15 p-1 text-4xl text-primary"
+              ><mat-icon inline>book_2</mat-icon></span
+            >&nbsp;Study
+          </h4>
+          <p class="text-base"><strong>ID:</strong> {{ study().accession }}</p>
+          @if (study().ega_accession) {
+            <p class="text-base">
+              <strong>EGA ID:</strong> {{ study().ega_accession }}
+            </p>
+          }
+          <p class="text-base"><strong>Title:</strong> {{ study().title }}</p>
+          <p class="text-base">
+            <strong>Description:</strong> {{ study().description }}
+          </p>
+          <p class="text-base">
+            <strong>Study type: </strong>
+            @if (details().types.length > 0) {
+              @for (type of details().types; track $index; let last = $last) {
+                {{ type }}{{ last ? '' : ', ' }}
+              }
+            } @else {
+              <mat-chip class="small-chips">None</mat-chip>
+            }
+          </p>
+        </div></mat-tab
+      >
+      <mat-tab
+        ><ng-template mat-tab-label
+          ><span class="flex items-center text-primary">
+            <mat-icon>article</mat-icon>
+            &nbsp;Publications
+          </span>
+        </ng-template>
+        <div class="p-4">
+          @if (publications().length > 0) {
+            @for (
+              pub of publications();
+              track pub.title;
+              let idx = $index;
+              let last = $last
+            ) {
+              <div>
+                @if (pub.doi && pub.doi !== '') {
+                  <a
+                    mat-stroked-button
+                    class="float-right"
+                    [href]="'https://www.doi.org/' + pub.doi"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    ><mat-icon>open_in_new</mat-icon>View Publication</a
+                  >
+                }
+                <h4 class="inline-flex items-center">
+                  <span
+                    class="inline-flex items-center rounded bg-primary/15 p-1 text-4xl text-primary"
+                    ><mat-icon inline>article</mat-icon></span
+                  >&nbsp;{{ pub.title }}
+                </h4>
+                <p class="text-base"><strong>Author(s):</strong> {{ pub.author }}</p>
+                <p class="text-base"><strong>Journal:</strong> {{ pub.journal }}</p>
+                <p class="text-base"><strong>Year:</strong> {{ pub.year }}</p>
+                @for (
+                  par of pub.abstract.split('\\n');
+                  track $index;
+                  let first = $first
+                ) {
+                  <p class="text-base">
+                    <strong>{{ first ? 'Abstract: ' : '' }}</strong
+                    >{{ par }}
+                  </p>
+                }
+                @if (!last) {
+                  <hr class="mx-14 my-6" />
+                }
+              </div>
+            }
+          } @else {
+            <h4 class="inline-flex items-center">
+              <span
+                class="inline-flex items-center rounded bg-primary/15 p-1 text-4xl text-primary"
+                ><mat-icon inline>article</mat-icon></span
+              >&nbsp;Publications
+            </h4>
+            <p>No publications available.</p>
+          }
+        </div></mat-tab
+      >
+      <mat-tab
+        ><ng-template mat-tab-label
+          ><span class="flex items-center text-primary">
+            <mat-icon>data_loss_prevention</mat-icon>
+            &nbsp;DAP/DAC
+          </span>
+        </ng-template>
+        <div class="p-4">
+          @if (dap().policy_url !== '') {
+            <a
+              mat-stroked-button
+              class="float-right"
+              [href]="dap().policy_url"
+              target="_blank"
+              rel="noopener noreferrer"
+              ><mat-icon>open_in_new</mat-icon>Data Access Info Form</a
+            >
+          }
+          <h4 class="inline-flex items-center">
+            <span
+              class="inline-flex items-center rounded bg-primary/15 p-1 text-4xl text-primary"
+              ><mat-icon inline>data_loss_prevention</mat-icon></span
+            >&nbsp;Policy and Data Access Committee
+          </h4>
+          <p class="text-base">
+            <strong>Data Access Committee:</strong> {{ dac().alias }}
+          </p>
+          <p class="text-base"><strong>e-Mail:</strong> {{ dac().email }}</p>
+          <p class="text-base"><strong>Data Access Policy:</strong> {{ dap().name }}</p>
+          @for (
+            par of dap().policy_text.split('\\n');
+            track $index;
+            let first = $first
+          ) {
+            <p class="text-base">
+              <strong>{{ first ? 'Policy: ' : '' }}</strong
+              >{{ par }}
+            </p>
+          }
+        </div></mat-tab
+      >
+    </mat-tab-group>
+
+    <hr class="mb-6" />
+
+    <div class="grid grid-cols-1 gap-2">
+      <mat-expansion-panel>
+        <mat-expansion-panel-header>
+          Experiments Summary ({{ experiments().length }} experiment{{
+            experiments().length | addPluralS
+          }})</mat-expansion-panel-header
+        ><ng-template matExpansionPanelContent
+          ><div class="overflow-auto">
+            <table mat-table [dataSource]="experiments()" matSort>
+              <ng-container matColumnDef="accession">
+                <th mat-header-cell *matHeaderCellDef class="font-bold" mat-sort-header>
+                  Experiment ID
+                </th>
+                <td mat-cell *matCellDef="let experiment">
+                  {{ experiment.accession }}
+                </td>
+              </ng-container>
+
+              <ng-container matColumnDef="ega_accession">
+                <th mat-header-cell *matHeaderCellDef class="font-bold" mat-sort-header>
+                  EGA ID
+                </th>
+                <td mat-cell *matCellDef="let experiment">
+                  {{ experiment.ega_accession }}
+                </td>
+              </ng-container>
+
+              <ng-container matColumnDef="title">
+                <th mat-header-cell *matHeaderCellDef class="font-bold" mat-sort-header>
+                  Title
+                </th>
+                <td mat-cell *matCellDef="let experiment">{{ experiment.title }}</td>
+              </ng-container>
+
+              <ng-container matColumnDef="description">
+                <th mat-header-cell *matHeaderCellDef class="font-bold" mat-sort-header>
+                  Description
+                </th>
+                <td mat-cell *matCellDef="let experiment">
+                  {{ experiment.description }}
+                </td>
+              </ng-container>
+
+              <ng-container matColumnDef="method">
+                <th mat-header-cell *matHeaderCellDef class="font-bold" mat-sort-header>
+                  Method
+                </th>
+                <td mat-cell *matCellDef="let experiment">
+                  {{ experiment.experiment_method.name }}
+                </td>
+              </ng-container>
+
+              <ng-container matColumnDef="platform">
+                <th mat-header-cell *matHeaderCellDef class="font-bold" mat-sort-header>
+                  Platform
+                </th>
+                <td mat-cell *matCellDef="let experiment">
+                  {{ experiment.experiment_method.instrument_model }}
+                </td>
+              </ng-container>
+
+              <tr mat-header-row *matHeaderRowDef="experimentsColumns"></tr>
+              <tr mat-row *matRowDef="let row; columns: experimentsColumns"></tr>
+            </table></div></ng-template
+      ></mat-expansion-panel>
+
+      <mat-expansion-panel>
+        <mat-expansion-panel-header>
+          Samples Summary ({{ samples().length }} sample{{
+            samples().length | addPluralS
+          }})</mat-expansion-panel-header
+        ><ng-template matExpansionPanelContent
+          ><div class="overflow-auto">
+            <table mat-table [dataSource]="samples()" matSort>
+              <ng-container matColumnDef="accession">
+                <th mat-header-cell *matHeaderCellDef class="font-bold" mat-sort-header>
+                  Experiment ID
+                </th>
+                <td mat-cell *matCellDef="let sample">{{ sample.accession }}</td>
+              </ng-container>
+
+              <ng-container matColumnDef="ega_accession">
+                <th mat-header-cell *matHeaderCellDef class="font-bold" mat-sort-header>
+                  EGA ID
+                </th>
+                <td mat-cell *matCellDef="let sample">
+                  {{ sample.ega_accession }}
+                </td>
+              </ng-container>
+
+              <ng-container matColumnDef="description">
+                <th mat-header-cell *matHeaderCellDef class="font-bold" mat-sort-header>
+                  Description
+                </th>
+                <td mat-cell *matCellDef="let sample">
+                  {{ sample.description }}
+                </td>
+              </ng-container>
+
+              <ng-container matColumnDef="status">
+                <th mat-header-cell *matHeaderCellDef class="font-bold" mat-sort-header>
+                  Status
+                </th>
+                <td mat-cell *matCellDef="let sample">
+                  {{ sample.case_control_status }}
+                </td>
+              </ng-container>
+
+              <ng-container matColumnDef="sex">
+                <th mat-header-cell *matHeaderCellDef class="font-bold" mat-sort-header>
+                  Sex
+                </th>
+                <td mat-cell *matCellDef="let sample">
+                  {{ sample.individual.sex }}
+                </td>
+              </ng-container>
+
+              <ng-container matColumnDef="phenotype">
+                <th mat-header-cell *matHeaderCellDef class="font-bold" mat-sort-header>
+                  Phenotype
+                </th>
+                <td mat-cell *matCellDef="let sample">
+                  @for (
+                    phenotype of sample.individual.phenotypic_features_terms;
+                    track $index;
+                    let last = $last
+                  ) {
+                    {{ phenotype }}{{ last ? '' : ', ' }}
+                  }
+                </td>
+              </ng-container>
+
+              <ng-container matColumnDef="biospecimen_type">
+                <th mat-header-cell *matHeaderCellDef class="font-bold" mat-sort-header>
+                  Biospeciment type
+                </th>
+                <td mat-cell *matCellDef="let sample">
+                  {{ sample.biospecimen_type }}
+                </td>
+              </ng-container>
+
+              <ng-container matColumnDef="tissue">
+                <th mat-header-cell *matHeaderCellDef class="font-bold" mat-sort-header>
+                  Tissue
+                </th>
+                <td mat-cell *matCellDef="let sample">
+                  {{ sample.biospecimen_tissue_term }}
+                </td>
+              </ng-container>
+
+              <tr mat-header-row *matHeaderRowDef="samplesColumns"></tr>
+              <tr mat-row *matRowDef="let row; columns: samplesColumns"></tr>
+            </table></div></ng-template
+      ></mat-expansion-panel>
+
+      <mat-expansion-panel>
+        <mat-expansion-panel-header>
+          Files Summary ({{ files().length }} file{{
+            files().length | addPluralS
+          }})</mat-expansion-panel-header
+        ><ng-template matExpansionPanelContent
+          ><div class="overflow-auto">
+            <table mat-table [dataSource]="files()" matSort>
+              <ng-container matColumnDef="accession">
+                <th mat-header-cell *matHeaderCellDef class="font-bold" mat-sort-header>
+                  File ID
+                </th>
+                <td mat-cell *matCellDef="let file">{{ file.accession }}</td>
+              </ng-container>
+
+              <ng-container matColumnDef="ega_accession">
+                <th mat-header-cell *matHeaderCellDef class="font-bold" mat-sort-header>
+                  EGA ID
+                </th>
+                <td mat-cell *matCellDef="let file">
+                  {{ file.ega_accession }}
+                </td>
+              </ng-container>
+
+              <ng-container matColumnDef="name">
+                <th mat-header-cell *matHeaderCellDef class="font-bold" mat-sort-header>
+                  File name
+                </th>
+                <td mat-cell *matCellDef="let file">{{ file.name }}</td>
+              </ng-container>
+
+              <ng-container matColumnDef="type">
+                <th mat-header-cell *matHeaderCellDef class="font-bold" mat-sort-header>
+                  File type
+                </th>
+                <td mat-cell *matCellDef="let file">
+                  {{ file.type }}
+                </td>
+              </ng-container>
+
+              <ng-container matColumnDef="origin">
+                <th mat-header-cell *matHeaderCellDef class="font-bold" mat-sort-header>
+                  File origin
+                </th>
+                <td mat-cell *matCellDef="let file">
+                  {{ file.name }}
+                </td>
+              </ng-container>
+
+              <ng-container matColumnDef="size">
+                <th mat-header-cell *matHeaderCellDef class="font-bold" mat-sort-header>
+                  File size
+                </th>
+                <td mat-cell *matCellDef="let file">
+                  {{ file.name }}
+                </td>
+              </ng-container>
+
+              <ng-container matColumnDef="location">
+                <th mat-header-cell *matHeaderCellDef class="font-bold" mat-sort-header>
+                  File location
+                </th>
+                <td mat-cell *matCellDef="let file">
+                  {{ file.name }}
+                </td>
+              </ng-container>
+
+              <ng-container matColumnDef="hash">
+                <th mat-header-cell *matHeaderCellDef class="font-bold" mat-sort-header>
+                  File hash
+                </th>
+                <td mat-cell *matCellDef="let file">
+                  {{ file.name }}
+                </td>
+              </ng-container>
+
+              <tr mat-header-row *matHeaderRowDef="filesColumns"></tr>
+              <tr mat-row *matRowDef="let row; columns: filesColumns"></tr>
+            </table></div></ng-template
+      ></mat-expansion-panel>
+    </div>
+  }
+</div>

--- a/src/app/metadata/features/dataset-details-page/dataset-details-page.component.scss
+++ b/src/app/metadata/features/dataset-details-page/dataset-details-page.component.scss
@@ -1,0 +1,18 @@
+@use '@angular/material' as mat;
+
+mat-chip {
+  @include mat.chips-overrides(
+    (
+      label-text-size: var(--mat-sys-label-medium-size),
+      container-height: 75%,
+    )
+  );
+}
+
+a {
+  @include mat.button-overrides(
+    (
+      protected-container-color: var(--mat-sys-quaternary),
+    )
+  );
+}

--- a/src/app/metadata/features/dataset-details-page/dataset-details-page.component.spec.ts
+++ b/src/app/metadata/features/dataset-details-page/dataset-details-page.component.spec.ts
@@ -1,0 +1,49 @@
+/**
+ * Short module description
+ * @copyright The GHGA Authors
+ * @license Apache-2.0
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { signal } from '@angular/core';
+import { datasetDetails } from '@app/../mocks/data';
+import { MetadataService } from '@app/metadata/services/metadata.service';
+import { DatasetDetailsPageComponent } from './dataset-details-page.component';
+
+/**
+ * Mock the metadata service as needed for the dataset details
+ */
+class MockMetadataService {
+  details = signal(datasetDetails);
+  detailsError = signal(undefined);
+  loadDatasetDetailsID = () => undefined;
+}
+
+describe('DatasetDetailsPageComponent', () => {
+  let component: DatasetDetailsPageComponent;
+  let fixture: ComponentFixture<DatasetDetailsPageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DatasetDetailsPageComponent],
+      providers: [{ provide: MetadataService, useClass: MockMetadataService }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DatasetDetailsPageComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('id', datasetDetails.accession);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should show details', () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+    const text = compiled.textContent;
+    expect(text).toContain('SYNTHETIC GENOMICS');
+    expect(text).toContain('An interesting dataset A of complete example set');
+  });
+});

--- a/src/app/metadata/features/dataset-details-page/dataset-details-page.component.ts
+++ b/src/app/metadata/features/dataset-details-page/dataset-details-page.component.ts
@@ -1,0 +1,109 @@
+/**
+ * Short module description
+ * @copyright The GHGA Authors
+ * @license Apache-2.0
+ */
+
+import { Location } from '@angular/common';
+import { Component, computed, effect, inject, input, OnInit } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatExpansionModule } from '@angular/material/expansion';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSortModule } from '@angular/material/sort';
+import { MatTableModule } from '@angular/material/table';
+import { MatTabsModule } from '@angular/material/tabs';
+import { MetadataService } from '@app/metadata/services/metadata.service';
+import { NotificationService } from '@app/shared/services/notification.service';
+import { AddPluralS } from '@app/shared/utils/add-plural-s.pipe';
+import { UnderscoreToSpace } from '@app/shared/utils/underscore-to-space.pipe';
+
+/**
+ * Component for the dataset details page
+ */
+@Component({
+  selector: 'app-dataset-details-page',
+  imports: [
+    MatIconModule,
+    MatButtonModule,
+    MatChipsModule,
+    UnderscoreToSpace,
+    MatTabsModule,
+    MatTableModule,
+    MatExpansionModule,
+    AddPluralS,
+    MatSortModule,
+  ],
+  templateUrl: './dataset-details-page.component.html',
+  styleUrl: './dataset-details-page.component.scss',
+})
+export class DatasetDetailsPageComponent implements OnInit {
+  id = input.required<string>();
+  #notify = inject(NotificationService);
+  #metadata = inject(MetadataService);
+
+  details = this.#metadata.datasetDetails;
+  dap = computed(() => this.details().data_access_policy);
+  dac = computed(() => this.dap().data_access_committee);
+  study = computed(() => this.details().study);
+  publications = computed(() => this.study().publications);
+  files = computed(() =>
+    [
+      this.details().process_data_files,
+      this.details().experiment_method_supporting_files,
+      this.details().analysis_method_supporting_files,
+      this.details().individual_supporting_files,
+      this.details().research_data_files,
+    ].flatMap((x) => x),
+  );
+  experiments = computed(() => this.details().experiments);
+  samples = computed(() => this.details().samples);
+
+  ngOnInit(): void {
+    this.#metadata.loadDatasetDetailsID(this.id());
+  }
+
+  location: Location;
+  constructor(location: Location) {
+    this.location = location;
+  }
+  goBack() {
+    this.location.historyGo(-1);
+  }
+
+  #errorEffect = effect(() => {
+    if (this.#metadata.datasetDetailsError()) {
+      this.#notify.showError('Error fetching dataset details.');
+    }
+  });
+
+  // TODO: implement sorting and pagination via MatDataSource using signals
+  experimentsColumns: string[] = [
+    'accession',
+    'ega_accession',
+    'title',
+    'description',
+    'method',
+    'platform',
+  ];
+  samplesColumns: string[] = [
+    'accession',
+    'ega_accession',
+    'description',
+    'status',
+    'sex',
+    'phenotype',
+    'biospecimen_type',
+    'tissue',
+  ];
+  filesColumns: string[] = [
+    'accession',
+    'ega_accession',
+    'name',
+    'type',
+    'origin',
+    'size',
+    'location',
+    'hash',
+  ];
+}

--- a/src/app/metadata/features/dataset-expansion-panel/dataset-expansion-panel.component.html
+++ b/src/app/metadata/features/dataset-expansion-panel/dataset-expansion-panel.component.html
@@ -24,7 +24,9 @@
           >
         }
         <a mat-raised-button><mat-icon>key</mat-icon>Request Access</a>
-        <a mat-raised-button><mat-icon>database_search</mat-icon>Dataset Details</a>
+        <a mat-raised-button [routerLink]="hit().id_"
+          ><mat-icon>database_search</mat-icon>Dataset Details</a
+        >
       </div>
       <p><strong>Dataset ID:</strong> {{ summary().accession }}</p>
       @if (hitContent().alias) {

--- a/src/app/metadata/features/dataset-expansion-panel/dataset-expansion-panel.component.ts
+++ b/src/app/metadata/features/dataset-expansion-panel/dataset-expansion-panel.component.ts
@@ -9,6 +9,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatIconModule } from '@angular/material/icon';
+import { RouterLink } from '@angular/router';
 import { Hit } from '@app/metadata/models/search-results';
 import { MetadataService } from '@app/metadata/services/metadata.service';
 import { NotificationService } from '@app/shared/services/notification.service';
@@ -27,6 +28,7 @@ import { UnderscoreToSpace } from '@app/shared/utils/underscore-to-space.pipe';
     MatButtonModule,
     UnderscoreToSpace,
     AddPluralS,
+    RouterLink,
   ],
   templateUrl: './dataset-expansion-panel.component.html',
   styleUrl: './dataset-expansion-panel.component.scss',
@@ -56,7 +58,7 @@ export class DatasetExpansionPanelComponent {
    * On opening of the expansible panel, load the query variables to the injectable service to prepare for the backend query
    */
   onOpen(): void {
-    this.#metadata.loadDatasetID(this.hit().id_);
+    this.#metadata.loadDatasetSummaryID(this.hit().id_);
   }
 
   #errorEffect = effect(() => {

--- a/src/app/metadata/features/global-summary/global-summary.component.spec.ts
+++ b/src/app/metadata/features/global-summary/global-summary.component.spec.ts
@@ -10,12 +10,12 @@ import { signal } from '@angular/core';
 import { GlobalStatsComponent } from './global-summary.component';
 
 import { metadataGlobalSummary } from '@app/../mocks/data';
-import { MetadataService } from '@app/metadata/services/metadata.service';
+import { MetadataStatsService } from '@app/metadata/services/metadataStats.service';
 
 /**
  * Mock the metadata service as needed for the global stats
  */
-class MockMetadataService {
+class MockMetadataStatsService {
   globalSummary = signal(metadataGlobalSummary.resource_stats);
   globalSummaryError = signal(undefined);
   globalSummaryIsLoading = signal(false);
@@ -28,7 +28,9 @@ describe('GlobalStatsComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [GlobalStatsComponent],
-      providers: [{ provide: MetadataService, useClass: MockMetadataService }],
+      providers: [
+        { provide: MetadataStatsService, useClass: MockMetadataStatsService },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(GlobalStatsComponent);

--- a/src/app/metadata/features/global-summary/global-summary.component.ts
+++ b/src/app/metadata/features/global-summary/global-summary.component.ts
@@ -8,9 +8,9 @@ import { Component, computed, effect, inject } from '@angular/core';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { MetadataService } from '@app/metadata/services/metadata.service';
-import { UnderscoreToSpace } from '@app/shared/utils/underscore-to-space.pipe';
+import { MetadataStatsService } from '@app/metadata/services/metadataStats.service';
 import { NotificationService } from '@app/shared/services/notification.service';
+import { UnderscoreToSpace } from '@app/shared/utils/underscore-to-space.pipe';
 
 /**
  * Component for the global summary cards
@@ -23,7 +23,7 @@ import { NotificationService } from '@app/shared/services/notification.service';
 })
 export class GlobalStatsComponent {
   #notify = inject(NotificationService);
-  #metadata = inject(MetadataService);
+  #metadata = inject(MetadataStatsService);
 
   isLoading = this.#metadata.globalSummaryIsLoading;
   error = this.#metadata.globalSummaryError;

--- a/src/app/metadata/features/metadata-browser/metadata-browser.component.scss
+++ b/src/app/metadata/features/metadata-browser/metadata-browser.component.scss
@@ -1,0 +1,11 @@
+@use '@angular/material' as mat;
+
+mat-chip-set mat-chip {
+  @include mat.chips-overrides(
+    (
+      outline-color: var(--mat-sys-tertiary),
+      label-text-color: var(--mat-sys-tertiary),
+      with-trailing-icon-trailing-icon-color: var(--mat-sys-tertiary),
+    )
+  );
+}

--- a/src/app/metadata/models/dataset-details.ts
+++ b/src/app/metadata/models/dataset-details.ts
@@ -1,0 +1,119 @@
+/**
+ * Short module description
+ * @copyright The GHGA Authors
+ * @license Apache-2.0
+ */
+
+export interface DatasetDetails {
+  accession: string;
+  title: string;
+  description: string;
+  types: string[];
+  ega_accession: string;
+  data_access_policy: DataAccessPolicy;
+  study: Study;
+  process_data_files: File[];
+  experiment_method_supporting_files: File[];
+  analysis_method_supporting_files: File[];
+  individual_supporting_files: File[];
+  research_data_files: File[];
+  experiments: Experiment[];
+  samples: Sample[];
+}
+
+interface DataAccessPolicy {
+  name: string;
+  policy_text: string;
+  policy_url: string;
+  data_access_committee: {
+    alias: string;
+    email: string;
+  };
+}
+
+interface Study {
+  accession: string;
+  title: string;
+  description: string;
+  types: string[];
+  ega_accession: string;
+  publications: Publication[];
+}
+
+interface Publication {
+  title: string;
+  abstract: string;
+  author: string;
+  year: number;
+  journal: string;
+  doi: string;
+}
+
+interface File {
+  accession: string;
+  format: string;
+  name: string;
+  ega_accession: string;
+}
+
+export interface Experiment {
+  accession: string;
+  experiment_method: ExperimentMethod;
+  title: string;
+  description: string;
+  ega_accession: string;
+}
+
+interface ExperimentMethod {
+  accession: string;
+  type: string;
+  instrument_model: string;
+}
+
+interface Sample {
+  accession: string;
+  individual: Individual;
+  name: string;
+  description: string;
+  case_control_status: string;
+  ega_accession: string;
+  biospecimen_type: string;
+  biospecimen_tissue_term: string;
+}
+
+interface Individual {
+  sex: string;
+  phenotypic_features_terms: string[];
+}
+
+export const emptyDatasetDetails: DatasetDetails = {
+  accession: '',
+  title: '',
+  description: '',
+  types: [],
+  ega_accession: '',
+  data_access_policy: {
+    name: '',
+    policy_text: '',
+    policy_url: '',
+    data_access_committee: {
+      alias: '',
+      email: '',
+    },
+  },
+  study: {
+    accession: '',
+    title: '',
+    description: '',
+    types: [],
+    ega_accession: '',
+    publications: [],
+  },
+  process_data_files: [],
+  experiment_method_supporting_files: [],
+  analysis_method_supporting_files: [],
+  individual_supporting_files: [],
+  research_data_files: [],
+  experiments: [],
+  samples: [],
+};

--- a/src/app/metadata/services/metadata.service.ts
+++ b/src/app/metadata/services/metadata.service.ts
@@ -6,19 +6,15 @@
 
 import { HttpClient } from '@angular/common/http';
 import { computed, inject, Injectable, resource, signal, Signal } from '@angular/core';
-import {
-  BaseGlobalSummary,
-  emptyGlobalSummary,
-  GlobalSummary,
-} from '@app/metadata/models/global-summary';
 import { ConfigService } from '@app/shared/services/config.service';
-import { firstValueFrom, map } from 'rxjs';
+import { firstValueFrom } from 'rxjs';
+import { DatasetDetails, emptyDatasetDetails } from '../models/dataset-details';
 import { DatasetSummary, emptyDatasetSummary } from '../models/dataset-summary';
 
 /**
  * Metadata Query service
  *
- * This service provides the functionality to fetch the global metadata summary stats from the server.
+ * This service provides the functionality to fetch dataset summaries and details from the server.
  */
 @Injectable({
   providedIn: 'root',
@@ -29,40 +25,15 @@ export class MetadataService {
   #config = inject(ConfigService);
   #metldataUrl = this.#config.metldataUrl;
 
-  #globalSummaryUrl = `${this.#metldataUrl}/stats`;
   #datasetSummaryUrl = `${this.#metldataUrl}/artifacts/stats_public/classes/DatasetStats/resources`;
+  #datasetDetailsUrl = `${this.#metldataUrl}/artifacts/embedded_public/classes/EmbeddedDataset/resources`;
 
-  #globalSummary = resource<GlobalSummary, void>({
-    loader: () =>
-      firstValueFrom(
-        this.#http
-          .get<BaseGlobalSummary>(this.#globalSummaryUrl)
-          .pipe(map((value) => value.resource_stats)),
-      ),
-  }).asReadonly();
-
-  /**
-   * The global summary (empty while loading) as a signal
-   */
-  globalSummary: Signal<GlobalSummary> = computed(
-    () => this.#globalSummary.value() ?? emptyGlobalSummary,
-  );
-
-  /**
-   * Whether the global summary is loading as a signal
-   */
-  globalSummaryIsLoading: Signal<boolean> = this.#globalSummary.isLoading;
-
-  /**
-   * The global summary error as a signal
-   */
-  globalSummaryError: Signal<unknown> = this.#globalSummary.error;
-
-  #id_ = signal<string | undefined>(undefined);
+  #summaryID = signal<string | undefined>(undefined);
+  #detailsID = signal<string | undefined>(undefined);
 
   #datasetSummary = resource({
     request: computed(() => ({
-      id_: this.#id_(),
+      id_: this.#summaryID(),
     })),
     loader: (param) => {
       const id_ = param.request.id_;
@@ -80,14 +51,6 @@ export class MetadataService {
   });
 
   /**
-   * Load the dataset with the given ID
-   * @param id_ Dataset ID
-   */
-  loadDatasetID(id_: string): void {
-    this.#id_.set(id_);
-  }
-
-  /**
    * The dataset summary (empty while loading) as a signal
    */
   datasetSummary: Signal<DatasetSummary> = computed(
@@ -97,10 +60,62 @@ export class MetadataService {
   /**
    * Whether the dataset summary is loading as a signal
    */
-  datasetIsLoading: Signal<boolean> = this.#datasetSummary.isLoading;
+  datasetSummaryIsLoading: Signal<boolean> = this.#datasetSummary.isLoading;
 
   /**
    * The dataset summary error as a signal
    */
   datasetSummaryError: Signal<unknown> = this.#datasetSummary.error;
+
+  /**
+   * Load the dataset with the given ID for the dataset summary call
+   * @param id Dataset ID
+   */
+  loadDatasetSummaryID(id: string): void {
+    this.#summaryID.set(id);
+  }
+
+  #datasetDetails = resource({
+    request: computed(() => ({
+      id_: this.#detailsID(),
+    })),
+    loader: (param) => {
+      const id_ = param.request.id_;
+
+      if (id_) {
+        return Promise.resolve(
+          firstValueFrom(
+            this.#http.get<DatasetDetails>(`${this.#datasetDetailsUrl}/${id_}`),
+          ),
+        );
+      } else {
+        return Promise.resolve(emptyDatasetDetails);
+      }
+    },
+  });
+
+  /**
+   * Load the dataset with the given ID for the dataset details call
+   * @param id Dataset ID
+   */
+  loadDatasetDetailsID(id: string): void {
+    this.#detailsID.set(id);
+  }
+
+  /**
+   * The dataset details (empty while loading) as a signal
+   */
+  datasetDetails: Signal<DatasetDetails> = computed(
+    () => this.#datasetDetails.value() ?? emptyDatasetDetails,
+  );
+
+  /**
+   * Whether the dataset details are loading as a signal
+   */
+  datasetDetailsIsLoading: Signal<boolean> = this.#datasetDetails.isLoading;
+
+  /**
+   * The dataset details error as a signal
+   */
+  datasetDetailsError: Signal<unknown> = this.#datasetDetails.error;
 }

--- a/src/app/metadata/services/metadataStats.service.spec.ts
+++ b/src/app/metadata/services/metadataStats.service.spec.ts
@@ -1,0 +1,38 @@
+/**
+ * Test the metadata service
+ * @copyright The GHGA Authors
+ * @license Apache-2.0
+ */
+
+import { TestBed } from '@angular/core/testing';
+
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { ConfigService } from '@app/shared/services/config.service';
+import { MetadataStatsService } from './metadataStats.service';
+
+/**
+ * Mock the config service as needed by the metadata service
+ */
+class MockConfigService {
+  metldataUrl = 'http://mock.dev/metldata';
+}
+
+describe('MetadataStatsService', () => {
+  let service: MetadataStatsService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: ConfigService, useClass: MockConfigService },
+      ],
+    });
+    service = TestBed.inject(MetadataStatsService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/metadata/services/metadataStats.service.ts
+++ b/src/app/metadata/services/metadataStats.service.ts
@@ -1,0 +1,58 @@
+/**
+ * Short module description
+ * @copyright The GHGA Authors
+ * @license Apache-2.0
+ */
+
+import { HttpClient } from '@angular/common/http';
+import { computed, inject, Injectable, resource, Signal } from '@angular/core';
+import { ConfigService } from '@app/shared/services/config.service';
+import { firstValueFrom, map } from 'rxjs';
+import {
+  BaseGlobalSummary,
+  emptyGlobalSummary,
+  GlobalSummary,
+} from '../models/global-summary';
+
+/**
+ * Metadata Stats service
+ *
+ * This service provides the functionality to fetch the global metadata summary stats from the server.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class MetadataStatsService {
+  #http = inject(HttpClient);
+
+  #config = inject(ConfigService);
+  #metldataUrl = this.#config.metldataUrl;
+
+  #globalSummaryUrl = `${this.#metldataUrl}/stats`;
+
+  #globalSummary = resource<GlobalSummary, void>({
+    loader: () =>
+      firstValueFrom(
+        this.#http
+          .get<BaseGlobalSummary>(this.#globalSummaryUrl)
+          .pipe(map((value) => value.resource_stats)),
+      ),
+  }).asReadonly();
+
+  /**
+   * The global summary (empty while loading) as a signal
+   */
+  globalSummary: Signal<GlobalSummary> = computed(
+    () => this.#globalSummary.value() ?? emptyGlobalSummary,
+  );
+
+  /**
+   * Whether the global summary is loading as a signal
+   */
+  globalSummaryIsLoading: Signal<boolean> = this.#globalSummary.isLoading;
+
+  /**
+   * The global summary error as a signal
+   */
+  globalSummaryError: Signal<unknown> = this.#globalSummary.error;
+}

--- a/src/app/portal/features/home-page/home-page.component.spec.ts
+++ b/src/app/portal/features/home-page/home-page.component.spec.ts
@@ -9,13 +9,13 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { signal } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { metadataGlobalSummary } from '@app/../mocks/data';
-import { MetadataService } from '@app/metadata/services/metadata.service';
+import { MetadataStatsService } from '@app/metadata/services/metadataStats.service';
 import { HomePageComponent } from './home-page.component';
 
 /**
  * Mock the metadata service as needed for the global stats
  */
-class MockMetadataService {
+class MockMetadataStatsService {
   globalSummary = signal(metadataGlobalSummary.resource_stats);
   globalSummaryError = signal(undefined);
   globalSummaryIsLoading = signal(false);
@@ -33,7 +33,7 @@ describe('HomePageComponent', () => {
     await TestBed.configureTestingModule({
       imports: [HomePageComponent],
       providers: [
-        { provide: MetadataService, useClass: MockMetadataService },
+        { provide: MetadataStatsService, useClass: MockMetadataStatsService },
         {
           provide: ActivatedRoute,
           useValue: fakeActivatedRoute,

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -4,6 +4,7 @@
  * @license Apache-2.0
  */
 
+import { DatasetDetails } from '@app/metadata/models/dataset-details';
 import { DatasetSummary } from '@app/metadata/models/dataset-summary';
 import { BaseGlobalSummary } from '@app/metadata/models/global-summary';
 import { SearchResults } from '@app/metadata/models/search-results';
@@ -160,6 +161,88 @@ export const searchResults: SearchResults = {
         title:
           'Test dataset for details and this is also testing whether more than two lines of text actually appear correctly on the expansion panel headers or not at least at a resolution of one thousand nine hundred and twenty pixels wide especially since this can cause issues with the layout of the expansion panels',
       },
+    },
+  ],
+};
+
+export const datasetDetails: DatasetDetails = {
+  accession: 'GHGAD588887987',
+  title: 'Test dataset for details',
+  description:
+    'Test dataset for Metadata Repository get dataset details call. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Vel risus commodo viverra maecenas accumsan lacus vel. Sit amet risus nullam eget felis eget nunc lobortis mattis. Iaculis at erat pellentesque adipiscing commodo. Volutpat consequat mauris nunc congue. At lectus urna duis convallis convallis tellus id interdum velit. Gravida cum sociis natoque penatibus et. Mauris in aliquam sem fringilla ut morbi. Ultrices gravida dictum fusce ut. At consectetur lorem donec massa sapien faucibus et molestie.',
+  types: ['Test Type'],
+  ega_accession: 'EGAD588887987',
+  data_access_policy: {
+    name: 'DAP 1',
+    data_access_committee: {
+      alias: 'Test DAC',
+      email: 'test[at]test[dot]de',
+    },
+    policy_text: `Test policy text. Neque volutpat ac tincidunt vitae semper quis. Mi eget mauris pharetra et ultrices neque ornare. Consectetur purus ut faucibus pulvinar elementum. Tortor at risus viverra adipiscing. Aliquam eleifend mi in nulla. Orci ac auctor augue mauris augue neque gravida. Rutrum tellus pellentesque eu tincidunt tortor aliquam nulla. Turpis massa tincidunt dui ut ornare lectus sit amet. Laoreet suspendisse interdum consectetur libero id faucibus nisl tincidunt. Auctor eu augue ut lectus arcu bibendum. Aenean et tortor at risus.\n
+      Diam phasellus vestibulum lorem sed risus ultricies tristique nulla aliquet. Tempor orci eu lobortis elementum nibh. Tincidunt praesent semper feugiat nibh sed pulvinar proin gravida. Sed nisi lacus sed viverra tellus. Orci dapibus ultrices in iaculis nunc sed augue. Gravida dictum fusce ut placerat orci nulla pellentesque dignissim enim. Facilisi cras fermentum odio eu. Est placerat in egestas erat. At ultrices mi tempus imperdiet nulla malesuada. Tincidunt arcu non sodales neque. Mi bibendum neque egestas congue quisque.\n
+      Pharetra vel turpis nunc eget lorem dolor sed. Commodo quis imperdiet massa tincidunt nunc pulvinar sapien et. Vel pretium lectus quam id leo. Ornare suspendisse sed nisi lacus sed viverra. Magna etiam tempor orci eu lobortis elementum. Aliquam nulla facilisi cras fermentum. Rutrum tellus pellentesque eu tincidunt tortor aliquam nulla facilisi cras. Nam at lectus urna duis. Nunc scelerisque viverra mauris in aliquam sem fringilla ut morbi. At elementum eu facilisis sed odio morbi quis commodo odio. Amet nisl purus in mollis nunc sed id. Tristique sollicitudin nibh sit amet. Arcu risus quis varius quam quisque id diam. Nisl tincidunt eget nullam non. Bibendum arcu vitae elementum curabitur vitae. Vitae aliquet nec ullamcorper sit amet risus nullam eget felis.\n
+      Cum sociis natoque penatibus et magnis. Quam lacus suspendisse faucibus interdum. Lorem dolor sed viverra ipsum. Non pulvinar neque laoreet suspendisse interdum consectetur. Sit amet consectetur adipiscing elit ut aliquam. Mi ipsum faucibus vitae aliquet nec. Eget egestas purus viverra accumsan in nisl nisi scelerisque eu. Vel orci porta non pulvinar neque laoreet suspendisse interdum consectetur. Justo nec ultrices dui sapien eget mi proin sed. Lacus viverra vitae congue eu consequat. Purus viverra accumsan in nisl nisi scelerisque eu ultrices vitae. Pretium aenean pharetra magna ac placerat vestibulum lectus mauris. Consequat interdum varius sit amet mattis vulputate. Venenatis cras sed felis eget velit. Cursus metus aliquam eleifend mi in nulla posuere sollicitudin aliquam. Tristique senectus et netus et malesuada fames ac. Massa enim nec dui nunc mattis enim ut tellus elementum.`,
+    policy_url: 'https://test.com',
+  },
+  study: {
+    accession: 'GHGAS21215636',
+    ega_accession: 'EGAS21215636',
+    types: ['test_genomics'],
+    title: 'Test Study',
+    description:
+      'Test study description. Pharetra convallis posuere morbi leo urna molestie. Ut faucibus pulvinar elementum integer. Nec nam aliquam sem et tortor. Pretium viverra suspendisse potenti nullam ac. Commodo sed egestas egestas fringilla. Tincidunt dui ut ornare lectus sit. Amet massa vitae tortor condimentum lacinia quis vel eros donec. Feugiat pretium nibh ipsum consequat. Pulvinar etiam non quam lacus suspendisse faucibus interdum. Aliquam sem et tortor consequat id.',
+    publications: [
+      {
+        doi: '10.1109/5.771073',
+        abstract:
+          'Test publication abstract. Varius duis at consectetur lorem donec massa sapien faucibus. Amet porttitor eget dolor morbi non arcu. Urna nec tincidunt praesent semper feugiat nibh sed pulvinar proin. Accumsan tortor posuere ac ut consequat semper viverra nam. Vestibulum lorem sed risus ultricies. Sed odio morbi quis commodo odio. Viverra tellus in hac habitasse. Vestibulum mattis ullamcorper velit sed ullamcorper morbi tincidunt. Egestas tellus rutrum tellus pellentesque eu tincidunt tortor. Faucibus purus in massa tempor nec feugiat nisl. Nibh cras pulvinar mattis nunc. In tellus integer feugiat scelerisque varius morbi enim nunc faucibus. Vestibulum mattis ullamcorper velit sed ullamcorper morbi tincidunt. Vitae et leo duis ut diam quam. Egestas fringilla phasellus faucibus scelerisque eleifend donec pretium vulputate. Cras pulvinar mattis nunc sed blandit libero volutpat sed cras. Id diam maecenas ultricies mi eget mauris. Pulvinar etiam non quam lacus suspendisse faucibus interdum posuere lorem. Consequat ac felis donec et.',
+        title: 'Test publication',
+        author: 'Test author',
+        journal: 'Test journal',
+        year: 2023,
+      },
+    ],
+  },
+  process_data_files: [
+    {
+      accession: 'GHGASF956121331',
+      ega_accession: 'EGAF956121331',
+      name: 'Test file 1',
+      format: 'FASTQ',
+    },
+  ],
+  experiment_method_supporting_files: [],
+  analysis_method_supporting_files: [],
+  individual_supporting_files: [],
+  research_data_files: [],
+  experiments: [
+    {
+      accession: 'GHGAE588321315',
+      ega_accession: 'EGAE588321315',
+      title: 'Text Experiment 1',
+      description:
+        'Test Experiment 1. Sagittis purus sit amet volutpat. Tellus cras adipiscing enim eu turpis egestas pretium. Vitae suscipit tellus mauris a diam maecenas sed enim ut. Vulputate enim nulla aliquet porttitor lacus luctus. Egestas sed sed risus pretium quam vulputate dignissim. Netus et malesuada fames ac turpis egestas maecenas. Nisl condimentum id venenatis a condimentum vitae sapien. Commodo quis imperdiet massa tincidunt nunc pulvinar sapien et. Vitae sapien pellentesque habitant morbi tristique senectus. Leo vel fringilla est ullamcorper eget nulla. Tempus egestas sed sed risus.',
+      experiment_method: {
+        accession: 'GHGAEM654513213',
+        type: 'Experiment Method 1',
+        instrument_model: 'Experiment Platform 1',
+      },
+    },
+  ],
+  samples: [
+    {
+      accession: 'GHGASA588321315',
+      ega_accession: 'EGASA588321315',
+      description:
+        'Test Sample 1. Vivamus arcu felis bibendum ut. Eget mi proin sed libero enim. Metus dictum at tempor commodo ullamcorper a lacus. Tincidunt tortor aliquam nulla facilisi cras. Nullam vehicula ipsum a arcu. Malesuada proin libero nunc consequat. Purus faucibus ornare suspendisse sed nisi lacus sed viverra tellus. Elementum eu facilisis sed odio morbi quis. Condimentum id venenatis a condimentum vitae sapien pellentesque habitant. Purus sit amet volutpat consequat mauris nunc. Ultricies mi quis hendrerit dolor magna eget est lorem. Fermentum leo vel orci porta non pulvinar. Integer malesuada nunc vel risus commodo viverra maecenas.',
+      name: 'Test anatomical entity',
+      case_control_status: 'Test control status',
+      individual: {
+        sex: 'Female',
+        phenotypic_features_terms: ['Test phenotypic feature 1'],
+      },
+      biospecimen_type: 'Test biospeciment type 1',
+      biospecimen_tissue_term: 'Test tissue',
     },
   ],
 };

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -40,6 +40,8 @@
       text-label-text-size: medium,
       filled-label-text-size: medium,
       outlined-label-text-size: medium,
+      outlined-outline-color: var(--mat-sys-quaternary),
+      outlined-label-text-color: var(--mat-sys-quaternary),
       protected-label-text-size: medium,
       protected-container-color: var(--mat-sys-tertiary),
       protected-label-text-color: var(--mat-sys-on-primary),
@@ -150,6 +152,6 @@ h6 {
   }
 }
 
-.small-chips .mat-mdc-chip-action {
+.small-chips span .mat-mdc-chip-action {
   padding: 0 6px;
 }


### PR DESCRIPTION
Moved global summary stats API call to its own service
Renamed internal names to dataset details page since it is less confusing and more descriptive
Fixed the small-chips class accidentally not applying
Made outlined buttons use the quaternary colour by default
Made some improvements to the filtering chips, which are now in tertiary colour to differentiate them from the number of datasets chip

TODO:
- [ ] fix tests
- [ ] add sorting and pagination functionality to summary tables
- [ ] add file info service API calls and array merging
- [ ] maybe add scrolling to content of details tab to prevent whitespace shift