### PR TITLE
Skip facets with many items (GSI-1591)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-portal",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/app/metadata/features/metadata-browser/metadata-browser.component.html
+++ b/src/app/metadata/features/metadata-browser/metadata-browser.component.html
@@ -100,13 +100,12 @@
               {{ facet.name }}
               <ul class="mt-1 mb-5 rounded-lg border">
                 @for (option of facet.options; track option.value) {
+                  @let name = `${facet.key}#${option.value}`;
                   <li>
                     <mat-checkbox
-                      name="{{ facet.key }}#{{ option.value }}"
+                      [name]="name"
                       (change)="onFacetFilterChanged($event)"
-                      [checked]="
-                        facet.key + '#' + option.value | facetActivity: facetData()
-                      "
+                      [checked]="name | facetActivity: facetData()"
                       >{{ option.value }} ({{ option.count }})</mat-checkbox
                     >
                   </li>

--- a/src/app/metadata/features/metadata-browser/metadata-browser.component.ts
+++ b/src/app/metadata/features/metadata-browser/metadata-browser.component.ts
@@ -25,6 +25,7 @@ import { SearchResultListComponent } from '../search-result-list/search-result-l
 
 const DEFAULT_PAGE_SIZE = 10;
 const DEFAULT_SKIP_VALUE = 0;
+const MAX_FACET_OPTIONS = 5;
 
 /**
  * This is the metadata browser component
@@ -67,7 +68,9 @@ export class MetadataBrowserComponent implements OnInit {
   lastSearchFilterFacets = this.#metadataSearch.facets;
   #searchResults = this.#metadataSearch.searchResults;
   searchResults = this.#searchResults.value;
-  facets = computed(() => this.searchResults().facets);
+  facets = computed(() =>
+    this.searchResults().facets.filter((f) => f.options.length <= MAX_FACET_OPTIONS),
+  );
   numResults = computed(() => this.searchResults().count);
   loading = computed(() => this.#searchResults.isLoading());
 

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -393,6 +393,8 @@ export const searchResults: SearchResults = {
       options: [
         { value: 'Option 1', count: 62 },
         { value: 'Option 2', count: 37 },
+        { value: 'Option 3', count: 42 },
+        { value: 'Option 4', count: 21 },
       ],
     },
     {


### PR DESCRIPTION
In the legacy portal, we only showed facets with less than 6 options. This PR re-implements the feature in the new portal.