### PR TITLE
All routes should have no-cache headers

### DIFF
--- a/sws.toml
+++ b/sws.toml
@@ -2,8 +2,21 @@
 root = "."
 page-fallback = "./index.html"
 
+# Cache hashed static assets for 1 year (immutable)
 [[advanced.headers]]
-source = "/index.html"
+source = "**/*.{js,css,png,jpg,jpeg,gif,svg,ico,woff,woff2,ttf,eot,webp,avif,map,wasm}"
+[advanced.headers.headers]
+Cache-Control = "public, max-age=31536000, immutable"
+
+# Cache other assets for shorter time (30 days)
+[[advanced.headers]]
+source = "**/*.{json,xml,txt,md,xlsx,zip,gz,py,scss}"
+[advanced.headers.headers]
+Cache-Control = "public, max-age=2592000"
+
+# No cache for HTML pages and SPA routes
+[[advanced.headers]]
+source = "**"
 [advanced.headers.headers]
 Cache-Control = "no-cache, no-store, must-revalidate, proxy-revalidate"
 Pragma = "no-cache"


### PR DESCRIPTION
The SWS was configured to add no-cache headers to the index page.

The problem with the config was that the source config option applies to the requested URL path, not the actual file that gets served. So the headers were only added to the actual index page, not when loading from another URL.

This PR changes the source config option to cover all possible routes using the "**" glob pattern. However, this means that all static assets would now be served with no-cache headers as well which is not what we want. Instead, they should have an explicit cache duration, and for bundles which are already hashed this duration should be virtually infinite.