### PR TITLE
Improve the Umami integration

### DIFF
--- a/src/app/shared/services/umami.service.ts
+++ b/src/app/shared/services/umami.service.ts
@@ -32,6 +32,7 @@ export class UmamiService {
       return;
     }
     const script = document.createElement('script');
+    script.async = true;
     script.src = this.#server_url;
     script.setAttribute('data-website-id', this.#website_id);
     document.head.appendChild(script);

--- a/src/app/shared/services/umami.service.ts
+++ b/src/app/shared/services/umami.service.ts
@@ -34,6 +34,7 @@ export class UmamiService {
     const script = document.createElement('script');
     script.async = true;
     script.src = this.#server_url;
+    script.setAttribute('data-auto-track', 'false');
     script.setAttribute('data-website-id', this.#website_id);
     document.head.appendChild(script);
   }

--- a/src/app/shared/services/umami.service.ts
+++ b/src/app/shared/services/umami.service.ts
@@ -12,7 +12,7 @@ import { ConfigService } from './config.service';
 declare global {
   interface Window {
     umami?: {
-      track: (event_name: string, event_data: object) => void;
+      track: (payload: object) => void;
     };
   }
 }
@@ -60,9 +60,13 @@ export class UmamiService {
       .subscribe((event) => {
         const umami = window.umami;
         if (umami) {
-          umami.track('navigation', {
+          umami.track({
+            website: this.#website_id,
             url: event.urlAfterRedirects,
             timestamp: new Date().toISOString(),
+            title:
+              this.#router.routerState.snapshot.root.firstChild?.routeConfig?.title ||
+              document.title,
           });
         }
       });

--- a/src/app/shared/services/umami.service.ts
+++ b/src/app/shared/services/umami.service.ts
@@ -75,7 +75,7 @@ export class UmamiService {
 
   /**
    * This method tracks events manually with Umami by subscribing to click events.
-   * We need to do this manually since we switched of auto-tracking in the script tag.
+   * We need to do this manually since we switched off auto-tracking in the script tag.
    */
   #trackEvents() {
     document.addEventListener('click', (event): event is MouseEvent => {

--- a/src/app/shared/services/umami.service.ts
+++ b/src/app/shared/services/umami.service.ts
@@ -27,6 +27,10 @@ export class UmamiService {
    * This method initializes the Umami tracker by creating a script tag and adding it to the DOM.
    */
   #initializeUmami() {
+    if (!this.#server_url || !this.#website_id) {
+      console.warn('Umami is not configured. Skipping initialization.');
+      return;
+    }
     const script = document.createElement('script');
     script.src = this.#server_url;
     script.setAttribute('data-website-id', this.#website_id);

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -7,6 +7,7 @@
 import { http, HttpResponse, RequestHandler } from 'msw';
 import { handlers as authHandlers } from './auth';
 import { responses as apiResponses, ResponseValue } from './responses';
+import { umamiHandler } from './umami';
 
 const DELAY = 0; // delay in seconds for testing
 
@@ -179,6 +180,7 @@ if (config.mock_api) {
   handlers.push(...noMockHandler('/@ng/*')); // hot module replacement
   handlers.push(...noMockHandler('/@fs/*')); // static files
   handlers.push(...noMockHandler('/chunk-*')); // code chunks
+  handlers.push(umamiHandler); // umami tracker
 } else {
   handlers.push(...noMockHandler('/*'));
 }

--- a/src/mocks/umami.ts
+++ b/src/mocks/umami.ts
@@ -1,0 +1,22 @@
+/**
+ * Mock the Umami tracker
+ * @copyright The GHGA Authors
+ * @license Apache-2.0
+ */
+
+import { http, RequestHandler } from 'msw';
+
+const CONFIG = window.config;
+let umamiUrl = CONFIG.umami_url;
+
+umamiUrl = umamiUrl.slice(0, umamiUrl.indexOf('/', 8)) || 'http://umami.dev';
+umamiUrl += '/*';
+
+export const umamiHandler: RequestHandler = http.post(
+  umamiUrl,
+  async ({ request }: { request: Request }) => {
+    const body = await request.json();
+    const payload = body.payload;
+    console.debug('Umami tracker called with this payload:', payload);
+  },
+);


### PR DESCRIPTION
This PR addresses the following issues:

1. allow disabling Umami via configuration
2. make Umami work with client side navigation
3. mock Umami with MSW (just log what is tracked)

To solve 2. I used the following approach:
- disable the auto-tracking on the script tag (this disables pageview tracking, but sadly also event tracking)
- manually track the client side navigation
- manually track events similar to how Umami would do it with auto-tracking