### PR TITLE
Fix global stats platform/experiment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-portal",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/app/metadata/features/global-summary/global-summary.component.html
+++ b/src/app/metadata/features/global-summary/global-summary.component.html
@@ -29,11 +29,11 @@
           ><mat-icon inline class="border-tertiary rounded-full border-4 px-1"
             >genetics</mat-icon
           ></span
-        ><br />Platforms:
+        ><br />Experiments:
         @if (isLoading()) {
           <app-stencil class="inline-flex w-10" />
         } @else {
-          {{ platforms().count }}
+          {{ methods().count }}
         }</mat-card-title
       ><mat-card-content class="mt-4 text-sm">
         <table class="mx-auto w-auto">
@@ -51,7 +51,7 @@
               }
             } @else {
               @for (
-                platform of platforms().stats?.instrument_model ?? [];
+                platform of methods().stats?.instrument_model ?? [];
                 track platform.value
               ) {
                 <tr>

--- a/src/app/metadata/features/global-summary/global-summary.component.spec.ts
+++ b/src/app/metadata/features/global-summary/global-summary.component.spec.ts
@@ -44,10 +44,10 @@ describe('GlobalStatsComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should show platforms', () => {
+  it('should show methods', () => {
     const compiled = fixture.nativeElement as HTMLElement;
     const text = compiled.textContent;
-    expect(text).toContain('1400');
+    expect(text).toContain('700');
     expect(text).toContain('Ilumina test');
   });
 });

--- a/src/app/metadata/features/global-summary/global-summary.component.ts
+++ b/src/app/metadata/features/global-summary/global-summary.component.ts
@@ -45,7 +45,7 @@ export class GlobalSummaryComponent {
   isLoading = computed(() => this.#stats.isLoading());
 
   datasets = computed(() => this.stats().Dataset);
-  platforms = computed(() => this.stats().ExperimentMethod);
+  methods = computed(() => this.stats().ExperimentMethod);
   individuals = computed(() => this.stats().Individual);
   files = computed(() => this.stats().ProcessDataFile);
 }

--- a/src/app/metadata/features/metadata-browser/metadata-browser.component.ts
+++ b/src/app/metadata/features/metadata-browser/metadata-browser.component.ts
@@ -69,7 +69,9 @@ export class MetadataBrowserComponent implements OnInit {
   #searchResults = this.#metadataSearch.searchResults;
   searchResults = this.#searchResults.value;
   facets = computed(() =>
-    this.searchResults().facets.filter((f) => f.options.length <= MAX_FACET_OPTIONS),
+    this.searchResults().facets.filter(
+      (f) => f.options.length > 0 && f.options.length <= MAX_FACET_OPTIONS,
+    ),
   );
   numResults = computed(() => this.searchResults().count);
   loading = computed(() => this.#searchResults.isLoading());

--- a/tests/home.spec.ts
+++ b/tests/home.spec.ts
@@ -26,7 +26,7 @@ test('has global statistics', async ({ page }) => {
   const main = page.locator('main');
   await expect(main).toContainText('Statistics');
   await expect(main).toContainText('Total datasets: 252');
-  await expect(main).toContainText('Platforms: 1400');
+  await expect(main).toContainText('Experiments: 1400');
   await expect(main).toContainText('Individuals: 5432');
   await expect(main).toContainText('Files: 532');
 });


### PR DESCRIPTION
The global stats currently shows the number of experiments instead of the number of different platforms as before.

We decided to fix that by changing the label to "experiments" instead of "platforms".

This PR also fixes the problem that empty facets resulted in headings with now option by skipping these facets.