### PR TITLE
Show more shows from 4 elements in summary (GSI-1668)

### DIFF
--- a/src/app/metadata/features/dataset-details/dataset-details.component.html
+++ b/src/app/metadata/features/dataset-details/dataset-details.component.html
@@ -28,13 +28,13 @@
               @if (study().types.length) {
                 <mat-chip-set>
                   @for (type of study().types; track $index) {
-                    <mat-chip class="small-chips me-1">{{
+                    <mat-chip class="small-chip me-1">{{
                       type | underscoreToSpace
                     }}</mat-chip>
                   }
                 </mat-chip-set>
               } @else {
-                <mat-chip class="small-chips">None</mat-chip>
+                <mat-chip class="small-chip">None</mat-chip>
               }
             </div>
             <div class="mb-2 flex flex-wrap items-baseline text-sm">
@@ -42,11 +42,11 @@
               @if (datasetDetails().types.length > 0) {
                 <mat-chip-set>
                   @for (type of datasetDetails().types; track $index) {
-                    <mat-chip class="small-chips me-1">{{ type }}</mat-chip>
+                    <mat-chip class="small-chip me-1">{{ type }}</mat-chip>
                   }
                 </mat-chip-set>
               } @else {
-                <mat-chip class="small-chips">None</mat-chip>
+                <mat-chip class="small-chip">None</mat-chip>
               }
             </div>
           </div>
@@ -108,7 +108,7 @@
                     {{ type }}{{ last ? '' : ', ' }}
                   }
                 } @else {
-                  <mat-chip class="small-chips">None</mat-chip>
+                  <mat-chip class="small-chip">None</mat-chip>
                 }
               </p>
             </div>

--- a/src/app/metadata/features/dataset-summary/dataset-summary.component.html
+++ b/src/app/metadata/features/dataset-summary/dataset-summary.component.html
@@ -35,7 +35,7 @@
         <strong>Types:&nbsp;</strong>
         <mat-chip-set>
           @for (type of summary().types; track type) {
-            <mat-chip class="small-chips mr-1 text-sm">{{ type }}</mat-chip>
+            <mat-chip class="small-chip mr-1 text-sm">{{ type }}</mat-chip>
           }
         </mat-chip-set>
       </div>

--- a/src/app/shared/ui/summary-badges/summary-badges.component.html
+++ b/src/app/shared/ui/summary-badges/summary-badges.component.html
@@ -13,10 +13,10 @@
       >
     </li>
     @if (count > 3) {
-      @if (idx === 2) {
+      @if (idx === 1) {
         <input type="checkbox" id="show_more" class="show_more hidden" />
         <label for="show_more" class="text-secondary underline"
-          >Show {{ count - 3 }} more…</label
+          >Show {{ count - 2 }} more…</label
         >
       }
       @if (last) {

--- a/src/app/shared/ui/summary-badges/summary-badges.component.html
+++ b/src/app/shared/ui/summary-badges/summary-badges.component.html
@@ -12,11 +12,11 @@
         <strong>{{ item.count }}</strong></mat-chip
       >
     </li>
-    @if (count > 3) {
-      @if (idx === 1) {
+    @if (count > maxItems) {
+      @if (idx === maxItems - 2) {
         <input type="checkbox" id="show_more" class="show_more hidden" />
         <label for="show_more" class="text-secondary underline"
-          >Show {{ count - 2 }} more…</label
+          >Show {{ count - (maxItems - 1) }} more…</label
         >
       }
       @if (last) {

--- a/src/app/shared/ui/summary-badges/summary-badges.component.spec.ts
+++ b/src/app/shared/ui/summary-badges/summary-badges.component.spec.ts
@@ -9,8 +9,10 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { SummaryBadgesComponent } from './summary-badges.component';
 
 describe('SummaryBadgesComponent', () => {
-  let component: SummaryBadgesComponent;
-  let fixture: ComponentFixture<SummaryBadgesComponent>;
+  let componentFourItems: SummaryBadgesComponent;
+  let fixtureFourItems: ComponentFixture<SummaryBadgesComponent>;
+  let componentThreeItems: SummaryBadgesComponent;
+  let fixtureThreeItems: ComponentFixture<SummaryBadgesComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -18,24 +20,38 @@ describe('SummaryBadgesComponent', () => {
       providers: [],
     }).compileComponents();
 
-    fixture = TestBed.createComponent(SummaryBadgesComponent);
-    component = fixture.componentInstance;
-    fixture.componentRef.setInput('data', [
+    fixtureFourItems = TestBed.createComponent(SummaryBadgesComponent);
+    componentFourItems = fixtureFourItems.componentInstance;
+    fixtureFourItems.componentRef.setInput('data', [
       { value: 'test 1', count: 1 },
       { value: 'test 2', count: 1 },
       { value: 'test 3', count: 1 },
       { value: 'test 4', count: 1 },
     ]);
-    await fixture.whenStable();
+    fixtureThreeItems = TestBed.createComponent(SummaryBadgesComponent);
+    componentThreeItems = fixtureThreeItems.componentInstance;
+    fixtureThreeItems.componentRef.setInput('data', [
+      { value: 'test 1', count: 1 },
+      { value: 'test 2', count: 1 },
+      { value: 'test 3', count: 1 },
+    ]);
+    await fixtureFourItems.whenStable();
+    await fixtureThreeItems.whenStable();
   });
 
   it('should create', () => {
-    expect(component).toBeTruthy();
+    expect(componentFourItems).toBeTruthy();
   });
 
-  it('should show "Show 1 More" type', () => {
-    const compiled = fixture.nativeElement as HTMLElement;
+  it('should show "Show 2 More" when there are four items', () => {
+    const compiled = fixtureFourItems.nativeElement as HTMLElement;
     const text = compiled.textContent;
-    expect(text).toContain('Show 1 more');
+    expect(text).toContain('Show 2 more');
+  });
+
+  it('should show all three data points when there are only three', () => {
+    const compiled = fixtureThreeItems.nativeElement as HTMLElement;
+    const text = compiled.textContent;
+    expect(text).toContain('test 3');
   });
 });

--- a/src/app/shared/ui/summary-badges/summary-badges.component.spec.ts
+++ b/src/app/shared/ui/summary-badges/summary-badges.component.spec.ts
@@ -41,17 +41,18 @@ describe('SummaryBadgesComponent', () => {
 
   it('should create', () => {
     expect(componentFourItems).toBeTruthy();
+    expect(componentThreeItems).toBeTruthy();
   });
 
   it('should show "Show 2 More" when there are four items', () => {
     const compiled = fixtureFourItems.nativeElement as HTMLElement;
     const text = compiled.textContent;
-    expect(text).toContain('Show 2 more');
+    expect(text).toContain('test 1 1test 2 1Show 2 more…test 3 1test 4 1Show less…');
   });
 
   it('should show all three data points when there are only three', () => {
     const compiled = fixtureThreeItems.nativeElement as HTMLElement;
     const text = compiled.textContent;
-    expect(text).toContain('test 3');
+    expect(text).toContain('test 1 1test 2 1test 3 1');
   });
 });

--- a/src/app/shared/ui/summary-badges/summary-badges.component.ts
+++ b/src/app/shared/ui/summary-badges/summary-badges.component.ts
@@ -8,6 +8,8 @@ import { Component, input } from '@angular/core';
 import { MatChipsModule } from '@angular/material/chips';
 import { UnderscoreToSpace } from '@app/shared/pipes/underscore-to-space.pipe';
 
+const MAX_ITEMS = 3;
+
 /**
  * A component for badges for dataset summaries
  */
@@ -18,6 +20,7 @@ import { UnderscoreToSpace } from '@app/shared/pipes/underscore-to-space.pipe';
   styleUrl: './summary-badges.component.scss',
 })
 export class SummaryBadgesComponent {
+  protected maxItems = MAX_ITEMS;
   data = input.required<
     {
       value: string;


### PR DESCRIPTION
In dataset summary:
If there are 4 elements (or more), it should show a `Show 2 more` link.
If there are only 3 elements or fewer, it should show them all. Added a test for these edge cases.

Fixed class names for some mat-chips.