### PR TITLE
Add date pipe that supports IANA time zone names

### DIFF
--- a/src/app/shared/pipes/date.pipe.spec.ts
+++ b/src/app/shared/pipes/date.pipe.spec.ts
@@ -4,7 +4,7 @@
  * @license Apache-2.0
  */
 
-import { DatePipe as AngularDatePipe } from '@angular/common';
+import { DatePipe as CommonDatePipe } from '@angular/common';
 import { TestBed } from '@angular/core/testing';
 import { DatePipe } from './date.pipe';
 
@@ -13,7 +13,7 @@ describe('DatePipe', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [AngularDatePipe, DatePipe],
+      providers: [CommonDatePipe, DatePipe],
     });
     pipe = TestBed.inject(DatePipe);
   });
@@ -74,5 +74,17 @@ describe('DatePipe', () => {
     // note that this is summer time in Sydney, so UTC+11
     const result = pipe.transform(date, 'yyyy-MM-dd HH:mm', 'Australia/Sydney');
     expect(result).toBe('2024-12-26 02:30');
+  });
+
+  it('should break if Sydney timezone is used with common pipe', () => {
+    const pipe = new CommonDatePipe('en');
+    const date = new Date('2024-12-25T15:30:00Z');
+    let result = pipe.transform(date, 'yyyy-MM-dd HH:mm', '+11:00');
+    expect(result).toBe('2024-12-26 02:30');
+    result = pipe.transform(date, 'yyyy-MM-dd HH:mm', 'Australia/Sydney');
+    // The following is expected to break (see
+    // https://github.com/angular/angular/issues/48279).
+    // If it works, it means we do not need the custom DatePipe any more.
+    expect(result).not.toBe('2024-12-26 02:30');
   });
 });

--- a/src/app/shared/pipes/date.pipe.spec.ts
+++ b/src/app/shared/pipes/date.pipe.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * These are the unit tests for the DatePipe pipe.
+ * @copyright The GHGA Authors
+ * @license Apache-2.0
+ */
+
+import { DatePipe as AngularDatePipe } from '@angular/common';
+import { TestBed } from '@angular/core/testing';
+import { DatePipe } from './date.pipe';
+
+describe('DatePipe', () => {
+  let pipe: DatePipe;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [AngularDatePipe, DatePipe],
+    });
+    pipe = TestBed.inject(DatePipe);
+  });
+
+  it('can create an instance', () => {
+    expect(pipe).toBeTruthy();
+  });
+
+  it('should return null for null input', () => {
+    const result = pipe.transform(null);
+    expect(result).toBeNull();
+  });
+
+  it('should return null for undefined input', () => {
+    const result = pipe.transform(undefined);
+    expect(result).toBeNull();
+  });
+
+  it('should work with default format when no format is specified', () => {
+    const date = new Date('2024-12-25');
+    const result = pipe.transform(date);
+    expect(result).toBe('Dec 25, 2024');
+  });
+
+  it('should work with custom format and local time zone', () => {
+    const date = new Date('2024-12-25T15:30:00');
+    const result = pipe.transform(date, 'yyyy-MM-dd HH:mm');
+    expect(result).toBe('2024-12-25 15:30');
+  });
+
+  it('should work with custom format and UTC', () => {
+    const date = new Date('2024-12-25T15:30:00Z');
+    const result = pipe.transform(date, 'yyyy-MM-dd HH:mm', 'UTC');
+    expect(result).toBe('2024-12-25 15:30');
+  });
+
+  it('should work with custom format and timezone offset', () => {
+    const date = new Date('2024-12-25T15:30:00Z');
+    const result = pipe.transform(date, 'yyyy-MM-dd HH:mm', '+01:30');
+    expect(result).toBe('2024-12-25 17:00');
+  });
+
+  it('should work with custom format and negative timezone offset', () => {
+    const date = new Date('2024-12-25T15:30:00Z');
+    const result = pipe.transform(date, 'yyyy-MM-dd HH:mm', '-01:30');
+    expect(result).toBe('2024-12-25 14:00');
+  });
+
+  it('should work with custom format and Berlin timezone', () => {
+    const date = new Date('2024-12-25T15:30:00Z');
+    // note that this is winter time in Berlin, so UTC+1
+    const result = pipe.transform(date, 'yyyy-MM-dd HH:mm', 'Europe/Berlin');
+    expect(result).toBe('2024-12-25 16:30');
+  });
+
+  it('should work with custom format and Sydney timezone', () => {
+    const date = new Date('2024-12-25T15:30:00Z');
+    // note that this is summer time in Sydney, so UTC+11
+    const result = pipe.transform(date, 'yyyy-MM-dd HH:mm', 'Australia/Sydney');
+    expect(result).toBe('2024-12-26 02:30');
+  });
+});

--- a/src/app/shared/pipes/date.pipe.ts
+++ b/src/app/shared/pipes/date.pipe.ts
@@ -1,0 +1,85 @@
+/**
+ * Improved DatePipe that supports IANA time zone names.
+ * @copyright The GHGA Authors
+ * @license Apache-2.0
+ */
+
+import { DatePipe as CommonDatePipe } from '@angular/common';
+import { inject, Pipe, PipeTransform } from '@angular/core';
+
+/**
+ * This is an improved DatePipe that also supports IANA time zone names.
+ *
+ * The existing Angular DatePipe currently only supports time zone offsets.
+ * This custom DatePipe extends the functionality by allowing
+ * the use of IANA time zone names like 'Europe/Berlin'.
+ * Please use either time zone offsets or IANA time zone names,
+ * but do not use time zone abbreviations (e.g., 'CET', 'EST')
+ * as they can be ambiguous* and can lead to incorrect results
+ * depending on the runtime environment.
+ * This pipe assumes the browser supports the Intl API, which all modern browsers do.
+ * If it is not supported, it behaves like the original DatePipe.
+ */
+@Pipe({
+  name: 'DatePipe',
+})
+export class DatePipe implements PipeTransform {
+  private datePipe = inject(CommonDatePipe);
+
+  /**
+   * Transforms a date value according to the specified parameters.
+   * @param value - the date value to transform
+   * @param format - the date format to use (optional)
+   * @param timezone - the timezone to use (optional)
+   * @param locale - the locale to use (optional)
+   * @returns the formatted date
+   */
+  transform(
+    value: Date | string | number | null | undefined,
+    format?: string,
+    timezone?: string,
+    locale?: string,
+  ): string | null {
+    // If the timezone is specified as an IANA time zone name,
+    // convert the time zone to an offset using the Intl API.
+    if (timezone && timezone.includes('/')) {
+      timezone = this.convertTimezoneToOffset(value, timezone);
+    }
+    return this.datePipe.transform(value, format, timezone, locale);
+  }
+
+  /**
+   * Converts a timezone name to an offset using the Intl API
+   * @param value The date value to use for timezone calculation
+   * @param timezone The IANA timezone name to convert
+   * @returns The timezone offset in +HHMM or -HHMM format
+   */
+  private convertTimezoneToOffset(
+    value: Date | string | number | null | undefined,
+    timezone: string,
+  ): string {
+    if (!value) {
+      return timezone;
+    }
+    try {
+      const date = new Date(value);
+      if (isNaN(date.getTime())) {
+        return timezone;
+      }
+      // Use Intl API to get offset in +01:00 format
+      const formatter = new Intl.DateTimeFormat('en', {
+        timeZone: timezone,
+        timeZoneName: 'shortOffset',
+      });
+      const parts = formatter.formatToParts(date);
+      const offsetPart = parts.find((part) => part.type === 'timeZoneName');
+      if (offsetPart?.value) {
+        // Convert "+01:00" to "+0100" format
+        return offsetPart.value.replace(':', '');
+      }
+      return timezone;
+    } catch {
+      return timezone;
+    }
+  }
+}

--- a/src/app/shared/pipes/date.pipe.ts
+++ b/src/app/shared/pipes/date.pipe.ts
@@ -10,14 +10,17 @@ import { inject, Pipe, PipeTransform } from '@angular/core';
 /**
  * This is an improved DatePipe that also supports IANA time zone names.
  *
- * The existing Angular DatePipe currently only supports time zone offsets.
+ * The existing Angular DatePipe currently only supports time zone offsets
+ * such as '+0100', but not abbreviations or IANA time zone names.
+ *
  * This custom DatePipe extends the functionality by allowing
  * the use of IANA time zone names like 'Europe/Berlin'.
- * Please use either time zone offsets or IANA time zone names,
- * but do not use time zone abbreviations (e.g., 'CET', 'EST')
- * as they can be ambiguous* and can lead to incorrect results
- * depending on the runtime environment.
- * This pipe assumes the browser supports the Intl API, which all modern browsers do.
+ *
+ * Please use either time zone offsets or IANA time zone names, but do not
+ * use time zone abbreviations such as 'CET', as they can be ambiguous and
+ * lead to incorrect results depending on the runtime environment.
+ *
+ * We assume the Intl API is supported since all modern browsers have it.
  * If it is not supported, it behaves like the original DatePipe.
  */
 @Pipe({
@@ -43,7 +46,7 @@ export class DatePipe implements PipeTransform {
     // If the timezone is specified as an IANA time zone name,
     // convert the time zone to an offset using the Intl API.
     if (timezone && timezone.includes('/')) {
-      timezone = this.convertTimezoneToOffset(value, timezone);
+      timezone = this.#convertTimezoneToOffset(value, timezone);
     }
     return this.datePipe.transform(value, format, timezone, locale);
   }
@@ -54,7 +57,7 @@ export class DatePipe implements PipeTransform {
    * @param timezone The IANA timezone name to convert
    * @returns The timezone offset in +HHMM or -HHMM format
    */
-  private convertTimezoneToOffset(
+  #convertTimezoneToOffset(
     value: Date | string | number | null | undefined,
     timezone: string,
   ): string {

--- a/src/app/shared/pipes/date.pipe.ts
+++ b/src/app/shared/pipes/date.pipe.ts
@@ -23,11 +23,9 @@ import { inject, Pipe, PipeTransform } from '@angular/core';
  * We assume the Intl API is supported since all modern browsers have it.
  * If it is not supported, it behaves like the original DatePipe.
  */
-@Pipe({
-  name: 'DatePipe',
-})
+@Pipe({ name: 'DatePipe' })
 export class DatePipe implements PipeTransform {
-  private datePipe = inject(CommonDatePipe);
+  #datePipe = inject(CommonDatePipe);
 
   /**
    * Transforms a date value according to the specified parameters.
@@ -48,7 +46,7 @@ export class DatePipe implements PipeTransform {
     if (timezone && timezone.includes('/')) {
       timezone = this.#convertTimezoneToOffset(value, timezone);
     }
-    return this.datePipe.transform(value, format, timezone, locale);
+    return this.#datePipe.transform(value, format, timezone, locale);
   }
 
   /**


### PR DESCRIPTION
The DatePipe that is shipped with Angular does not support IANA time zones, only fixed zone offsets. We need dynamic zones for the access and end dates. Therefore, I added an improved date pipe that supports the dynamic IANA zones.