### PR TITLE
Centralize date format (GSI-1424)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -155,11 +155,15 @@ export default [
             {
               from: ['config'],
               disallow: ['*'],
-              message: 'Config modules can only import routes and auth services',
+              message: 'Config modules can only import routes, utils and auth services',
             },
             {
               from: ['config'],
-              allow: ['routes', ['service', { context: 'auth' }]],
+              allow: [
+                'routes',
+                ['service', { context: 'auth' }],
+                ['util', { context: 'shared' }],
+              ],
             },
             // modules for routes may import feature components
             {

--- a/src/app/access-requests/features/access-request-dialog/access-request-dialog.component.html
+++ b/src/app/access-requests/features/access-request-dialog/access-request-dialog.component.html
@@ -36,7 +36,7 @@
           {{ fromDateErrorMessage() }}
         </mat-error>
       }
-      <mat-hint>YYYY-MM-DD</mat-hint>
+      <mat-hint>{{ dateInputFormat }}</mat-hint>
       <mat-datepicker-toggle matIconSuffix [for]="from_picker"></mat-datepicker-toggle>
       <mat-datepicker #from_picker></mat-datepicker>
     </mat-form-field>
@@ -56,7 +56,7 @@
           {{ untilDateErrorMessage() }}
         </mat-error>
       }
-      <mat-hint>YYYY-MM-DD</mat-hint>
+      <mat-hint>{{ dateInputFormat }}</mat-hint>
       <mat-datepicker-toggle matIconSuffix [for]="until_picker"></mat-datepicker-toggle>
       <mat-datepicker #until_picker></mat-datepicker>
     </mat-form-field>

--- a/src/app/access-requests/features/access-request-dialog/access-request-dialog.component.html
+++ b/src/app/access-requests/features/access-request-dialog/access-request-dialog.component.html
@@ -36,7 +36,7 @@
           {{ fromDateErrorMessage() }}
         </mat-error>
       }
-      <mat-hint>{{ dateInputFormat }}</mat-hint>
+      <mat-hint>{{ dateInputFormatHint }}</mat-hint>
       <mat-datepicker-toggle matIconSuffix [for]="from_picker"></mat-datepicker-toggle>
       <mat-datepicker #from_picker></mat-datepicker>
     </mat-form-field>
@@ -56,7 +56,7 @@
           {{ untilDateErrorMessage() }}
         </mat-error>
       }
-      <mat-hint>{{ dateInputFormat }}</mat-hint>
+      <mat-hint>{{ dateInputFormatHint }}</mat-hint>
       <mat-datepicker-toggle matIconSuffix [for]="until_picker"></mat-datepicker-toggle>
       <mat-datepicker #until_picker></mat-datepicker>
     </mat-form-field>

--- a/src/app/access-requests/features/access-request-dialog/access-request-dialog.component.ts
+++ b/src/app/access-requests/features/access-request-dialog/access-request-dialog.component.ts
@@ -27,7 +27,7 @@ import { MatFormField, MatHint, MatLabel } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { AccessRequestDialogData } from '@app/access-requests/models/access-requests';
 import { ConfigService } from '@app/shared/services/config.service';
-import { DEFAULT_DATE_INPUT_FORMAT } from '@app/shared/utils/date-formats';
+import { DATE_INPUT_FORMAT_HINT } from '@app/shared/utils/date-formats';
 
 const MILLISECONDS_PER_DAY = 86400000;
 
@@ -62,7 +62,7 @@ export class AccessRequestDialogComponent {
   readonly result = model(this.data);
   readonly email = model(this.data.email);
   readonly description = model(this.data.description);
-  readonly dateInputFormat = DEFAULT_DATE_INPUT_FORMAT;
+  readonly dateInputFormatHint = DATE_INPUT_FORMAT_HINT;
   fromDate = model(this.data.fromDate);
   untilDate = model(this.data.untilDate);
   todayMidnight = new Date();

--- a/src/app/access-requests/features/access-request-dialog/access-request-dialog.component.ts
+++ b/src/app/access-requests/features/access-request-dialog/access-request-dialog.component.ts
@@ -27,6 +27,7 @@ import { MatFormField, MatHint, MatLabel } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { AccessRequestDialogData } from '@app/access-requests/models/access-requests';
 import { ConfigService } from '@app/shared/services/config.service';
+import { DEFAULT_DATE_INPUT_FORMAT } from '@app/shared/utils/date-formats';
 
 const MILLISECONDS_PER_DAY = 86400000;
 
@@ -61,6 +62,7 @@ export class AccessRequestDialogComponent {
   readonly result = model(this.data);
   readonly email = model(this.data.email);
   readonly description = model(this.data.description);
+  readonly dateInputFormat = DEFAULT_DATE_INPUT_FORMAT;
   fromDate = model(this.data.fromDate);
   untilDate = model(this.data.untilDate);
   todayMidnight = new Date();

--- a/src/app/access-requests/features/access-request-manager-dialog/access-request-manager-dialog.component.html
+++ b/src/app/access-requests/features/access-request-manager-dialog/access-request-manager-dialog.component.html
@@ -19,10 +19,10 @@
         <td>{{ data.request_text }}</td>
       </tr>
     </table>
-    <p>The request has been made on {{ data.request_created | date }}.</p>
+    <p>The request has been made on {{ data.request_created | date: 'mediumDate' }}.</p>
     <p>
-      Acess has been requested from {{ data.access_starts | date }} until
-      {{ data.access_ends | date }}.
+      Access has been requested from {{ data.access_starts | date: 'mediumDate' }} until
+      {{ data.access_ends | date: 'mediumDate' }}.
     </p>
     <p>
       Access request is currently <strong>{{ data.status }}</strong

--- a/src/app/access-requests/features/access-request-manager-dialog/access-request-manager-dialog.component.html
+++ b/src/app/access-requests/features/access-request-manager-dialog/access-request-manager-dialog.component.html
@@ -19,10 +19,14 @@
         <td>{{ data.request_text }}</td>
       </tr>
     </table>
-    <p>The request has been made on {{ data.request_created | date: 'mediumDate' }}.</p>
     <p>
-      Access has been requested from {{ data.access_starts | date: 'mediumDate' }} until
-      {{ data.access_ends | date: 'mediumDate' }}.
+      The request has been made on
+      {{ data.request_created | date: friendlyDateFormat }}.
+    </p>
+    <p>
+      Access has been requested from
+      {{ data.access_starts | date: friendlyDateFormat }} until
+      {{ data.access_ends | date: friendlyDateFormat }}.
     </p>
     <p>
       Access request is currently <strong>{{ data.status }}</strong

--- a/src/app/access-requests/features/access-request-manager-dialog/access-request-manager-dialog.component.ts
+++ b/src/app/access-requests/features/access-request-manager-dialog/access-request-manager-dialog.component.ts
@@ -20,6 +20,7 @@ import {
 } from '@app/access-requests/models/access-requests';
 import { ConfirmationService } from '@app/shared/services/confirmation.service';
 import { NotificationService } from '@app/shared/services/notification.service';
+import { DEFAULT_DATE_INPUT_FORMAT } from '@app/shared/utils/date-formats';
 import {
   Iva,
   IvaState,
@@ -43,6 +44,8 @@ export class AccessRequestManagerDialogComponent implements OnInit {
   #ivaService = inject(IvaService);
   #confirmationService = inject(ConfirmationService);
   #notificationService = inject(NotificationService);
+
+  dateInputFormat = DEFAULT_DATE_INPUT_FORMAT;
 
   ivas = this.#ivaService.userIvas;
   ivasAreLoading = this.#ivaService.userIvasAreLoading;

--- a/src/app/access-requests/features/access-request-manager-dialog/access-request-manager-dialog.component.ts
+++ b/src/app/access-requests/features/access-request-manager-dialog/access-request-manager-dialog.component.ts
@@ -20,7 +20,6 @@ import {
 } from '@app/access-requests/models/access-requests';
 import { ConfirmationService } from '@app/shared/services/confirmation.service';
 import { NotificationService } from '@app/shared/services/notification.service';
-import { DEFAULT_DATE_INPUT_FORMAT } from '@app/shared/utils/date-formats';
 import {
   Iva,
   IvaState,
@@ -44,8 +43,6 @@ export class AccessRequestManagerDialogComponent implements OnInit {
   #ivaService = inject(IvaService);
   #confirmationService = inject(ConfirmationService);
   #notificationService = inject(NotificationService);
-
-  dateInputFormat = DEFAULT_DATE_INPUT_FORMAT;
 
   ivas = this.#ivaService.userIvas;
   ivasAreLoading = this.#ivaService.userIvasAreLoading;

--- a/src/app/access-requests/features/access-request-manager-dialog/access-request-manager-dialog.component.ts
+++ b/src/app/access-requests/features/access-request-manager-dialog/access-request-manager-dialog.component.ts
@@ -20,6 +20,7 @@ import {
 } from '@app/access-requests/models/access-requests';
 import { ConfirmationService } from '@app/shared/services/confirmation.service';
 import { NotificationService } from '@app/shared/services/notification.service';
+import { FRIENDLY_DATE_FORMAT } from '@app/shared/utils/date-formats';
 import {
   Iva,
   IvaState,
@@ -40,6 +41,7 @@ import { IvaService } from '@app/verification-addresses/services/iva.service';
 export class AccessRequestManagerDialogComponent implements OnInit {
   readonly dialogRef = inject(MatDialogRef<AccessRequestManagerDialogComponent>);
   readonly data = inject<AccessRequest>(MAT_DIALOG_DATA);
+  readonly friendlyDateFormat = FRIENDLY_DATE_FORMAT;
   #ivaService = inject(IvaService);
   #confirmationService = inject(ConfirmationService);
   #notificationService = inject(NotificationService);

--- a/src/app/access-requests/features/access-request-manager-filter/access-request-manager-filter.component.html
+++ b/src/app/access-requests/features/access-request-manager-filter/access-request-manager-filter.component.html
@@ -38,7 +38,7 @@
           <mat-form-field class="grow">
             <mat-label>Request created from</mat-label>
             <input matInput [matDatepicker]="fromPicker" [(ngModel)]="fromDate" />
-            <mat-hint>{{ dateInputFormat }}</mat-hint>
+            <mat-hint>{{ dateInputFormatHint }}</mat-hint>
             <mat-datepicker-toggle
               matIconSuffix
               [for]="fromPicker"
@@ -58,7 +58,7 @@
           <mat-form-field class="grow">
             <mat-label>Request created until</mat-label>
             <input matInput [matDatepicker]="toPicker" [(ngModel)]="toDate" />
-            <mat-hint>{{ dateInputFormat }}</mat-hint>
+            <mat-hint>{{ dateInputFormatHint }}</mat-hint>
             <mat-datepicker-toggle
               matIconSuffix
               [for]="toPicker"

--- a/src/app/access-requests/features/access-request-manager-filter/access-request-manager-filter.component.html
+++ b/src/app/access-requests/features/access-request-manager-filter/access-request-manager-filter.component.html
@@ -38,7 +38,7 @@
           <mat-form-field class="grow">
             <mat-label>Request created from</mat-label>
             <input matInput [matDatepicker]="fromPicker" [(ngModel)]="fromDate" />
-            <mat-hint>YYYY-MM-DD</mat-hint>
+            <mat-hint>{{ dateInputFormat }}</mat-hint>
             <mat-datepicker-toggle
               matIconSuffix
               [for]="fromPicker"
@@ -58,7 +58,7 @@
           <mat-form-field class="grow">
             <mat-label>Request created until</mat-label>
             <input matInput [matDatepicker]="toPicker" [(ngModel)]="toDate" />
-            <mat-hint>YYYY-MM-DD</mat-hint>
+            <mat-hint>{{ dateInputFormat }}</mat-hint>
             <mat-datepicker-toggle
               matIconSuffix
               [for]="toPicker"

--- a/src/app/access-requests/features/access-request-manager-filter/access-request-manager-filter.component.ts
+++ b/src/app/access-requests/features/access-request-manager-filter/access-request-manager-filter.component.ts
@@ -41,7 +41,7 @@ export class AccessRequestManagerFilterComponent {
 
   #filter = this.#ars.allAccessRequestsFilter;
 
-  dateInputFormat = DEFAULT_DATE_INPUT_FORMAT;
+  readonly dateInputFormat = DEFAULT_DATE_INPUT_FORMAT;
 
   /**
    * The model for the filter properties

--- a/src/app/access-requests/features/access-request-manager-filter/access-request-manager-filter.component.ts
+++ b/src/app/access-requests/features/access-request-manager-filter/access-request-manager-filter.component.ts
@@ -14,6 +14,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { AccessRequestStatus } from '@app/access-requests/models/access-requests';
 import { AccessRequestService } from '@app/access-requests/services/access-request.service';
+import { DEFAULT_DATE_INPUT_FORMAT } from '@app/shared/utils/date-formats';
 
 /**
  * Access Request Manager Filter component.
@@ -39,6 +40,8 @@ export class AccessRequestManagerFilterComponent {
   #ars = inject(AccessRequestService);
 
   #filter = this.#ars.allAccessRequestsFilter;
+
+  dateInputFormat = DEFAULT_DATE_INPUT_FORMAT;
 
   /**
    * The model for the filter properties

--- a/src/app/access-requests/features/access-request-manager-filter/access-request-manager-filter.component.ts
+++ b/src/app/access-requests/features/access-request-manager-filter/access-request-manager-filter.component.ts
@@ -14,7 +14,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { AccessRequestStatus } from '@app/access-requests/models/access-requests';
 import { AccessRequestService } from '@app/access-requests/services/access-request.service';
-import { DEFAULT_DATE_INPUT_FORMAT } from '@app/shared/utils/date-formats';
+import { DATE_INPUT_FORMAT_HINT } from '@app/shared/utils/date-formats';
 
 /**
  * Access Request Manager Filter component.
@@ -41,7 +41,7 @@ export class AccessRequestManagerFilterComponent {
 
   #filter = this.#ars.allAccessRequestsFilter;
 
-  readonly dateInputFormat = DEFAULT_DATE_INPUT_FORMAT;
+  readonly dateInputFormatHint = DATE_INPUT_FORMAT_HINT;
 
   /**
    * The model for the filter properties

--- a/src/app/access-requests/features/access-request-manager-list/access-request-manager-list.component.html
+++ b/src/app/access-requests/features/access-request-manager-list/access-request-manager-list.component.html
@@ -24,19 +24,19 @@
     <ng-container matColumnDef="starts">
       <th mat-header-cell *matHeaderCellDef class="w-36" mat-sort-header>Starts</th>
       <td mat-cell class="text-base" *matCellDef="let ar">
-        {{ ar.access_starts | isoDate }}
+        {{ ar.access_starts | date }}
       </td>
     </ng-container>
     <ng-container matColumnDef="ends">
       <th mat-header-cell *matHeaderCellDef class="w-36" mat-sort-header>Ends</th>
       <td mat-cell class="text-base" *matCellDef="let ar">
-        {{ ar.access_ends | isoDate }}
+        {{ ar.access_ends | date }}
       </td>
     </ng-container>
     <ng-container matColumnDef="requested">
       <th mat-header-cell *matHeaderCellDef class="w-36" mat-sort-header>Requested</th>
       <td mat-cell class="text-base" *matCellDef="let ar">
-        {{ ar.request_created | isoDate }}
+        {{ ar.request_created | date }}
       </td>
     </ng-container>
     <ng-container matColumnDef="status">

--- a/src/app/access-requests/features/access-request-manager-list/access-request-manager-list.component.ts
+++ b/src/app/access-requests/features/access-request-manager-list/access-request-manager-list.component.ts
@@ -4,6 +4,7 @@
  * @license Apache-2.0
  */
 
+import { DatePipe } from '@angular/common';
 import {
   AfterViewInit,
   Component,
@@ -20,7 +21,6 @@ import { MatTableDataSource, MatTableModule } from '@angular/material/table';
 import { AccessRequest } from '@app/access-requests/models/access-requests';
 import { AccessRequestService } from '@app/access-requests/services/access-request.service';
 import { NotificationService } from '@app/shared/services/notification.service';
-import { isoDatePipe } from '@app/shared/utils/iso-date.pipe';
 import { AccessRequestManagerDialogComponent } from '../access-request-manager-dialog/access-request-manager-dialog.component';
 
 /**
@@ -31,7 +31,7 @@ import { AccessRequestManagerDialogComponent } from '../access-request-manager-d
  */
 @Component({
   selector: 'app-access-request-manager-list',
-  imports: [MatTableModule, MatSortModule, MatPaginatorModule, isoDatePipe],
+  imports: [MatTableModule, MatSortModule, MatPaginatorModule, DatePipe],
   templateUrl: './access-request-manager-list.component.html',
   styleUrl: './access-request-manager-list.component.scss',
 })

--- a/src/app/access-requests/features/granted-access-requests-list/granted-access-requests-list.component.html
+++ b/src/app/access-requests/features/granted-access-requests-list/granted-access-requests-list.component.html
@@ -17,8 +17,8 @@
             <a routerLink="/dataset/{{ request.dataset_id }}">{{
               request.dataset_id
             }}</a>
-            from {{ request.access_starts | date: 'mediumDate' }} to
-            {{ request.access_ends | date: 'mediumDate' }} &ndash;
+            from {{ request.access_starts | date: friendlyDateFormat }} to
+            {{ request.access_ends | date: friendlyDateFormat }} &ndash;
             <span class="font-bold">{{ grantedRequest.daysRemaining }}</span> days left.
           </li>
         }

--- a/src/app/access-requests/features/granted-access-requests-list/granted-access-requests-list.component.html
+++ b/src/app/access-requests/features/granted-access-requests-list/granted-access-requests-list.component.html
@@ -17,8 +17,8 @@
             <a routerLink="/dataset/{{ request.dataset_id }}">{{
               request.dataset_id
             }}</a>
-            from {{ request.access_starts | isoDate }} to
-            {{ request.access_ends | isoDate }} &ndash;
+            from {{ request.access_starts | date: 'mediumDate' }} to
+            {{ request.access_ends | date: 'mediumDate' }} &ndash;
             <span class="font-bold">{{ grantedRequest.daysRemaining }}</span> days left.
           </li>
         }

--- a/src/app/access-requests/features/granted-access-requests-list/granted-access-requests-list.component.ts
+++ b/src/app/access-requests/features/granted-access-requests-list/granted-access-requests-list.component.ts
@@ -4,10 +4,10 @@
  * @license Apache-2.0
  */
 
+import { DatePipe } from '@angular/common';
 import { Component, inject } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { AccessRequestService } from '@app/access-requests/services/access-request.service';
-import { isoDatePipe } from '@app/shared/utils/iso-date.pipe';
 import { StencilComponent } from '../../../shared/ui/stencil/stencil/stencil.component';
 
 /**
@@ -15,7 +15,7 @@ import { StencilComponent } from '../../../shared/ui/stencil/stencil/stencil.com
  */
 @Component({
   selector: 'app-granted-access-requests-list',
-  imports: [RouterLink, StencilComponent, isoDatePipe],
+  imports: [RouterLink, StencilComponent, DatePipe],
   templateUrl: './granted-access-requests-list.component.html',
   styleUrl: './granted-access-requests-list.component.scss',
 })

--- a/src/app/access-requests/features/granted-access-requests-list/granted-access-requests-list.component.ts
+++ b/src/app/access-requests/features/granted-access-requests-list/granted-access-requests-list.component.ts
@@ -8,6 +8,7 @@ import { DatePipe } from '@angular/common';
 import { Component, inject } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { AccessRequestService } from '@app/access-requests/services/access-request.service';
+import { FRIENDLY_DATE_FORMAT } from '@app/shared/utils/date-formats';
 import { StencilComponent } from '../../../shared/ui/stencil/stencil/stencil.component';
 
 /**
@@ -20,6 +21,7 @@ import { StencilComponent } from '../../../shared/ui/stencil/stencil/stencil.com
   styleUrl: './granted-access-requests-list.component.scss',
 })
 export class GrantedAccessRequestsListComponent {
+  readonly friendlyDateFormat = FRIENDLY_DATE_FORMAT;
   #ars = inject(AccessRequestService);
 
   grantedRequests = this.#ars.grantedUserAccessRequests;

--- a/src/app/access-requests/features/pending-access-requests-list/pending-access-requests-list.component.html
+++ b/src/app/access-requests/features/pending-access-requests-list/pending-access-requests-list.component.html
@@ -16,8 +16,8 @@
             <a routerLink="/dataset/{{ request.dataset_id }}">{{
               request.dataset_id
             }}</a>
-            from {{ request.access_starts | date: 'mediumDate' }} to
-            {{ request.access_ends | date: 'mediumDate' }}.
+            from {{ request.access_starts | date: friendlyDateFormat }} to
+            {{ request.access_ends | date: friendlyDateFormat }}.
           </li>
         }
       </ul>

--- a/src/app/access-requests/features/pending-access-requests-list/pending-access-requests-list.component.html
+++ b/src/app/access-requests/features/pending-access-requests-list/pending-access-requests-list.component.html
@@ -16,8 +16,8 @@
             <a routerLink="/dataset/{{ request.dataset_id }}">{{
               request.dataset_id
             }}</a>
-            from {{ request.access_starts | isoDate }} to
-            {{ request.access_ends | isoDate }}.
+            from {{ request.access_starts | date: 'mediumDate' }} to
+            {{ request.access_ends | date: 'mediumDate' }}.
           </li>
         }
       </ul>

--- a/src/app/access-requests/features/pending-access-requests-list/pending-access-requests-list.component.ts
+++ b/src/app/access-requests/features/pending-access-requests-list/pending-access-requests-list.component.ts
@@ -8,6 +8,7 @@ import { DatePipe } from '@angular/common';
 import { Component, inject } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { AccessRequestService } from '@app/access-requests/services/access-request.service';
+import { FRIENDLY_DATE_FORMAT } from '@app/shared/utils/date-formats';
 import { StencilComponent } from '../../../shared/ui/stencil/stencil/stencil.component';
 
 /**
@@ -20,6 +21,7 @@ import { StencilComponent } from '../../../shared/ui/stencil/stencil/stencil.com
   styleUrl: './pending-access-requests-list.component.scss',
 })
 export class PendingAccessRequestsListComponent {
+  readonly friendlyDateFormat = FRIENDLY_DATE_FORMAT;
   #ars = inject(AccessRequestService);
 
   pendingRequests = this.#ars.pendingUserAccessRequests;

--- a/src/app/access-requests/features/pending-access-requests-list/pending-access-requests-list.component.ts
+++ b/src/app/access-requests/features/pending-access-requests-list/pending-access-requests-list.component.ts
@@ -4,10 +4,10 @@
  * @license Apache-2.0
  */
 
+import { DatePipe } from '@angular/common';
 import { Component, inject } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { AccessRequestService } from '@app/access-requests/services/access-request.service';
-import { isoDatePipe } from '@app/shared/utils/iso-date.pipe';
 import { StencilComponent } from '../../../shared/ui/stencil/stencil/stencil.component';
 
 /**
@@ -15,7 +15,7 @@ import { StencilComponent } from '../../../shared/ui/stencil/stencil/stencil.com
  */
 @Component({
   selector: 'app-pending-access-requests-list',
-  imports: [RouterLink, StencilComponent, isoDatePipe],
+  imports: [RouterLink, StencilComponent, DatePipe],
   templateUrl: './pending-access-requests-list.component.html',
   styleUrl: './pending-access-requests-list.component.scss',
 })

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -22,11 +22,11 @@ import { withFetch } from '@angular/common/http';
 import { provideDateFnsAdapter } from '@angular/material-date-fns-adapter';
 import { MAT_DATE_LOCALE } from '@angular/material/core';
 import { csrfInterceptor } from '@app/auth/services/csrf.service';
-import { enGB } from 'date-fns/locale';
 import { routes, TemplatePageTitleStrategy } from './app.routes';
 
 import {
   DEFAULT_DATE_FORMATS,
+  DEFAULT_DATE_LOCALE,
   DEFAULT_DATE_OUTPUT_FORMAT,
 } from '@app/shared/utils/date-formats';
 
@@ -42,7 +42,7 @@ export const appConfig: ApplicationConfig = {
     // cache all GET requests by default
     provideHttpCache({ strategy: 'implicit' }),
     provideAnimationsAsync(),
-    { provide: MAT_DATE_LOCALE, useValue: enGB },
+    { provide: MAT_DATE_LOCALE, useValue: DEFAULT_DATE_LOCALE },
     {
       provide: DATE_PIPE_DEFAULT_OPTIONS,
       useValue: { dateFormat: DEFAULT_DATE_OUTPUT_FORMAT },

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -25,8 +25,10 @@ import { csrfInterceptor } from '@app/auth/services/csrf.service';
 import { enGB } from 'date-fns/locale';
 import { routes, TemplatePageTitleStrategy } from './app.routes';
 
-const DEFAULT_INPUT_DATE_FORMAT = 'yyyy-MM-dd';
-const DEFAULT_OUTPUT_DATE_FORMAT = 'yyyy-MM-dd';
+import {
+  DEFAULT_DATE_FORMATS,
+  DEFAULT_DATE_OUTPUT_FORMAT,
+} from '@app/shared/utils/date-formats';
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -43,29 +45,8 @@ export const appConfig: ApplicationConfig = {
     { provide: MAT_DATE_LOCALE, useValue: enGB },
     {
       provide: DATE_PIPE_DEFAULT_OPTIONS,
-      useValue: { dateFormat: DEFAULT_OUTPUT_DATE_FORMAT },
+      useValue: { dateFormat: DEFAULT_DATE_OUTPUT_FORMAT },
     },
-    provideDateFnsAdapter({
-      parse: {
-        dateInput: [
-          DEFAULT_INPUT_DATE_FORMAT,
-          'yyyy-MM-dd',
-          'dd.MM.yyyy',
-          'dd/MM/yyyy',
-          'd.M.yyyy',
-          'd/M/yyyy',
-          'dd.M.yyyy',
-          'dd/M/yyyy',
-          'd.MM.yyyy',
-          'd/MM/yyyy',
-        ],
-      },
-      display: {
-        dateInput: DEFAULT_INPUT_DATE_FORMAT,
-        monthYearLabel: 'MMM yyyy',
-        dateA11yLabel: 'LL',
-        monthYearA11yLabel: 'MMMM yyyy',
-      },
-    }),
+    provideDateFnsAdapter(DEFAULT_DATE_FORMATS),
   ],
 };

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -17,12 +17,16 @@ import {
 } from '@angular/router';
 import { provideHttpCache, withHttpCacheInterceptor } from '@ngneat/cashew';
 
+import { DATE_PIPE_DEFAULT_OPTIONS } from '@angular/common';
 import { withFetch } from '@angular/common/http';
 import { provideDateFnsAdapter } from '@angular/material-date-fns-adapter';
 import { MAT_DATE_LOCALE } from '@angular/material/core';
 import { csrfInterceptor } from '@app/auth/services/csrf.service';
 import { enGB } from 'date-fns/locale';
 import { routes, TemplatePageTitleStrategy } from './app.routes';
+
+const DEFAULT_INPUT_DATE_FORMAT = 'yyyy-MM-dd';
+const DEFAULT_OUTPUT_DATE_FORMAT = 'yyyy-MM-dd';
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -37,9 +41,14 @@ export const appConfig: ApplicationConfig = {
     provideHttpCache({ strategy: 'implicit' }),
     provideAnimationsAsync(),
     { provide: MAT_DATE_LOCALE, useValue: enGB },
+    {
+      provide: DATE_PIPE_DEFAULT_OPTIONS,
+      useValue: { dateFormat: DEFAULT_OUTPUT_DATE_FORMAT },
+    },
     provideDateFnsAdapter({
       parse: {
         dateInput: [
+          DEFAULT_INPUT_DATE_FORMAT,
           'yyyy-MM-dd',
           'dd.MM.yyyy',
           'dd/MM/yyyy',
@@ -52,7 +61,7 @@ export const appConfig: ApplicationConfig = {
         ],
       },
       display: {
-        dateInput: 'yyyy-MM-dd',
+        dateInput: DEFAULT_INPUT_DATE_FORMAT,
         monthYearLabel: 'MMM yyyy',
         dateA11yLabel: 'LL',
         monthYearA11yLabel: 'MMMM yyyy',

--- a/src/app/shared/utils/date-formats.ts
+++ b/src/app/shared/utils/date-formats.ts
@@ -5,6 +5,9 @@
  */
 
 import { MatDateFormats } from '@angular/material/core';
+import { enGB } from 'date-fns/locale';
+
+export const DEFAULT_DATE_LOCALE = enGB;
 
 export const DEFAULT_DATE_OUTPUT_FORMAT = 'yyyy-MM-dd';
 export const DEFAULT_DATE_INPUT_FORMAT = 'yyyy-MM-dd';

--- a/src/app/shared/utils/date-formats.ts
+++ b/src/app/shared/utils/date-formats.ts
@@ -11,6 +11,7 @@ export const DEFAULT_DATE_LOCALE = enGB;
 
 export const DEFAULT_DATE_OUTPUT_FORMAT = 'yyyy-MM-dd';
 export const DEFAULT_DATE_INPUT_FORMAT = 'yyyy-MM-dd';
+export const DATE_INPUT_FORMAT_HINT = 'YYYY-MM-DD';
 
 export const DEFAULT_DATE_FORMATS: MatDateFormats = {
   parse: {

--- a/src/app/shared/utils/date-formats.ts
+++ b/src/app/shared/utils/date-formats.ts
@@ -1,0 +1,32 @@
+/**
+ * Date formats used throughout the application.
+ * @copyright The GHGA Authors
+ * @license Apache-2.0
+ */
+
+import { MatDateFormats } from '@angular/material/core';
+
+export const DEFAULT_DATE_OUTPUT_FORMAT = 'yyyy-MM-dd';
+export const DEFAULT_DATE_INPUT_FORMAT = 'yyyy-MM-dd';
+
+export const DEFAULT_DATE_FORMATS: MatDateFormats = {
+  parse: {
+    dateInput: [
+      'yyyy-MM-dd',
+      'dd.MM.yyyy',
+      'dd/MM/yyyy',
+      'd.M.yyyy',
+      'd/M/yyyy',
+      'dd.M.yyyy',
+      'dd/M/yyyy',
+      'd.MM.yyyy',
+      'd/MM/yyyy',
+    ],
+  },
+  display: {
+    dateInput: DEFAULT_DATE_INPUT_FORMAT,
+    monthYearLabel: 'MMM yyyy',
+    dateA11yLabel: 'LL',
+    monthYearA11yLabel: 'MMMM yyyy',
+  },
+};

--- a/src/app/shared/utils/date-formats.ts
+++ b/src/app/shared/utils/date-formats.ts
@@ -11,6 +11,7 @@ export const DEFAULT_DATE_LOCALE = enGB;
 
 export const DEFAULT_DATE_OUTPUT_FORMAT = 'yyyy-MM-dd';
 export const DEFAULT_DATE_INPUT_FORMAT = 'yyyy-MM-dd';
+export const FRIENDLY_DATE_FORMAT = 'MMMM d, y';
 export const DATE_INPUT_FORMAT_HINT = 'YYYY-MM-DD';
 
 export const DEFAULT_DATE_FORMATS: MatDateFormats = {

--- a/src/app/verification-addresses/features/iva-manager-filter/iva-manager-filter.component.html
+++ b/src/app/verification-addresses/features/iva-manager-filter/iva-manager-filter.component.html
@@ -24,7 +24,7 @@
           <mat-form-field class="grow">
             <mat-label>Changed dates ranging from</mat-label>
             <input matInput [matDatepicker]="fromPicker" [(ngModel)]="fromDate" />
-            <mat-hint>YYYY-MM-DD</mat-hint>
+            <mat-hint>{{ dateInputFormat }}</mat-hint>
             <mat-datepicker-toggle
               matIconSuffix
               [for]="fromPicker"
@@ -44,7 +44,7 @@
           <mat-form-field class="grow">
             <mat-label>Changed dates ranging to</mat-label>
             <input matInput [matDatepicker]="toPicker" [(ngModel)]="toDate" />
-            <mat-hint>YYYY-MM-DD</mat-hint>
+            <mat-hint>{{ dateInputFormat }}</mat-hint>
             <mat-datepicker-toggle
               matIconSuffix
               [for]="toPicker"

--- a/src/app/verification-addresses/features/iva-manager-filter/iva-manager-filter.component.html
+++ b/src/app/verification-addresses/features/iva-manager-filter/iva-manager-filter.component.html
@@ -24,7 +24,7 @@
           <mat-form-field class="grow">
             <mat-label>Changed dates ranging from</mat-label>
             <input matInput [matDatepicker]="fromPicker" [(ngModel)]="fromDate" />
-            <mat-hint>{{ dateInputFormat }}</mat-hint>
+            <mat-hint>{{ dateInputFormatHint }}</mat-hint>
             <mat-datepicker-toggle
               matIconSuffix
               [for]="fromPicker"
@@ -44,7 +44,7 @@
           <mat-form-field class="grow">
             <mat-label>Changed dates ranging to</mat-label>
             <input matInput [matDatepicker]="toPicker" [(ngModel)]="toDate" />
-            <mat-hint>{{ dateInputFormat }}</mat-hint>
+            <mat-hint>{{ dateInputFormatHint }}</mat-hint>
             <mat-datepicker-toggle
               matIconSuffix
               [for]="toPicker"

--- a/src/app/verification-addresses/features/iva-manager-filter/iva-manager-filter.component.ts
+++ b/src/app/verification-addresses/features/iva-manager-filter/iva-manager-filter.component.ts
@@ -12,6 +12,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
+import { DEFAULT_DATE_INPUT_FORMAT } from '@app/shared/utils/date-formats';
 import { IvaState, IvaStatePrintable } from '@app/verification-addresses/models/iva';
 import { IvaService } from '@app/verification-addresses/services/iva.service';
 
@@ -39,6 +40,8 @@ export class IvaManagerFilterComponent {
   #ivaService = inject(IvaService);
 
   #filter = this.#ivaService.allIvasFilter;
+
+  dateInputFormat = DEFAULT_DATE_INPUT_FORMAT;
 
   /**
    * The model for the filter properties

--- a/src/app/verification-addresses/features/iva-manager-filter/iva-manager-filter.component.ts
+++ b/src/app/verification-addresses/features/iva-manager-filter/iva-manager-filter.component.ts
@@ -41,7 +41,7 @@ export class IvaManagerFilterComponent {
 
   #filter = this.#ivaService.allIvasFilter;
 
-  dateInputFormat = DEFAULT_DATE_INPUT_FORMAT;
+  readonly dateInputFormat = DEFAULT_DATE_INPUT_FORMAT;
 
   /**
    * The model for the filter properties

--- a/src/app/verification-addresses/features/iva-manager-filter/iva-manager-filter.component.ts
+++ b/src/app/verification-addresses/features/iva-manager-filter/iva-manager-filter.component.ts
@@ -12,7 +12,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
-import { DEFAULT_DATE_INPUT_FORMAT } from '@app/shared/utils/date-formats';
+import { DATE_INPUT_FORMAT_HINT } from '@app/shared/utils/date-formats';
 import { IvaState, IvaStatePrintable } from '@app/verification-addresses/models/iva';
 import { IvaService } from '@app/verification-addresses/services/iva.service';
 
@@ -41,7 +41,7 @@ export class IvaManagerFilterComponent {
 
   #filter = this.#ivaService.allIvasFilter;
 
-  readonly dateInputFormat = DEFAULT_DATE_INPUT_FORMAT;
+  readonly dateInputFormatHint = DATE_INPUT_FORMAT_HINT;
 
   /**
    * The model for the filter properties

--- a/src/app/verification-addresses/features/iva-manager-list/iva-manager-list.component.html
+++ b/src/app/verification-addresses/features/iva-manager-list/iva-manager-list.component.html
@@ -33,7 +33,7 @@
         Last change
       </th>
       <td mat-cell class="text-base" *matCellDef="let iva">
-        {{ iva.changed | isoDate }}
+        {{ iva.changed | date }}
       </td>
     </ng-container>
     <ng-container matColumnDef="state">

--- a/src/app/verification-addresses/features/iva-manager-list/iva-manager-list.component.ts
+++ b/src/app/verification-addresses/features/iva-manager-list/iva-manager-list.component.ts
@@ -14,6 +14,7 @@ import {
   ViewChildren,
 } from '@angular/core';
 
+import { DatePipe } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialog } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
@@ -22,7 +23,6 @@ import { MatSort, MatSortModule } from '@angular/material/sort';
 import { MatTableDataSource, MatTableModule } from '@angular/material/table';
 import { ConfirmationService } from '@app/shared/services/confirmation.service';
 import { NotificationService } from '@app/shared/services/notification.service';
-import { isoDatePipe } from '@app/shared/utils/iso-date.pipe';
 import {
   IvaStatePrintable,
   IvaType,
@@ -48,7 +48,7 @@ const IVA_TYPE_ICONS: { [K in keyof typeof IvaType]: string } = {
 @Component({
   selector: 'app-iva-manager-list',
   imports: [
-    isoDatePipe,
+    DatePipe,
     MatTableModule,
     MatButtonModule,
     MatIconModule,


### PR DESCRIPTION
- Move all date format definitions used in the application to shared/utils/date-formats
- Use these formats in app.config.ts to configure the DateFnsAdapter and the standard DatePipe
- Use the default date format for tabular output, and shortDate format for dates that are part of prose
- Show the defined input date format as hint for date picker input fields