### PR TITLE
Disallow caching of index page (GSI-1659)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,11 +35,12 @@ USER root
 RUN touch ./dist/config.js && chown appuser ./dist/config.js ./package.json
 USER appuser
 # install run script
-COPY ./run.js ./run.mjs
+COPY run.js ./run.mjs
 # install dependencies for run script
 RUN npm install js-yaml
-# install default configuration file
-COPY ./data-portal.default.yaml .
+# install configuration files
+COPY data-portal.default.yaml .
+COPY sws.toml .
 
 ENTRYPOINT ["node"]
 CMD ["/home/appuser/run.mjs"]

--- a/run.js
+++ b/run.js
@@ -235,7 +235,9 @@ function runDevServer(host, port, ssl, sslCert, sslKey, logLevel, baseUrl, basic
 function runProdServer(host, port, ssl, sslCert, sslKey, logLevel) {
   console.log('Running the production server...');
 
-  const distDir = getBrowserDir(path.join(__dirname, 'dist'));
+  const runDir = __dirname;
+  const confFile = path.join(runDir, 'sws.toml');
+  const distDir = getBrowserDir(path.join(runDir, 'dist'));
   process.chdir(distDir);
 
   const params = [
@@ -248,11 +250,13 @@ function runProdServer(host, port, ssl, sslCert, sslKey, logLevel) {
     '-d',
     '.',
     '--page-fallback',
+    './index.html',
+    '-w',
+    confFile,
   ];
   if (ssl) {
     params.push('--http2', '--http2-tls-cert', sslCert, '--http2-tls-key', sslKey);
   }
-  params.push('./index.html');
 
   const result = spawnSync('static-web-server', params, {
     stdio: 'inherit',

--- a/sws.toml
+++ b/sws.toml
@@ -5,6 +5,6 @@ page-fallback = "./index.html"
 [[advanced.headers]]
 source = "/index.html"
 [advanced.headers.headers]
-Cache-Control = "no-cache, no-store, must-revalidate"
+Cache-Control = "no-cache, no-store, must-revalidate, proxy-revalidate"
 Pragma = "no-cache"
 Expires = "0"

--- a/sws.toml
+++ b/sws.toml
@@ -1,0 +1,10 @@
+[general]
+root = "."
+page-fallback = "./index.html"
+
+[[advanced.headers]]
+source = "/index.html"
+[advanced.headers.headers]
+Cache-Control = "no-cache, no-store, must-revalidate"
+Pragma = "no-cache"
+Expires = "0"


### PR DESCRIPTION
Unlike JS and CSS bundles, which Angular are built with hash values as file names,, the index file is fixed. If browsers cache it, users may continue to load an old version, which references outdated bundles that no longer exist after a deployment. This can result in broken pages or missing resources.

The PR fixes this by adding a config file to SWS that adds no-cache headers to the index file (and only to that file).