### PR TITLE
Fix duplicate 2FA verification (GSI-1676)

### DIFF
--- a/src/app/auth/features/confirm-totp/confirm-totp.component.html
+++ b/src/app/auth/features/confirm-totp/confirm-totp.component.html
@@ -25,7 +25,6 @@
       id="submit-auth"
       class="w-full sm:w-auto"
       mat-raised-button
-      (click)="onSubmit()"
       data-umami-event="Confirm TOTP Submit Clicked"
     >
       Submit

--- a/src/app/auth/features/confirm-totp/confirm-totp.component.ts
+++ b/src/app/auth/features/confirm-totp/confirm-totp.component.ts
@@ -35,6 +35,7 @@ import { NotificationService } from '@app/shared/services/notification.service';
 export class ConfirmTotpComponent {
   #notify = inject(NotificationService);
   #authService = inject(AuthService);
+  #submitted = false;
 
   codeControl = new FormControl<string>('', [
     Validators.required,
@@ -56,9 +57,11 @@ export class ConfirmTotpComponent {
    * Submit authentication code
    */
   async onSubmit(): Promise<void> {
+    if (this.#submitted) return;
     this.verificationError = false;
     const code = this.codeControl.value;
     if (!code) return;
+    this.#submitted = true;
     const verified = await this.#authService.verifyTotpCode(code);
     if (verified) {
       this.#notify.showSuccess('Successfully authenticated.');
@@ -68,6 +71,7 @@ export class ConfirmTotpComponent {
       this.#notify.showError('Failed to authenticate.');
       this.codeControl.reset();
       this.verificationError = true;
+      this.#submitted = false;
     }
   }
 


### PR DESCRIPTION
When submitting a 2FA code, it was checked twice against the backend, because the onSubmit method was called on both the form and the submit button.

This PR removes the call on the button and makes sure that a new submission is not possible while the check is still running (e.g. when double clicking the button).