### PR TITLE
Fix bugs in rc.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-portal",
-  "version": "2.0.0-rc.2",
+  "version": "2.0.0-rc.3",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
         version: 19.2.7(@angular/cdk@19.2.7(@angular/common@19.2.3(@angular/core@19.2.3(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2))(@angular/core@19.2.3(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2))(@angular/common@19.2.3(@angular/core@19.2.3(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2))(@angular/core@19.2.3(rxjs@7.8.2)(zone.js@0.15.0))(@angular/forms@19.2.3(@angular/common@19.2.3(@angular/core@19.2.3(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2))(@angular/core@19.2.3(rxjs@7.8.2)(zone.js@0.15.0))(@angular/platform-browser@19.2.3(@angular/animations@19.2.3(@angular/core@19.2.3(rxjs@7.8.2)(zone.js@0.15.0)))(@angular/common@19.2.3(@angular/core@19.2.3(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2))(@angular/core@19.2.3(rxjs@7.8.2)(zone.js@0.15.0)))(rxjs@7.8.2))(@angular/platform-browser@19.2.3(@angular/animations@19.2.3(@angular/core@19.2.3(rxjs@7.8.2)(zone.js@0.15.0)))(@angular/common@19.2.3(@angular/core@19.2.3(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2))(@angular/core@19.2.3(rxjs@7.8.2)(zone.js@0.15.0)))(rxjs@7.8.2)
       '@angular/material-date-fns-adapter':
         specifier: ^19.2.7
-        version: 19.2.7(w7wrnrxih5tb5zkvi2xchj5gji)
+        version: 19.2.7(d751a11cb89e48b690ff2a7274bb6b3e)
       '@angular/platform-browser':
         specifier: ^19.2.3
         version: 19.2.3(@angular/animations@19.2.3(@angular/core@19.2.3(rxjs@7.8.2)(zone.js@0.15.0)))(@angular/common@19.2.3(@angular/core@19.2.3(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2))(@angular/core@19.2.3(rxjs@7.8.2)(zone.js@0.15.0))
@@ -7040,7 +7040,7 @@ snapshots:
       rxjs: 7.8.2
       tslib: 2.8.1
 
-  '@angular/material-date-fns-adapter@19.2.7(w7wrnrxih5tb5zkvi2xchj5gji)':
+  '@angular/material-date-fns-adapter@19.2.7(d751a11cb89e48b690ff2a7274bb6b3e)':
     dependencies:
       '@angular/core': 19.2.3(rxjs@7.8.2)(zone.js@0.15.0)
       '@angular/material': 19.2.7(@angular/cdk@19.2.7(@angular/common@19.2.3(@angular/core@19.2.3(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2))(@angular/core@19.2.3(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2))(@angular/common@19.2.3(@angular/core@19.2.3(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2))(@angular/core@19.2.3(rxjs@7.8.2)(zone.js@0.15.0))(@angular/forms@19.2.3(@angular/common@19.2.3(@angular/core@19.2.3(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2))(@angular/core@19.2.3(rxjs@7.8.2)(zone.js@0.15.0))(@angular/platform-browser@19.2.3(@angular/animations@19.2.3(@angular/core@19.2.3(rxjs@7.8.2)(zone.js@0.15.0)))(@angular/common@19.2.3(@angular/core@19.2.3(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2))(@angular/core@19.2.3(rxjs@7.8.2)(zone.js@0.15.0)))(rxjs@7.8.2))(@angular/platform-browser@19.2.3(@angular/animations@19.2.3(@angular/core@19.2.3(rxjs@7.8.2)(zone.js@0.15.0)))(@angular/common@19.2.3(@angular/core@19.2.3(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2))(@angular/core@19.2.3(rxjs@7.8.2)(zone.js@0.15.0)))(rxjs@7.8.2)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2401,78 +2401,78 @@ packages:
     resolution: {integrity: sha512-hbn8SZ8w4u2pRwgQ1GlUrPKE+t2XvcCW5tTRF7j6SMYIuYG37XuzIW44JCZPa36evi0Oy2SnM664BlIaAuQcvg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@unrs/resolver-binding-darwin-arm64@1.3.1':
-    resolution: {integrity: sha512-PdaB3zQ6Z3Jn+m/5ajYCbR0tQFFTwr3ddJ/SH2L+AAKBUfEKJHUv/dZIJNKkCq2YVJNL/SfdksRe+nU3e5f2Lg==}
+  '@unrs/resolver-binding-darwin-arm64@1.3.2':
+    resolution: {integrity: sha512-ddnlXgRi0Fog5+7U5Q1qY62wl95Q1lB4tXQX1UIA9YHmRCHN2twaQW0/4tDVGCvTVEU3xEayU7VemEr7GcBYUw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@unrs/resolver-binding-darwin-x64@1.3.1':
-    resolution: {integrity: sha512-SyrYaFWaWla0PK5Bf0d8zXbK/OiiPO/nPyksT9JPzgzP2Qt7GTwihSA+lwdbu0MJfG/ppEVou/qedmhbevJPGQ==}
+  '@unrs/resolver-binding-darwin-x64@1.3.2':
+    resolution: {integrity: sha512-tnl9xoEeg503jis+LW5cuq4hyLGQyqaoBL8VdPSqcewo/FL1C8POHbzl+AL25TidWYJD+R6bGUTE381kA1sT9w==}
     cpu: [x64]
     os: [darwin]
 
-  '@unrs/resolver-binding-freebsd-x64@1.3.1':
-    resolution: {integrity: sha512-Ky60j3ZLqbM0Rbwo04htABNTWRDNx6GttGX+L9ixE1T5/XBDmrMSOqxvWhqfVeZHskQ3/pCVEH/ylmofJ6mFZg==}
+  '@unrs/resolver-binding-freebsd-x64@1.3.2':
+    resolution: {integrity: sha512-zyPn9LFCCjhKPeCtECZaiMUgkYN/VpLb4a9Xv7QriJmTaQxsuDtXqOHifrzUXIhorJTyS+5MOKDuNL0X9I4EHA==}
     cpu: [x64]
     os: [freebsd]
 
-  '@unrs/resolver-binding-linux-arm-gnueabihf@1.3.1':
-    resolution: {integrity: sha512-Un+2iis8yZMkP0qLDqjAEoRjsw40jvrgyaLtaeVk0G77AXdo0QrpUq1dqXvE9M9lVVJj7kXfaDtE7CBZ1EWmoQ==}
+  '@unrs/resolver-binding-linux-arm-gnueabihf@1.3.2':
+    resolution: {integrity: sha512-UWx56Wh59Ro69fe+Wfvld4E1n9KG0e3zeouWLn8eSasyi/yVH/7ZW3CLTVFQ81oMKSpXwr5u6RpzttDXZKiO4g==}
     cpu: [arm]
     os: [linux]
 
-  '@unrs/resolver-binding-linux-arm-musleabihf@1.3.1':
-    resolution: {integrity: sha512-Vj6LgN8zTwfiPSTtaneKb3kWS0kc6qmZTASCUg5oPviXJh9WsXwRKQE/biYwX0C/YDY5S1Dqs6AV7R5i3X95ew==}
+  '@unrs/resolver-binding-linux-arm-musleabihf@1.3.2':
+    resolution: {integrity: sha512-VYGQXsOEJtfaoY2fOm8Z9ii5idFaHFYlrq3yMFZPaFKo8ufOXYm8hnfru7qetbM9MX116iWaPC0ZX5sK+1Dr+g==}
     cpu: [arm]
     os: [linux]
 
-  '@unrs/resolver-binding-linux-arm64-gnu@1.3.1':
-    resolution: {integrity: sha512-aA4KA/92L62KLZf7d2b6JSrRCRpenFIKuIyLckf0DqLSEavKq3Iql8xU7T7OW8ite0+b4uQlx7RjkCFsME8KYg==}
+  '@unrs/resolver-binding-linux-arm64-gnu@1.3.2':
+    resolution: {integrity: sha512-3zP420zxJfYPD1rGp2/OTIBxF8E3+/6VqCG+DEO6kkDgBiloa7Y8pw1o7N9BfgAC+VC8FPZsFXhV2lpx+lLRMQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@unrs/resolver-binding-linux-arm64-musl@1.3.1':
-    resolution: {integrity: sha512-WyVE0f4gks4v0kL4B4l5SB7GrEZvT7ZYbZjdVDHRpnrhYjEoEj/3G1Otu7XAkf1ykXZ65dVLqPBVeNn8OYbsPA==}
+  '@unrs/resolver-binding-linux-arm64-musl@1.3.2':
+    resolution: {integrity: sha512-ZWjSleUgr88H4Kei7yT4PlPqySTuWN1OYDDcdbmMCtLWFly3ed+rkrcCb3gvqXdDbYrGOtzv3g2qPEN+WWNv5Q==}
     cpu: [arm64]
     os: [linux]
 
-  '@unrs/resolver-binding-linux-ppc64-gnu@1.3.1':
-    resolution: {integrity: sha512-BcF2tCI8B+oD1F+6jNxZxUWKzaCr4aNCrPnU3K/OLmMTdttHeiS2u3KvwZmgpkEc36gIBx65P7VFh4rBhcOQKA==}
+  '@unrs/resolver-binding-linux-ppc64-gnu@1.3.2':
+    resolution: {integrity: sha512-p+5OvYJ2UOlpjes3WfBlxyvQok2u26hLyPxLFHkYlfzhZW0juhvBf/tvewz1LDFe30M7zL9cF4OOO5dcvtk+cw==}
     cpu: [ppc64]
     os: [linux]
 
-  '@unrs/resolver-binding-linux-s390x-gnu@1.3.1':
-    resolution: {integrity: sha512-stCbOVTMrYsCyKfSkr8mvdUz78kkHCqMSy60LuK245pJByFgs4vG8Qpehr4jDHORHve4OOXf3ZJP5vEJuil2ng==}
+  '@unrs/resolver-binding-linux-s390x-gnu@1.3.2':
+    resolution: {integrity: sha512-yweY7I6SqNn3kvj6vE4PQRo7j8Oz6+NiUhmgciBNAUOuI3Jq0bnW29hbHJdxZRSN1kYkQnSkbbA1tT8VnK816w==}
     cpu: [s390x]
     os: [linux]
 
-  '@unrs/resolver-binding-linux-x64-gnu@1.3.1':
-    resolution: {integrity: sha512-lZZunwEvM6mCbibcS7Jxd2fYT9D/aRjjw24p0ua43lIymkzhAUA1UI11q6MWmZF0EgrLoFfAS73ExjyU5ghTWA==}
+  '@unrs/resolver-binding-linux-x64-gnu@1.3.2':
+    resolution: {integrity: sha512-fNIvtzJcGN9hzWTIayrTSk2+KHQrqKbbY+I88xMVMOFV9t4AXha4veJdKaIuuks+2JNr6GuuNdsL7+exywZ32w==}
     cpu: [x64]
     os: [linux]
 
-  '@unrs/resolver-binding-linux-x64-musl@1.3.1':
-    resolution: {integrity: sha512-mhAUo+vj5jO76AKhy/IP7ALzGw0m/6EkOIZYrW64AlmGlm094CvHzQqHz/nAW3ffQLZMzhBez8AuhZwdgCeqrA==}
+  '@unrs/resolver-binding-linux-x64-musl@1.3.2':
+    resolution: {integrity: sha512-OaFEw8WAjiwBGxutQgkWhoAGB5BQqZJ8Gjt/mW+m6DWNjimcxU22uWCuEtfw1CIwLlKPOzsgH0429fWmZcTGkg==}
     cpu: [x64]
     os: [linux]
 
-  '@unrs/resolver-binding-wasm32-wasi@1.3.1':
-    resolution: {integrity: sha512-2eKumvKdxBlvDjgbv5I/slDlw0lyRno0VsOPNl9L4cyO/LftBoPPZUEhRpN/JuEjX0PljEbAPG9j1Kd1EpTV6w==}
+  '@unrs/resolver-binding-wasm32-wasi@1.3.2':
+    resolution: {integrity: sha512-u+sumtO7M0AGQ9bNQrF4BHNpUyxo23FM/yXZfmVAicTQ+mXtG06O7pm5zQUw3Mr4jRs2I84uh4O0hd8bdouuvQ==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
-  '@unrs/resolver-binding-win32-arm64-msvc@1.3.1':
-    resolution: {integrity: sha512-4McXLSAp5lcg94AuKQ/SefXswIuZbO4VDzBSvcKP7Hy0mEJAuxKfGKUeDSFobu/CBDPJ9emhDJHLRbo3k3AcGw==}
+  '@unrs/resolver-binding-win32-arm64-msvc@1.3.2':
+    resolution: {integrity: sha512-ZAJKy95vmDIHsRFuPNqPQRON8r2mSMf3p9DoX+OMOhvu2c8OXGg8MvhGRf3PNg45ozRrPdXDnngURKgaFfpGoQ==}
     cpu: [arm64]
     os: [win32]
 
-  '@unrs/resolver-binding-win32-ia32-msvc@1.3.1':
-    resolution: {integrity: sha512-8k9ioJqL+0HlFQW+J795Iw5Eowfhis3xhY3W0EfOFvUCXYhilGPBuHGTSh3t4M/pMC49vBJ0ZTpsR/jk8oAWIg==}
+  '@unrs/resolver-binding-win32-ia32-msvc@1.3.2':
+    resolution: {integrity: sha512-nQG4YFAS2BLoKVQFK/FrWJvFATI5DQUWQrcPcsWG9Ve5BLLHZuPOrJ2SpAJwLXQrRv6XHSFAYGI8wQpBg/CiFA==}
     cpu: [ia32]
     os: [win32]
 
-  '@unrs/resolver-binding-win32-x64-msvc@1.3.1':
-    resolution: {integrity: sha512-/dargLEQa2N4o/lNml09ff2P11XpBq50Jpjk8cMsDvj8YmzKLTzqguobXavj63ZWE9mN+Y3DTEbVpQOk+uY9XQ==}
+  '@unrs/resolver-binding-win32-x64-msvc@1.3.2':
+    resolution: {integrity: sha512-XBWpUP0mHya6yGBwNefhyEa6V7HgYKCxEAY4qhTm/PcAQyBPNmjj97VZJOJkVdUsyuuii7xmq0pXWX/c2aToHQ==}
     cpu: [x64]
     os: [win32]
 
@@ -6356,8 +6356,8 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
-  unrs-resolver@1.3.1:
-    resolution: {integrity: sha512-8OaGhiFH/BLD8CPBPs1y/OLlMvxmZs5tqLT/7FO49LyG3oXYEx20tNcOrLZzzKWYhnCprv60tzJjbZgzWZvHvg==}
+  unrs-resolver@1.3.2:
+    resolution: {integrity: sha512-ZKQBC351Ubw0PY8xWhneIfb6dygTQeUHtCcNGd0QB618zabD/WbFMYdRyJ7xeVT+6G82K5v/oyZO0QSHFtbIuw==}
 
   update-browserslist-db@1.1.3:
     resolution: {integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==}
@@ -9798,51 +9798,51 @@ snapshots:
       '@typescript-eslint/types': 8.28.0
       eslint-visitor-keys: 4.2.0
 
-  '@unrs/resolver-binding-darwin-arm64@1.3.1':
+  '@unrs/resolver-binding-darwin-arm64@1.3.2':
     optional: true
 
-  '@unrs/resolver-binding-darwin-x64@1.3.1':
+  '@unrs/resolver-binding-darwin-x64@1.3.2':
     optional: true
 
-  '@unrs/resolver-binding-freebsd-x64@1.3.1':
+  '@unrs/resolver-binding-freebsd-x64@1.3.2':
     optional: true
 
-  '@unrs/resolver-binding-linux-arm-gnueabihf@1.3.1':
+  '@unrs/resolver-binding-linux-arm-gnueabihf@1.3.2':
     optional: true
 
-  '@unrs/resolver-binding-linux-arm-musleabihf@1.3.1':
+  '@unrs/resolver-binding-linux-arm-musleabihf@1.3.2':
     optional: true
 
-  '@unrs/resolver-binding-linux-arm64-gnu@1.3.1':
+  '@unrs/resolver-binding-linux-arm64-gnu@1.3.2':
     optional: true
 
-  '@unrs/resolver-binding-linux-arm64-musl@1.3.1':
+  '@unrs/resolver-binding-linux-arm64-musl@1.3.2':
     optional: true
 
-  '@unrs/resolver-binding-linux-ppc64-gnu@1.3.1':
+  '@unrs/resolver-binding-linux-ppc64-gnu@1.3.2':
     optional: true
 
-  '@unrs/resolver-binding-linux-s390x-gnu@1.3.1':
+  '@unrs/resolver-binding-linux-s390x-gnu@1.3.2':
     optional: true
 
-  '@unrs/resolver-binding-linux-x64-gnu@1.3.1':
+  '@unrs/resolver-binding-linux-x64-gnu@1.3.2':
     optional: true
 
-  '@unrs/resolver-binding-linux-x64-musl@1.3.1':
+  '@unrs/resolver-binding-linux-x64-musl@1.3.2':
     optional: true
 
-  '@unrs/resolver-binding-wasm32-wasi@1.3.1':
+  '@unrs/resolver-binding-wasm32-wasi@1.3.2':
     dependencies:
       '@napi-rs/wasm-runtime': 0.2.7
     optional: true
 
-  '@unrs/resolver-binding-win32-arm64-msvc@1.3.1':
+  '@unrs/resolver-binding-win32-arm64-msvc@1.3.2':
     optional: true
 
-  '@unrs/resolver-binding-win32-ia32-msvc@1.3.1':
+  '@unrs/resolver-binding-win32-ia32-msvc@1.3.2':
     optional: true
 
-  '@unrs/resolver-binding-win32-x64-msvc@1.3.1':
+  '@unrs/resolver-binding-win32-x64-msvc@1.3.2':
     optional: true
 
   '@vitejs/plugin-basic-ssl@1.2.0(vite@6.2.3(@types/node@22.13.13)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.0)(terser@5.39.0)(yaml@2.7.0))':
@@ -10940,7 +10940,7 @@ snapshots:
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
       tinyglobby: 0.2.12
-      unrs-resolver: 1.3.1
+      unrs-resolver: 1.3.2
     transitivePeerDependencies:
       - supports-color
 
@@ -14331,23 +14331,23 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unrs-resolver@1.3.1:
+  unrs-resolver@1.3.2:
     optionalDependencies:
-      '@unrs/resolver-binding-darwin-arm64': 1.3.1
-      '@unrs/resolver-binding-darwin-x64': 1.3.1
-      '@unrs/resolver-binding-freebsd-x64': 1.3.1
-      '@unrs/resolver-binding-linux-arm-gnueabihf': 1.3.1
-      '@unrs/resolver-binding-linux-arm-musleabihf': 1.3.1
-      '@unrs/resolver-binding-linux-arm64-gnu': 1.3.1
-      '@unrs/resolver-binding-linux-arm64-musl': 1.3.1
-      '@unrs/resolver-binding-linux-ppc64-gnu': 1.3.1
-      '@unrs/resolver-binding-linux-s390x-gnu': 1.3.1
-      '@unrs/resolver-binding-linux-x64-gnu': 1.3.1
-      '@unrs/resolver-binding-linux-x64-musl': 1.3.1
-      '@unrs/resolver-binding-wasm32-wasi': 1.3.1
-      '@unrs/resolver-binding-win32-arm64-msvc': 1.3.1
-      '@unrs/resolver-binding-win32-ia32-msvc': 1.3.1
-      '@unrs/resolver-binding-win32-x64-msvc': 1.3.1
+      '@unrs/resolver-binding-darwin-arm64': 1.3.2
+      '@unrs/resolver-binding-darwin-x64': 1.3.2
+      '@unrs/resolver-binding-freebsd-x64': 1.3.2
+      '@unrs/resolver-binding-linux-arm-gnueabihf': 1.3.2
+      '@unrs/resolver-binding-linux-arm-musleabihf': 1.3.2
+      '@unrs/resolver-binding-linux-arm64-gnu': 1.3.2
+      '@unrs/resolver-binding-linux-arm64-musl': 1.3.2
+      '@unrs/resolver-binding-linux-ppc64-gnu': 1.3.2
+      '@unrs/resolver-binding-linux-s390x-gnu': 1.3.2
+      '@unrs/resolver-binding-linux-x64-gnu': 1.3.2
+      '@unrs/resolver-binding-linux-x64-musl': 1.3.2
+      '@unrs/resolver-binding-wasm32-wasi': 1.3.2
+      '@unrs/resolver-binding-win32-arm64-msvc': 1.3.2
+      '@unrs/resolver-binding-win32-ia32-msvc': 1.3.2
+      '@unrs/resolver-binding-win32-x64-msvc': 1.3.2
 
   update-browserslist-db@1.1.3(browserslist@4.24.4):
     dependencies:

--- a/src/app/access-requests/features/access-request-dialog/access-request-dialog.component.html
+++ b/src/app/access-requests/features/access-request-dialog/access-request-dialog.component.html
@@ -10,7 +10,6 @@
         matInput
         placeholder="I need access for research on..."
         [formControl]="descriptionFormControl"
-        [(ngModel)]="description"
         (blur)="updateDescriptionErrorMessage()"
         #details
       ></textarea>
@@ -69,7 +68,6 @@
         placeholder="your.email@goes.here"
         #emailField
         [formControl]="emailFormControl"
-        [(ngModel)]="email"
         (blur)="updateEmailErrorMessage()"
       />
       @if (emailFormControl.invalid) {

--- a/src/app/access-requests/features/access-request-dialog/access-request-dialog.component.spec.ts
+++ b/src/app/access-requests/features/access-request-dialog/access-request-dialog.component.spec.ts
@@ -51,12 +51,9 @@ describe('AccessRequestDialogComponent', () => {
       imports: [AccessRequestDialogComponent, MatDialogModule],
       providers: [
         provideNativeDateAdapter(),
-        {
-          provide: MatDialogRef,
-          useValue: {},
-        },
-        { provide: MAT_DIALOG_DATA, useValue: {} },
         provideAnimationsAsync(),
+        { provide: MatDialogRef, useValue: {} },
+        { provide: MAT_DIALOG_DATA, useValue: {} },
         { provide: ConfigService, useValue: mockConfig },
       ],
     }).compileComponents();

--- a/src/app/access-requests/features/access-request-dialog/access-request-dialog.component.ts
+++ b/src/app/access-requests/features/access-request-dialog/access-request-dialog.component.ts
@@ -50,18 +50,17 @@ const MILLISECONDS_PER_DAY = 86400000;
   templateUrl: './access-request-dialog.component.html',
 })
 export class AccessRequestDialogComponent {
-  readonly emailFormControl = new FormControl('', [
-    Validators.required,
-    Validators.email,
-  ]);
-  readonly descriptionFormControl = new FormControl('', [Validators.required]);
   readonly dialogRef = inject(MatDialogRef<AccessRequestDialogComponent>);
   readonly data = inject<AccessRequestDialogData>(MAT_DIALOG_DATA);
   #config = inject(ConfigService);
-  readonly result = model(this.data);
-  readonly email = model(this.data.email);
-  readonly description = model(this.data.description);
   readonly dateInputFormatHint = DATE_INPUT_FORMAT_HINT;
+  readonly emailFormControl = new FormControl(this.data.email, [
+    Validators.required,
+    Validators.email,
+  ]);
+  readonly descriptionFormControl = new FormControl(this.data.description, [
+    Validators.required,
+  ]);
   fromDate = model(this.data.fromDate);
   untilDate = model(this.data.untilDate);
   todayMidnight = new Date();
@@ -242,7 +241,7 @@ export class AccessRequestDialogComponent {
 
   /**
    * Update the range for the until date based on the from date
-   * @param date - The frin date to update the range for
+   * @param date - The from date to update the range for
    */
   updateUntilRangeForFromValue(date: Date): void {
     const newUntilMinDate = new Date(
@@ -280,6 +279,11 @@ export class AccessRequestDialogComponent {
    * Submit the access request and close the dialog
    */
   submit(): void {
-    this.dialogRef.close(this.data);
+    const description = this.descriptionFormControl.value;
+    const fromDate = this.fromDate();
+    const untilDate = this.untilDate();
+    const email = this.emailFormControl.value;
+    const data = { ...this.data, description, fromDate, untilDate, email };
+    this.dialogRef.close(data);
   }
 }

--- a/src/app/access-requests/features/access-request-manager-dialog/access-request-manager-dialog.component.html
+++ b/src/app/access-requests/features/access-request-manager-dialog/access-request-manager-dialog.component.html
@@ -39,6 +39,8 @@
       <p>Loading verification addresses...</p>
     } @else if (ivasError() || !ivas().length) {
       <p>No corresponding verification addresses found, cannot process request.</p>
+    } @else if (data.status === 'denied') {
+      <p>This status cannot be reverted.</p>
     } @else {
       <label for="iva-selection-group" class="text-lg">
         @if (allowedAccessRequestIvaId()) {
@@ -69,49 +71,58 @@
     <br />
   </mat-dialog-content>
   <mat-dialog-actions>
-    <div class="mr-2">
+    @if (
+      ivasAreLoading() || ivasError() || !ivas().length || data.status === 'denied'
+    ) {
       <button
         mat-stroked-button
         (click)="cancel()"
-        data-umami-event="Access Request Manager Cancel Clicked"
+        data-umami-event="Access Request Manager Close Clicked"
       >
-        Cancel
+        Close
       </button>
-    </div>
-    <div class="flex-grow"></div>
-    <div class="ml-2">
-      <button
-        mat-raised-button
-        class="error mr-1"
-        (click)="safeDeny()"
-        data-umami-event="Access Request Manager Deny Clicked"
-        [disabled]="data.status === 'denied'"
-      >
-        @if (allowedAccessRequestIvaId()) {
-          Revoke access
-        } @else if (this.data.status === 'denied') {
-          Denied
-        } @else {
-          Deny
-        }
-      </button>
-      <button
-        mat-raised-button
-        class="success"
-        (click)="safeAllow()"
-        data-umami-event="Access Request Manager Allow Clicked"
-        [disabled]="
-          !selectedIvaIdRadioButton() ||
-          (data.status === 'allowed' &&
-            selectedIvaIdRadioButton() === allowedAccessRequestIvaId())
-        "
-      >
-        @if (allowedAccessRequestIvaId()) {
-          Change address
-        } @else {
-          Allow
-        }
-      </button>
-    </div>
+    } @else {
+      <div class="mr-2">
+        <button
+          mat-stroked-button
+          (click)="cancel()"
+          data-umami-event="Access Request Manager Cancel Clicked"
+        >
+          Cancel
+        </button>
+      </div>
+      <div class="flex-grow"></div>
+      <div class="ml-2">
+        <button
+          mat-raised-button
+          class="error mr-1"
+          (click)="safeDeny()"
+          data-umami-event="Access Request Manager Deny Clicked"
+        >
+          @if (allowedAccessRequestIvaId()) {
+            Revoke access
+          } @else {
+            Deny
+          }
+        </button>
+        <button
+          mat-raised-button
+          class="success"
+          (click)="safeAllow()"
+          data-umami-event="Access Request Manager Allow Clicked"
+          [disabled]="
+            !selectedIvaIdRadioButton() ||
+            (data.status === 'allowed' &&
+              selectedIvaIdRadioButton() === allowedAccessRequestIvaId())
+          "
+        >
+          @if (allowedAccessRequestIvaId()) {
+            Change address
+          } @else {
+            Allow
+          }
+        </button>
+      </div>
+    }
   </mat-dialog-actions>
 </div>

--- a/src/app/access-requests/features/access-request-manager-dialog/access-request-manager-dialog.component.html
+++ b/src/app/access-requests/features/access-request-manager-dialog/access-request-manager-dialog.component.html
@@ -55,11 +55,11 @@
             <tr>
               <td>
                 <mat-radio-button [value]="iva.id">
-                  {{ (iva.type | IvaTypePipe: iva.value).typeAndValue }}
+                  {{ (iva.type | IvaTypePipe).name }}: {{ iva.value }}
                 </mat-radio-button>
               </td>
-              <td class="{{ (iva.state | IvaStatePipe).class }} w-40 ps-4">
-                {{ (iva.state | IvaStatePipe).display }}
+              <td [class]="(iva.state | IvaStatePipe).class" class="w-40 ps-4">
+                {{ (iva.state | IvaStatePipe).name }}
               </td>
             </tr>
           }

--- a/src/app/access-requests/features/access-request-manager-dialog/access-request-manager-dialog.component.spec.ts
+++ b/src/app/access-requests/features/access-request-manager-dialog/access-request-manager-dialog.component.spec.ts
@@ -35,7 +35,10 @@ describe('AccessRequestManagerDialogComponent', () => {
       imports: [AccessRequestManagerDialogComponent],
       providers: [
         { provide: IvaService, useClass: MockIvaService },
-        { provide: MAT_DIALOG_DATA, useValue: accessRequests[0] },
+        {
+          provide: MAT_DIALOG_DATA,
+          useValue: { ...accessRequests[0], status: 'pending' },
+        },
         { provide: MatDialogRef, useValue: {} },
         provideNoopAnimations(),
       ],

--- a/src/app/access-requests/features/access-request-manager-dialog/access-request-manager-dialog.component.ts
+++ b/src/app/access-requests/features/access-request-manager-dialog/access-request-manager-dialog.component.ts
@@ -141,7 +141,7 @@ export class AccessRequestManagerDialogComponent implements OnInit {
     if (!this.selectedIvaIdRadioButton()) return;
     const data = {
       ...this.data,
-      iva_id: this.selectedIvaIdRadioButton,
+      iva_id: this.selectedIvaIdRadioButton(),
       status: AccessRequestStatus.allowed,
     };
     this.dialogRef.close(data);
@@ -153,7 +153,7 @@ export class AccessRequestManagerDialogComponent implements OnInit {
   #deny = () => {
     const data = {
       ...this.data,
-      iva_id: this.selectedIvaIdRadioButton,
+      iva_id: this.selectedIvaIdRadioButton(),
       status: AccessRequestStatus.denied,
     };
     this.dialogRef.close(data);

--- a/src/app/access-requests/features/access-request-manager-dialog/access-request-manager-dialog.component.ts
+++ b/src/app/access-requests/features/access-request-manager-dialog/access-request-manager-dialog.component.ts
@@ -22,7 +22,7 @@ import { AccessRequestStatusClassPipe } from '@app/access-requests/pipes/access-
 import { ConfirmationService } from '@app/shared/services/confirmation.service';
 import { NotificationService } from '@app/shared/services/notification.service';
 import { FRIENDLY_DATE_FORMAT } from '@app/shared/utils/date-formats';
-import { IvaState } from '@app/verification-addresses/models/iva';
+import { Iva, IvaState } from '@app/verification-addresses/models/iva';
 import { IvaStatePipe } from '@app/verification-addresses/pipes/iva-state.pipe';
 import { IvaTypePipe } from '@app/verification-addresses/pipes/iva-type.pipe';
 import { IvaService } from '@app/verification-addresses/services/iva.service';
@@ -43,6 +43,7 @@ import { IvaService } from '@app/verification-addresses/services/iva.service';
     IvaTypePipe,
     IvaStatePipe,
   ],
+  providers: [IvaTypePipe],
   templateUrl: './access-request-manager-dialog.component.html',
 })
 export class AccessRequestManagerDialogComponent implements OnInit {
@@ -58,6 +59,8 @@ export class AccessRequestManagerDialogComponent implements OnInit {
   ivasAreLoading = this.#ivas.isLoading;
   ivasError = this.#ivas.error;
 
+  #ivaTypePipe = inject(IvaTypePipe);
+
   selectedIvaIdRadioButton = model<string | undefined>(undefined);
   allowedAccessRequestIvaId = signal<string | undefined>(undefined);
 
@@ -72,6 +75,15 @@ export class AccessRequestManagerDialogComponent implements OnInit {
       this.#preSelectIvaRadioButton();
     }
   });
+
+  /**
+   * Get the display name for the IVA type
+   * @param iva the IVA in question
+   * @returns the display name for the type
+   */
+  #ivaTypeName(iva: Iva): string {
+    return this.#ivaTypePipe.transform(iva.type).name;
+  }
 
   /**
    * Load the IVAs of the user when the component is initialized
@@ -91,12 +103,12 @@ export class AccessRequestManagerDialogComponent implements OnInit {
     if (!this.selectedIvaIdRadioButton()) return;
     const iva = this.ivas().find((iva) => iva.id === this.selectedIvaIdRadioButton());
     if (!iva) return;
-    const typeAndValue = new IvaTypePipe().transform(iva.type, iva.value).typeAndValue;
+    const ivaType = this.#ivaTypeName(iva);
     this.#confirmationService.confirm({
       title: 'Confirm approval of the access request',
       message:
         'Please confirm that the access request shall be allowed' +
-        ` and coupled to ${typeAndValue}.`,
+        ` and coupled to ${ivaType}: ${iva.value}.`,
       cancelText: 'Cancel',
       confirmText: 'Confirm approval',
       confirmClass: 'success',

--- a/src/app/access-requests/services/access-request.service.ts
+++ b/src/app/access-requests/services/access-request.service.ts
@@ -42,8 +42,8 @@ export class AccessRequestService {
             dataset_id: data.datasetID,
             email: data.email,
             request_text: data.description,
-            access_starts: data.fromDate?.toDateString(),
-            access_ends: data.untilDate?.toDateString(),
+            access_starts: data.fromDate?.toISOString(),
+            access_ends: data.untilDate?.toISOString(),
           })
           .pipe(
             catchError(async () =>

--- a/src/app/verification-addresses/features/code-creation-dialog/code-creation-dialog.component.html
+++ b/src/app/verification-addresses/features/code-creation-dialog/code-creation-dialog.component.html
@@ -13,7 +13,7 @@
       </tr>
       <tr>
         <th class="pe-1 text-right">Via:</th>
-        <td>{{ (iva.type | IvaTypePipe).display }}</td>
+        <td>{{ (iva.type | IvaTypePipe).name }}</td>
       </tr>
       <tr>
         <th class="pe-1 text-right">Address:</th>

--- a/src/app/verification-addresses/features/iva-manager-filter/iva-manager-filter.component.ts
+++ b/src/app/verification-addresses/features/iva-manager-filter/iva-manager-filter.component.ts
@@ -34,6 +34,7 @@ import { IvaService } from '@app/verification-addresses/services/iva.service';
     MatFormFieldModule,
     MatIconModule,
   ],
+  providers: [IvaStatePipe],
   templateUrl: './iva-manager-filter.component.html',
   styleUrl: './iva-manager-filter.component.scss',
 })
@@ -41,6 +42,8 @@ export class IvaManagerFilterComponent {
   #ivaService = inject(IvaService);
 
   #filter = this.#ivaService.allIvasFilter;
+
+  #ivaStatePipe = inject(IvaStatePipe);
 
   readonly dateInputFormatHint = DATE_INPUT_FORMAT_HINT;
 
@@ -65,10 +68,19 @@ export class IvaManagerFilterComponent {
   });
 
   /**
+   * Get the display name for the IVA state
+   * @param state the IVA state in question
+   * @returns the display name for the type
+   */
+  #ivaStateName(state: IvaState): string {
+    return this.#ivaStatePipe.transform(state).name;
+  }
+
+  /**
    * All IVA status values with printable text.
    */
   stateOptions = Object.entries(IvaState).map((entry) => ({
     value: entry[0] as keyof typeof IvaState,
-    text: new IvaStatePipe().transform(entry[1]).display,
+    text: this.#ivaStateName(entry[1]),
   }));
 }

--- a/src/app/verification-addresses/features/iva-manager-filter/iva-manager-filter.component.ts
+++ b/src/app/verification-addresses/features/iva-manager-filter/iva-manager-filter.component.ts
@@ -70,7 +70,7 @@ export class IvaManagerFilterComponent {
   /**
    * Get the display name for the IVA state
    * @param state the IVA state in question
-   * @returns the display name for the type
+   * @returns the display name for the state
    */
   #ivaStateName(state: IvaState): string {
     return this.#ivaStatePipe.transform(state).name;

--- a/src/app/verification-addresses/features/iva-manager-list/iva-manager-list.component.html
+++ b/src/app/verification-addresses/features/iva-manager-list/iva-manager-list.component.html
@@ -13,7 +13,7 @@
       <th mat-header-cell *matHeaderCellDef mat-sort-header>Type</th>
       <td mat-cell *matCellDef="let iva">
         <mat-icon class="mr-3">{{ (iva.type | IvaTypePipe).icon }}</mat-icon
-        ><span class="align-super">{{ (iva.type | IvaTypePipe).display }}</span>
+        ><span class="align-super">{{ (iva.type | IvaTypePipe).name }}</span>
       </td>
     </ng-container>
     <ng-container matColumnDef="value">
@@ -30,8 +30,8 @@
     </ng-container>
     <ng-container matColumnDef="state">
       <th mat-header-cell *matHeaderCellDef mat-sort-header>Status</th>
-      <td mat-cell class="{{ (iva.state | IvaStatePipe).class }}" *matCellDef="let iva">
-        {{ (iva.state | IvaStatePipe).display }}
+      <td mat-cell [class]="(iva.state | IvaStatePipe).class" *matCellDef="let iva">
+        {{ (iva.state | IvaStatePipe).name }}
       </td>
     </ng-container>
     <ng-container matColumnDef="actions">

--- a/src/app/verification-addresses/features/iva-manager-list/iva-manager-list.component.ts
+++ b/src/app/verification-addresses/features/iva-manager-list/iva-manager-list.component.ts
@@ -47,6 +47,7 @@ import { CodeCreationDialogComponent } from '../code-creation-dialog/code-creati
     IvaTypePipe,
     IvaStatePipe,
   ],
+  providers: [IvaTypePipe],
   templateUrl: './iva-manager-list.component.html',
   styleUrl: './iva-manager-list.component.scss',
 })
@@ -55,6 +56,7 @@ export class IvaManagerListComponent implements AfterViewInit {
   #confirmationService = inject(ConfirmationService);
   #notificationService = inject(NotificationService);
   #ivaService = inject(IvaService);
+  #ivaTypePipe = inject(IvaTypePipe);
 
   #ivas = this.#ivaService.allIvas;
   ivas = this.#ivaService.allIvasFiltered;
@@ -102,6 +104,15 @@ export class IvaManagerListComponent implements AfterViewInit {
   }
 
   /**
+   * Get the display name for the IVA type
+   * @param iva the IVA in question
+   * @returns the display name for the type
+   */
+  #ivaTypeName(iva: UserWithIva): string {
+    return this.#ivaTypePipe.transform(iva.type).name;
+  }
+
+  /**
    * After the view has been initialised
    * assign the sorting of the table to the data source
    */
@@ -132,10 +143,11 @@ export class IvaManagerListComponent implements AfterViewInit {
    * @param iva - the IVA to invalidate
    */
   invalidateWhenConfirmed(iva: UserWithIva) {
+    const ivaType = this.#ivaTypeName(iva);
     this.#confirmationService.confirm({
       title: 'Confirm invalidation of IVA',
       message:
-        `Do you really wish to invalidate the ${new IvaTypePipe().transform(iva.type).display} IVA of` +
+        `Do you really wish to invalidate the ${ivaType} IVA of` +
         ` ${iva.user_name} with address "${iva.value}"?` +
         ' The user will lose access to any dataset linked to this IVA.',
       cancelText: 'Cancel',
@@ -171,12 +183,12 @@ export class IvaManagerListComponent implements AfterViewInit {
    * @param iva - the IVA for which the code was transmitted
    */
   markAsTransmittedWhenConfirmed(iva: UserWithIva) {
+    const ivaType = this.#ivaTypeName(iva);
     this.#confirmationService.confirm({
       title: 'Confirm code transmission',
       message:
         'Please confirm the transmission of the verification code' +
-        ` the ${new IvaTypePipe().transform(iva.type).display} IVA of` +
-        ` ${iva.user_name} with address "${iva.value}".`,
+        ` the ${ivaType} IVA of ${iva.user_name} with address "${iva.value}".`,
       cancelText: 'Cancel',
       confirmText: 'Confirm transmission',
       callback: (confirmed) => {

--- a/src/app/verification-addresses/features/new-iva-dialog/new-iva-dialog.component.ts
+++ b/src/app/verification-addresses/features/new-iva-dialog/new-iva-dialog.component.ts
@@ -38,12 +38,14 @@ import { IvaTypePipe } from '@app/verification-addresses/pipes/iva-type.pipe';
     MatDialogActions,
     MatButtonToggleModule,
   ],
+  providers: [IvaTypePipe],
   templateUrl: './new-iva-dialog.component.html',
 })
 export class NewIvaDialogComponent {
   #dialogRef = inject(
     MatDialogRef<NewIvaDialogComponent, { type: IvaType; value: string }>,
   );
+  #ivaTypePipe = inject(IvaTypePipe);
 
   /**
    * Value prompts for the different IVA types
@@ -56,13 +58,22 @@ export class NewIvaDialogComponent {
   };
 
   /**
+   * Get the display name for an IVA type
+   * @param type the IVA type in question
+   * @returns the display name
+   */
+  #ivaTypeName(type: IvaType): string {
+    return this.#ivaTypePipe.transform(type).name;
+  }
+
+  /**
    * All possible IVA types
    */
   types = Object.entries(IvaType)
     .filter((entry) => this.valuePrompts[entry[0] as keyof typeof IvaType])
     .map((entry) => ({
       value: entry[0] as keyof typeof IvaType,
-      text: new IvaTypePipe().transform(entry[1]).display,
+      text: this.#ivaTypeName(entry[1]),
     }));
 
   valueField = viewChild('valueField', { read: ElementRef });

--- a/src/app/verification-addresses/features/user-iva-list/user-iva-list.component.html
+++ b/src/app/verification-addresses/features/user-iva-list/user-iva-list.component.html
@@ -22,7 +22,7 @@
     <table mat-table [dataSource]="ivaSource" class="mat-elevation-z8">
       <ng-container matColumnDef="value">
         <td mat-cell class="max-w-72 text-base" *matCellDef="let iva">
-          {{ (iva.type | IvaTypePipe).typeAndValue }}
+          {{ (iva.type | IvaTypePipe).name }}: {{ iva.value }}
         </td>
       </ng-container>
 

--- a/src/app/verification-addresses/features/user-iva-list/user-iva-list.component.ts
+++ b/src/app/verification-addresses/features/user-iva-list/user-iva-list.component.ts
@@ -29,6 +29,7 @@ import { VerificationDialogComponent } from '../verification-dialog/verification
     MatDialogModule,
     IvaTypePipe,
   ],
+  providers: [IvaTypePipe],
   templateUrl: './user-iva-list.component.html',
 })
 export class UserIvaListComponent implements OnInit {
@@ -45,6 +46,18 @@ export class UserIvaListComponent implements OnInit {
   ivaSource = new MatTableDataSource<Iva>([]);
 
   #updateIvaSourceEffect = effect(() => (this.ivaSource.data = this.ivas()));
+
+  #ivaTypePipe = inject(IvaTypePipe);
+
+  /**
+   * Get the type and value of the IVA
+   * @param iva the IVA in question
+   * @returns the type and value of the IVA combined as address
+   */
+  #ivaAddress(iva: Iva): string {
+    const ivaType = this.#ivaTypePipe.transform(iva.type).name;
+    return `${ivaType}: ${iva.value}`;
+  }
 
   /**
    * Load the IVAs of the current user when the component is initialized
@@ -81,11 +94,12 @@ export class UserIvaListComponent implements OnInit {
    * @param iva - the IVA to be verified
    */
   requestVerification(iva: Iva): void {
+    const address = this.#ivaAddress(iva);
     this.#confirm.confirm({
       title: 'Request verification of your address',
       message:
         'We will send a verification code to the address selected for verification (' +
-        new IvaTypePipe().transform(iva.type).typeAndValue +
+        address +
         '). Please allow some time for processing' +
         ' your request. When the verification code has been transmitted,' +
         ' you will also be notified via e-mail.',
@@ -134,7 +148,7 @@ export class UserIvaListComponent implements OnInit {
    * @param iva - the IVA to verify
    */
   enterVerificationCode(iva: Iva): void {
-    const address = new IvaTypePipe().transform(iva.type).typeAndValue;
+    const address = this.#ivaAddress(iva);
     const dialogRef = this.#dialog.open(VerificationDialogComponent, {
       data: { address },
     });
@@ -166,10 +180,11 @@ export class UserIvaListComponent implements OnInit {
    * @param iva - the IVA to delete
    */
   deleteWhenConfirmed(iva: Iva): void {
+    const address = this.#ivaAddress(iva);
     this.#confirm.confirm({
       title: 'Confirm deletion of contact address',
       message:
-        `Please confirm deleting the ${new IvaTypePipe().transform(iva.type).typeAndValue}.` +
+        `Please confirm deleting the ${address}.` +
         ' Remember that you will lose access to any datasets' +
         ' whose access was linked to that address.',
       cancelText: 'Cancel',

--- a/src/app/verification-addresses/pipes/iva-state.pipe.spec.ts
+++ b/src/app/verification-addresses/pipes/iva-state.pipe.spec.ts
@@ -13,9 +13,29 @@ describe('IvaStatePipe', () => {
     expect(pipe).toBeTruthy();
   });
 
-  it('should return {display:"Code Requested",class:"text-warning"} for CodeRequested', () => {
+  it('should show "None" for an empty state', () => {
     const pipe = new IvaStatePipe();
-    const result = pipe.transform(IvaState['CodeRequested']);
-    expect(result).toStrictEqual({ display: 'Code Requested', class: 'text-warning' });
+    for (const state of [null, undefined, '']) {
+      const result = pipe.transform(state as unknown as IvaState);
+      expect(result).toStrictEqual({ name: 'None', class: 'text-error' });
+    }
+  });
+
+  it('should show the state itself for an unknown state', () => {
+    const pipe = new IvaStatePipe();
+    const result = pipe.transform('Unknown state' as IvaState);
+    expect(result).toStrictEqual({ name: 'Unknown state', class: 'text-error' });
+  });
+
+  it('should work properly for the CodeRequested state', () => {
+    const pipe = new IvaStatePipe();
+    const result = pipe.transform(IvaState.CodeRequested);
+    expect(result).toStrictEqual({ name: 'Code Requested', class: 'text-warning' });
+  });
+
+  it('should work properly for the CodeRequested state', () => {
+    const pipe = new IvaStatePipe();
+    const result = pipe.transform(IvaState.Verified);
+    expect(result).toStrictEqual({ name: 'Verified', class: 'text-success' });
   });
 });

--- a/src/app/verification-addresses/pipes/iva-state.pipe.ts
+++ b/src/app/verification-addresses/pipes/iva-state.pipe.ts
@@ -14,16 +14,17 @@ import {
 /**
  * This pipe is used to provide state-specific display names and classes for IVAs.
  */
-@Pipe({
-  name: 'IvaStatePipe',
-})
+@Pipe({ name: 'IvaStatePipe' })
 export class IvaStatePipe implements PipeTransform {
   /**
    * This method will return an object containing a display name and classes based on the IVA state provided
    * @param state The IVA state to process
-   * @returns The display name and class based on the state of the IVA state sent in an object of shape { display: string; class: string }
+   * @returns The display name and class based on the state of the IVA state
    */
-  transform(state: IvaState): { display: string; class: string } {
-    return { display: IvaStatePrintable[state], class: IvaStateClass[state] };
+  transform(state: IvaState): { name: string; class: string } {
+    return {
+      name: IvaStatePrintable[state] ?? (state || 'None'),
+      class: IvaStateClass[state] ?? IvaStateClass.Unverified,
+    };
   }
 }

--- a/src/app/verification-addresses/pipes/iva-state.pipe.ts
+++ b/src/app/verification-addresses/pipes/iva-state.pipe.ts
@@ -19,7 +19,7 @@ export class IvaStatePipe implements PipeTransform {
   /**
    * This method will return an object containing a display name and classes based on the IVA state provided
    * @param state The IVA state to process
-   * @returns The display name and class based on the state of the IVA state
+   * @returns The display name and class based on the given IVA state
    */
   transform(state: IvaState): { name: string; class: string } {
     return {

--- a/src/app/verification-addresses/pipes/iva-type.pipe.spec.ts
+++ b/src/app/verification-addresses/pipes/iva-type.pipe.spec.ts
@@ -13,22 +13,34 @@ describe('IvaTypePipe', () => {
     expect(pipe).toBeTruthy();
   });
 
-  it('should return {display: "SMS",typeAndValue: "SMS: +49123456789",icon: "smartphone"} for type Phone and value "49123456789"', () => {
+  it('should show "None" for an empty type', () => {
     const pipe = new IvaTypePipe();
-    const result = pipe.transform(IvaType['Phone'], '+49123456789');
+    for (const type of [null, undefined, '']) {
+      const result = pipe.transform(type as unknown as IvaType);
+      expect(result).toStrictEqual({ name: 'None', icon: 'warning' });
+    }
+  });
+
+  it('should show the type itself for an unknown type', () => {
+    const pipe = new IvaTypePipe();
+    const result = pipe.transform('Unknown type' as IvaType);
+    expect(result).toStrictEqual({ name: 'Unknown type', icon: 'warning' });
+  });
+
+  it('should properly transform the SMS type', () => {
+    const pipe = new IvaTypePipe();
+    const result = pipe.transform(IvaType['Phone']);
     expect(result).toStrictEqual({
-      display: 'SMS',
-      typeAndValue: 'SMS: +49123456789',
+      name: 'SMS',
       icon: 'smartphone',
     });
   });
 
-  it('should return {display: "In Person",typeAndValue: "In Person: ",icon: "handshakes"} for type InPerson', () => {
+  it('should properly transform the InPerson type', () => {
     const pipe = new IvaTypePipe();
     const result = pipe.transform(IvaType['InPerson']);
     expect(result).toStrictEqual({
-      display: 'In Person',
-      typeAndValue: 'In Person: ',
+      name: 'In Person',
       icon: 'handshakes',
     });
   });

--- a/src/app/verification-addresses/pipes/iva-type.pipe.ts
+++ b/src/app/verification-addresses/pipes/iva-type.pipe.ts
@@ -15,7 +15,7 @@ export class IvaTypePipe implements PipeTransform {
   /**
    * This method will return an object containing a display name and icon for the IVA type provided
    * @param type The IVA type to process
-   * @returns The display name and icon based on the type of the IVA type
+   * @returns The display name and icon based on the given IVA type
    */
   transform(type: IvaType): { name: string; icon: string } {
     return {

--- a/src/app/verification-addresses/pipes/iva-type.pipe.ts
+++ b/src/app/verification-addresses/pipes/iva-type.pipe.ts
@@ -1,5 +1,5 @@
 /**
- * This pipe takes an IVA type and returns an object with the display name, type and value string, and icon for the specified type
+ * This pipe takes an IVA type and returns an object with the display name and icon for the specified type
  * @copyright The GHGA Authors
  * @license Apache-2.0
  */
@@ -8,29 +8,19 @@ import { Pipe, PipeTransform } from '@angular/core';
 import { IvaType, IvaTypeIcon, IvaTypePrintable } from '../models/iva';
 
 /**
- * This pipe is used to provide type-specific display names and classes for IVAs.
+ * This pipe is used to provide type-specific display names and icons for IVAs.
  */
-@Pipe({
-  name: 'IvaTypePipe',
-})
+@Pipe({ name: 'IvaTypePipe' })
 export class IvaTypePipe implements PipeTransform {
   /**
-   * This method will return an object containing a display name, type and value string, and icon for the IVA type provided
+   * This method will return an object containing a display name and icon for the IVA type provided
    * @param type The IVA type to process
-   * @param value The value of the IVA to use
-   * @returns The display name and class based on the type of the IVA type sent in an object of shape { display: string; class: string }
+   * @returns The display name and icon based on the type of the IVA type
    */
-  transform(
-    type: IvaType,
-    value?: string | undefined,
-  ): { display: string; typeAndValue: string; icon: string } {
-    if (!value) {
-      value = '';
-    }
+  transform(type: IvaType): { name: string; icon: string } {
     return {
-      display: IvaTypePrintable[type],
-      typeAndValue: `${IvaTypePrintable[type]}: ${value}`,
-      icon: IvaTypeIcon[type],
+      name: IvaTypePrintable[type] ?? (type || 'None'),
+      icon: IvaTypeIcon[type] ?? 'warning',
     };
   }
 }

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -456,7 +456,7 @@ export const accessRequests = [
     access_starts: access_starts,
     access_ends: access_ends,
     request_created: '2023-05-09T12:04:02.000Z',
-    status: 'pending',
+    status: 'denied',
     status_changed: null,
     changed_by: null,
   },

--- a/src/mocks/responses.ts
+++ b/src/mocks/responses.ts
@@ -138,7 +138,7 @@ export const responses: { [endpoint: string]: ResponseValue } = {
   // All access requests
   'GET /api/ars/access-requests': getAccessRequests(),
 
-  // Create an access requests
+  // Create an access request
   'POST /api/ars/access-requests': 204,
 
   // Patch an access request

--- a/src/mocks/responses.ts
+++ b/src/mocks/responses.ts
@@ -138,7 +138,7 @@ export const responses: { [endpoint: string]: ResponseValue } = {
   // All access requests
   'GET /api/ars/access-requests': getAccessRequests(),
 
-  // All access requests
+  // Create an access requests
   'POST /api/ars/access-requests': 204,
 
   // Patch an access request


### PR DESCRIPTION
This PR fixes some more bugs that have been found when testing rc.2 against the staging backend:

- The IVA types and values were not shown properly. This was caused by several problems with the implementation of the IvaTypePipe and IvaStatusPipe.
- The access requests were not properly sent to the backend; some fields were missing or in the wrong format.
- Also, some controls used both template driven and reactive form controls, causing a warning on the console.
- When there was an error on the backend, like due to the above, the success message was shown anyway.
- The IVA id was not submitted when allowing/denying requests. The cause was a signal that was not called.
- The backend does not allow reverting a status of "denied" to "allowed", so the frontend shouldn't offer that option either.
