### PR TITLE
Support Auth Service v3 with multi role support (GSI-1495)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-portal",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-rc.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/app/access-requests/features/dynamic-access-request-button/dynamic-access-request-button.component.spec.ts
+++ b/src/app/access-requests/features/dynamic-access-request-button/dynamic-access-request-button.component.spec.ts
@@ -22,8 +22,8 @@ import { DynamicAccessRequestButtonComponent } from './dynamic-access-request-bu
 export class MockAuthService {
   fullName = () => 'Dr. John Doe';
   email = () => 'doe@home.org';
-  role = () => 'data_steward';
-  roleName = () => 'Data Steward';
+  roles = () => ['data_steward'];
+  roleNames = () => ['Data Steward'];
 }
 
 describe('DynamicAccessRequestButtonComponent', () => {

--- a/src/app/auth/features/register/register.component.spec.ts
+++ b/src/app/auth/features/register/register.component.spec.ts
@@ -25,6 +25,7 @@ class MockAuthService {
       full_name: 'Dr. John Doe',
       email: 'john@ghga.de',
       state: 'LoggedIn',
+      roles: [],
       csrf: 'dummy-csrf',
       ext_id: 'john@op.dev',
     };

--- a/src/app/auth/models/user.ts
+++ b/src/app/auth/models/user.ts
@@ -53,7 +53,7 @@ export interface User extends UserRegisteredData {
   id?: string;
   full_name: string;
   state: LoginState;
-  role?: keyof typeof RoleNames;
+  roles: (keyof typeof RoleNames)[];
   csrf: string;
   timeout?: number;
   extends?: number;

--- a/src/app/auth/models/user.ts
+++ b/src/app/auth/models/user.ts
@@ -42,6 +42,11 @@ export interface UserRegisteredData extends UserBasicData {
 }
 
 /**
+ * Type alias for user roles (the enum keys which are strings)
+ */
+export type UserRole = keyof typeof RoleNames;
+
+/**
  * User session interface
  *
  * Contains all data describing the user and the user session.
@@ -53,7 +58,7 @@ export interface User extends UserRegisteredData {
   id?: string;
   full_name: string;
   state: LoginState;
-  roles: (keyof typeof RoleNames)[];
+  roles: UserRole[];
   csrf: string;
   timeout?: number;
   extends?: number;

--- a/src/app/auth/services/auth.service.ts
+++ b/src/app/auth/services/auth.service.ts
@@ -30,7 +30,7 @@ import {
   of,
   timeout,
 } from 'rxjs';
-import { LoginState, RoleNames, User, UserBasicData } from '../models/user';
+import { LoginState, RoleNames, User, UserBasicData, UserRole } from '../models/user';
 import { CsrfService } from './csrf.service';
 
 /**
@@ -122,7 +122,7 @@ export class AuthService {
   /**
    * Get the roles of the current user as a signal
    */
-  roles = computed<(keyof typeof RoleNames)[]>(() => this.user()?.roles ?? []);
+  roles = computed<UserRole[]>(() => this.user()?.roles ?? []);
 
   /**
    * Get the readable name of the role of the current user as a signal

--- a/src/app/metadata/features/dataset-details/dataset-details.component.spec.ts
+++ b/src/app/metadata/features/dataset-details/dataset-details.component.spec.ts
@@ -39,8 +39,8 @@ import { screen } from '@testing-library/angular';
 export class MockAuthService {
   fullName = () => 'Dr. John Doe';
   email = () => 'doe@home.org';
-  role = () => 'data_steward';
-  roleName = () => 'Data Steward';
+  roles = () => ['data_steward'];
+  roleNames = () => ['Data Steward'];
 }
 
 /**

--- a/src/app/metadata/features/dataset-summary/dataset-summary.component.spec.ts
+++ b/src/app/metadata/features/dataset-summary/dataset-summary.component.spec.ts
@@ -34,8 +34,8 @@ class MockMetadataService {
 class MockAuthService {
   fullName = () => 'Dr. John Doe';
   email = () => 'doe@home.org';
-  role = () => 'data_steward';
-  roleName = () => 'Data Steward';
+  roles = () => ['data_steward'];
+  roleNames = () => ['Data Steward'];
 }
 
 describe('DatasetSummaryComponent', () => {

--- a/src/app/metadata/features/search-result/search-result.component.spec.ts
+++ b/src/app/metadata/features/search-result/search-result.component.spec.ts
@@ -37,8 +37,8 @@ const fakeActivatedRoute = {
 class MockAuthService {
   fullName = () => 'Dr. John Doe';
   email = () => 'doe@home.org';
-  role = () => 'data_steward';
-  roleName = () => 'Data Steward';
+  roles = () => ['data_steward'];
+  roleNames = () => ['Data Steward'];
 }
 
 describe(SearchResultComponent, () => {

--- a/src/app/portal/features/account-button/account-button.component.html
+++ b/src/app/portal/features/account-button/account-button.component.html
@@ -16,7 +16,7 @@
   <mat-menu #menu="matMenu" class="p-3">
     <h4>Hello, {{ fullName() || 'User' }}!</h4>
     @if (roleNames().length) {
-      <p>You are logged in as {{ roleNames()[0] }}.</p>
+      <p>You are logged in as a {{ roleNames()[0] }}.</p>
     }
     <button (click)="gotoAccount()" mat-menu-item>
       <mat-icon class="text-secondary">account_circle</mat-icon>

--- a/src/app/portal/features/account-button/account-button.component.html
+++ b/src/app/portal/features/account-button/account-button.component.html
@@ -15,8 +15,8 @@
   </button>
   <mat-menu #menu="matMenu" class="p-3">
     <h4>Hello, {{ fullName() || 'User' }}!</h4>
-    @if (roleName()) {
-      <p>You are logged in as {{ roleName() }}.</p>
+    @if (roleNames().length) {
+      <p>You are logged in as {{ roleNames()[0] }}.</p>
     }
     <button (click)="gotoAccount()" mat-menu-item>
       <mat-icon class="text-secondary">account_circle</mat-icon>

--- a/src/app/portal/features/account-button/account-button.component.spec.ts
+++ b/src/app/portal/features/account-button/account-button.component.spec.ts
@@ -21,7 +21,7 @@ export const USER = {
   name: 'John Doe',
   title: 'Dr.',
   full_name: 'Dr. John Doe',
-  role: 'data_steward',
+  roles: ['data_steward'],
   state: 'Authenticated',
 } as User;
 
@@ -53,9 +53,9 @@ class MockAuthService {
   user = computed(() => (this.isAuthenticated() ? USER : null));
   name = computed(() => this.user()?.name);
   fullName = computed(() => this.user()?.full_name);
-  role = computed(() => this.user()?.role);
-  roleName = computed(() =>
-    this.role() ? RoleNames[this.role() as keyof typeof RoleNames] : undefined,
+  roles = computed(() => this.user()?.roles ?? []);
+  roleNames = computed(() =>
+    this.roles() ? this.roles().map((role) => RoleNames[role]) : [],
   );
 }
 

--- a/src/app/portal/features/account-button/account-button.component.ts
+++ b/src/app/portal/features/account-button/account-button.component.ts
@@ -42,7 +42,7 @@ export class AccountButtonComponent {
   sessionState = this.#auth.sessionState;
   name = this.#auth.name;
   fullName = this.#auth.fullName;
-  roleName = this.#auth.roleName;
+  roleNames = this.#auth.roleNames;
 
   /**
    * User login

--- a/src/app/portal/features/account/account.component.html
+++ b/src/app/portal/features/account/account.component.html
@@ -4,8 +4,8 @@
 <h2>
   <span class="flex text-2xl"
     >{{ fullName() }}
-    @if (roleName()) {
-      <mat-chip class="ms-2">{{ roleName() }}</mat-chip>
+    @for (roleName of roleNames(); track roleName) {
+      <mat-chip class="ms-2">{{ roleName }}</mat-chip>
     }
   </span>
 </h2>

--- a/src/app/portal/features/account/account.component.spec.ts
+++ b/src/app/portal/features/account/account.component.spec.ts
@@ -22,8 +22,8 @@ import { AccountComponent } from './account.component';
 class MockAuthService {
   fullName = () => 'Dr. John Doe';
   email = () => 'doe@home.org';
-  role = () => 'data_steward';
-  roleName = () => 'Data Steward';
+  roles = () => ['data_steward'];
+  roleNames = () => ['Data Steward'];
 }
 
 describe('AccountComponent', () => {

--- a/src/app/portal/features/account/account.component.ts
+++ b/src/app/portal/features/account/account.component.ts
@@ -32,6 +32,6 @@ import { UserIvaListComponent } from '@app/verification-addresses/features/user-
 export class AccountComponent {
   #auth = inject(AuthService);
   fullName = this.#auth.fullName;
-  roleName = this.#auth.roleName;
+  roleNames = this.#auth.roleNames;
   email = this.#auth.email;
 }

--- a/src/app/portal/features/admin-menu/admin-menu.component.spec.ts
+++ b/src/app/portal/features/admin-menu/admin-menu.component.spec.ts
@@ -14,7 +14,7 @@ import { AdminMenuComponent } from './admin-menu.component';
  * Mock the auth service as needed for the admin menu
  */
 class MockAuthService {
-  role = () => 'data_steward';
+  roles = () => ['data_steward'];
 }
 
 const fakeActivatedRoute = {

--- a/src/app/portal/features/admin-menu/admin-menu.component.ts
+++ b/src/app/portal/features/admin-menu/admin-menu.component.ts
@@ -25,7 +25,7 @@ export class AdminMenuComponent {
   #auth = inject(AuthService);
   #baseRoute = inject(BaseRouteService);
   #route = this.#baseRoute.route;
-  isDataSteward = computed(() => this.#auth.role() === 'data_steward');
+  isDataSteward = computed(() => this.#auth.roles().includes('data_steward'));
   isIvaManagerRoute = computed<boolean>(() => this.#route() === 'iva-manager');
   isAccessRequestsManagerRoute = computed<boolean>(
     () => this.#route() === 'access-request-manager',

--- a/src/app/shared/utils/errors.ts
+++ b/src/app/shared/utils/errors.ts
@@ -15,7 +15,7 @@ export type MaybeBackendError = {
   status?: number;
   statusText?: string;
   message?: string;
-  error?: { detail?: string | Array<{ msg?: string }> };
+  error?: { detail?: string | { msg?: string }[] };
 };
 
 /**

--- a/src/mocks/auth.ts
+++ b/src/mocks/auth.ts
@@ -43,7 +43,7 @@ export const user: User = {
   title: 'Dr.',
   full_name: 'Dr. John Doe',
   email: 'doe@home.org',
-  role: 'data_steward',
+  roles: ['data_steward'],
   state: INITIAL_LOGIN_STATE,
   csrf: 'mock-csrf-token',
   timeout: 3600,
@@ -62,7 +62,6 @@ export function setOidcUser() {
     access_token: 'test123',
     token_type: 'Bearer',
     scope: OIDC_SCOPE,
-    role: user.role,
     profile: {
       sub: user.ext_id,
       sid: null,


### PR DESCRIPTION
This PR adds support for the new session object of Auth Service v3 which can have multiple roles.

The old version is still supported for now.

The PR also bumps the version number to 2.0.0-rc1.