### PR TITLE
Fixing the host of the link of the View Publication button

### DIFF
--- a/src/app/metadata/features/dataset-details/dataset-details.component.html
+++ b/src/app/metadata/features/dataset-details/dataset-details.component.html
@@ -117,7 +117,7 @@
                   <a
                     mat-stroked-button
                     class="mb-4 w-full sm:float-right sm:mb-0 sm:w-auto"
-                    [href]="'https://www.doi.org/' + pub.doi | validateDOI"
+                    [href]="'https://www.doi.org/' + (pub.doi | validateDOI)"
                     target="_blank"
                     rel="noopener noreferrer"
                     data-umami-event="Dataset Details Publication DOI Clicked"


### PR DESCRIPTION
The View Publication button used to direct users to https://data.ghga.de/DOI instead of https://doi.org/DOI