### PR TITLE
Improve time zone handling for access periods

### DIFF
--- a/src/app/access-requests/features/access-request-dialog/access-request-dialog.component.ts
+++ b/src/app/access-requests/features/access-request-dialog/access-request-dialog.component.ts
@@ -272,17 +272,13 @@ export class AccessRequestDialogComponent {
   submit(): void {
     const description = this.descriptionFormControl.value;
     const email = this.emailFormControl.value;
-    const from = this.fromDate();
-    const until = this.untilDate();
-    const fromDate = timeZoneToUTC(
-      from!.getFullYear(),
-      from!.getMonth(),
-      from!.getDate(),
-    );
+    const from = this.fromDate()!;
+    const until = this.untilDate()!;
+    const fromDate = timeZoneToUTC(from.getFullYear(), from.getMonth(), from.getDate());
     const untilDate = timeZoneToUTC(
-      until!.getFullYear(),
-      until!.getMonth(),
-      until!.getDate(),
+      until.getFullYear(),
+      until.getMonth(),
+      until.getDate(),
       true,
     );
     const data = { ...this.data, description, fromDate, untilDate, email };

--- a/src/app/access-requests/features/access-request-dialog/access-request-dialog.component.ts
+++ b/src/app/access-requests/features/access-request-dialog/access-request-dialog.component.ts
@@ -27,7 +27,7 @@ import { MatFormField, MatHint, MatLabel } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { AccessRequestDialogData } from '@app/access-requests/models/access-requests';
 import { ConfigService } from '@app/shared/services/config.service';
-import { DATE_INPUT_FORMAT_HINT } from '@app/shared/utils/date-formats';
+import { DATE_INPUT_FORMAT_HINT, timeZoneToUTC } from '@app/shared/utils/date-formats';
 
 /**
  * This component contains a form for all the data needed for an access request.
@@ -271,29 +271,20 @@ export class AccessRequestDialogComponent {
    */
   submit(): void {
     const description = this.descriptionFormControl.value;
-    const fromDate = new Date(
-      Date.UTC(
-        this.fromDate()!.getFullYear(),
-        this.fromDate()!.getMonth(),
-        this.fromDate()!.getDate(),
-        0,
-        0,
-        0,
-        0,
-      ),
-    );
-    const untilDate = new Date(
-      Date.UTC(
-        this.untilDate()!.getFullYear(),
-        this.untilDate()!.getMonth(),
-        this.untilDate()!.getDate(),
-        23,
-        59,
-        59,
-        999,
-      ),
-    );
     const email = this.emailFormControl.value;
+    const from = this.fromDate();
+    const until = this.untilDate();
+    const fromDate = timeZoneToUTC(
+      from!.getFullYear(),
+      from!.getMonth(),
+      from!.getDate(),
+    );
+    const untilDate = timeZoneToUTC(
+      until!.getFullYear(),
+      until!.getMonth(),
+      until!.getDate(),
+      true,
+    );
     const data = { ...this.data, description, fromDate, untilDate, email };
     this.dialogRef.close(data);
   }

--- a/src/app/access-requests/features/access-request-duration-edit/access-request-duration-edit.component.html
+++ b/src/app/access-requests/features/access-request-duration-edit/access-request-duration-edit.component.html
@@ -68,8 +68,8 @@
       <th class="w-36 min-w-36 pe-1 text-start align-middle">Access duration:</th>
       <td class="flex min-w-60 items-center pb-1">
         <span class="grow">
-          {{ fromField() | date }} to
-          {{ untilField() | date }}
+          {{ fromField() | date: periodFormat : periodTimeZone }} to
+          {{ untilField() | date: periodFormat : periodTimeZone }}
         </span>
         <mat-chip
           (click)="open()"

--- a/src/app/access-requests/features/access-request-manager-list/access-request-manager-list.component.html
+++ b/src/app/access-requests/features/access-request-manager-list/access-request-manager-list.component.html
@@ -35,13 +35,13 @@
       <ng-container matColumnDef="starts">
         <th mat-header-cell *matHeaderCellDef mat-sort-header>Access start</th>
         <td mat-cell *matCellDef="let ar">
-          {{ ar.access_starts | date }}
+          {{ ar.access_starts | date: periodFormat : periodTimeZone }}
         </td>
       </ng-container>
       <ng-container matColumnDef="ends">
         <th mat-header-cell *matHeaderCellDef mat-sort-header>Access end</th>
         <td mat-cell *matCellDef="let ar">
-          {{ ar.access_ends | date }}
+          {{ ar.access_ends | date: periodFormat : periodTimeZone }}
         </td>
       </ng-container>
       <ng-container matColumnDef="requested">

--- a/src/app/access-requests/features/access-request-manager-list/access-request-manager-list.component.ts
+++ b/src/app/access-requests/features/access-request-manager-list/access-request-manager-list.component.ts
@@ -4,7 +4,7 @@
  * @license Apache-2.0
  */
 
-import { DatePipe } from '@angular/common';
+import { DatePipe as CommonDatePipe } from '@angular/common';
 import {
   AfterViewInit,
   Component,
@@ -22,6 +22,11 @@ import { MatTableDataSource, MatTableModule } from '@angular/material/table';
 import { AccessRequest } from '@app/access-requests/models/access-requests';
 import { AccessRequestStatusClassPipe } from '@app/access-requests/pipes/access-request-status-class.pipe';
 import { AccessRequestService } from '@app/access-requests/services/access-request.service';
+import { DatePipe } from '@app/shared/pipes/date.pipe';
+import {
+  DEFAULT_DATE_OUTPUT_FORMAT,
+  DEFAULT_TIME_ZONE,
+} from '@app/shared/utils/date-formats';
 import { AccessRequestManagerDialogComponent } from '../access-request-manager-dialog/access-request-manager-dialog.component';
 
 /**
@@ -40,6 +45,7 @@ import { AccessRequestManagerDialogComponent } from '../access-request-manager-d
     AccessRequestStatusClassPipe,
     MatIconModule,
   ],
+  providers: [CommonDatePipe],
   templateUrl: './access-request-manager-list.component.html',
   styleUrl: './access-request-manager-list.component.scss',
 })
@@ -56,6 +62,9 @@ export class AccessRequestManagerListComponent implements AfterViewInit {
 
   defaultTablePageSize = 10;
   tablePageSizeOptions = [10, 25, 50, 100, 250, 500];
+
+  periodFormat = DEFAULT_DATE_OUTPUT_FORMAT;
+  periodTimeZone = DEFAULT_TIME_ZONE;
 
   #updateSourceEffect = effect(() => (this.source.data = this.accessRequests()));
 

--- a/src/app/shared/pipes/date.pipe.ts
+++ b/src/app/shared/pipes/date.pipe.ts
@@ -23,7 +23,7 @@ import { inject, Pipe, PipeTransform } from '@angular/core';
  * We assume the Intl API is supported since all modern browsers have it.
  * If it is not supported, it behaves like the original DatePipe.
  */
-@Pipe({ name: 'DatePipe' })
+@Pipe({ name: 'date' })
 export class DatePipe implements PipeTransform {
   #datePipe = inject(CommonDatePipe);
 

--- a/src/app/shared/utils/date-formats.spec.ts
+++ b/src/app/shared/utils/date-formats.spec.ts
@@ -1,0 +1,42 @@
+/**
+ * Unit tests for date formats and utility functions.
+ * @copyright The GHGA Authors
+ * @license Apache-2.0
+ */
+
+import { timeZoneToUTC } from './date-formats';
+
+describe('Date Formats', () => {
+  describe('timeZoneToUTC', () => {
+    it('should create valid dates', () => {
+      // Basic test to ensure no invalid date errors
+      const result = timeZoneToUTC(2025, 5, 1);
+      expect(result).toBeInstanceOf(Date);
+      expect(isNaN(result.getTime())).toBe(false);
+    });
+
+    it('should convert Berlin summer time to UTC correctly', () => {
+      // 2025-08-01 00:00 Berlin time should be 2025-07-31 22:00 UTC (CEST = UTC+2)
+      const result = timeZoneToUTC(2025, 7, 1);
+      expect(result.toISOString()).toBe('2025-07-31T22:00:00.000Z');
+    });
+
+    it('should convert Berlin winter time to UTC correctly', () => {
+      // 2025-01-01 00:00 Berlin time should be 2024-12-31 23:00 UTC (CET = UTC+1)
+      const result = timeZoneToUTC(2025, 0, 1);
+      expect(result.toISOString()).toBe('2024-12-31T23:00:00.000Z');
+    });
+
+    it('should handle end of day correctly in summer time', () => {
+      // 2025-08-01 23:59:59.999 Berlin time should be 2025-08-01 21:59:59.999 UTC (CEST = UTC+2)
+      const result = timeZoneToUTC(2025, 7, 1, true);
+      expect(result.toISOString()).toBe('2025-08-01T21:59:59.999Z');
+    });
+
+    it('should handle end of day correctly in winter time', () => {
+      // 2025-01-01 23:59:59.999 Berlin time should be 2025-01-01 22:59:59.999 UTC (CET = UTC+1)
+      const result = timeZoneToUTC(2025, 0, 1, true);
+      expect(result.toISOString()).toBe('2025-01-01T22:59:59.999Z');
+    });
+  });
+});

--- a/src/app/shared/utils/date-formats.ts
+++ b/src/app/shared/utils/date-formats.ts
@@ -9,6 +9,8 @@ import { enGB } from 'date-fns/locale';
 
 export const DEFAULT_DATE_LOCALE = enGB;
 
+export const DEFAULT_TIME_ZONE = 'Europe/Berlin';
+
 export const DEFAULT_DATE_OUTPUT_FORMAT = 'yyyy-MM-dd';
 export const DEFAULT_DATE_INPUT_FORMAT = 'yyyy-MM-dd';
 export const FRIENDLY_DATE_FORMAT = 'd MMMM y';
@@ -35,3 +37,43 @@ export const DEFAULT_DATE_FORMATS: MatDateFormats = {
     monthYearA11yLabel: 'MMMM yyyy',
   },
 };
+
+/**
+ * Create a UTC Date from a local time in the given IANA time zone
+ * @param year - the year
+ * @param month - the month (0-based, e.g. January = 0)
+ * @param day - the day of the month
+ * @param end - whether we want the time at the end of the day (default false)
+ * @param timeZone - the IANA timezone name
+ * @returns the Date in UTC
+ */
+export function timeZoneToUTC(
+  year: number,
+  month: number,
+  day: number,
+  end: boolean = false,
+  timeZone: string = DEFAULT_TIME_ZONE,
+): Date {
+  const [hour, minute, second, ms] = end ? [23, 59, 59, 999] : [0, 0, 0, 0];
+  const utcDate = new Date(Date.UTC(year, month, day, hour, minute, second, ms));
+  const tzOptions: Intl.DateTimeFormatOptions = {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  };
+  const tzFormatter = new Intl.DateTimeFormat('de-DE', tzOptions);
+  const tzString = tzFormatter.format(utcDate); // e.g. "01.08.2025, 02:00:00"
+  const [datePart, timePart] = tzString.split(', ');
+  const [tzHour, tzMinute, tzSecond] = timePart.split(':').map(Number);
+  const [tzDay, tzMonth, tzYear] = datePart.split('.').map(Number);
+  const tzAsUtc = new Date(
+    Date.UTC(tzYear, tzMonth - 1, tzDay, tzHour, tzMinute, tzSecond, ms),
+  );
+  const offset = utcDate.getTime() - tzAsUtc.getTime();
+  return new Date(utcDate.getTime() + offset);
+}


### PR DESCRIPTION
The access period should be converted from German time zone to UTC when stored and vice versa when displayed.