### PR TITLE
Prevent commits to main branch

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,11 @@
+#!/bin/sh
+
+# Prevent commits to the main branch
+if [ "$(git rev-parse --abbrev-ref HEAD)" = "main" ]; then
+  echo "Direct commits to the main branch are not allowed."
+  echo "Please create a feature branch and commit your changes there."
+  exit 1
+fi
+
+# Run linting
 ng lint


### PR DESCRIPTION
Do not allow commits to the main branch directly. This is disabled on GitHub anyway, but it's better to catch this already on the local repository as well.