### PR TITLE
Add user management list view (GSI-1734)

### DIFF
--- a/src/app/access-requests/features/access-request-manager-dialog/access-request-manager-dialog.component.ts
+++ b/src/app/access-requests/features/access-request-manager-dialog/access-request-manager-dialog.component.ts
@@ -34,7 +34,7 @@ import {
 } from '@app/access-requests/models/access-requests';
 import { AccessRequestStatusClassPipe } from '@app/access-requests/pipes/access-request-status-class.pipe';
 import { AccessRequestService } from '@app/access-requests/services/access-request.service';
-import { User } from '@app/auth/models/user';
+import { UserSession } from '@app/auth/models/user';
 import { SplitLinesPipe } from '@app/shared/pipes/split-lines.pipe';
 import { ConfigService } from '@app/shared/services/config.service';
 import { ConfirmationService } from '@app/shared/services/confirmation.service';
@@ -111,7 +111,7 @@ export class AccessRequestManagerDialogComponent implements OnInit {
       return `${this.#usersUrl}/${userId}`;
     },
     {
-      parse: (raw) => (raw as User).ext_id,
+      parse: (raw) => (raw as UserSession).ext_id,
       defaultValue: undefined,
     },
   );

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -74,6 +74,15 @@ export const routes: Routes = [
       ).then((m) => m.AccessRequestManagerComponent),
     title: 'Access Request Manager',
   },
+  {
+    path: 'user-manager',
+    canActivate: [() => inject(AuthService).guardDataSteward()],
+    loadComponent: () =>
+      import('./auth/features/user-manager/user-manager.component').then(
+        (m) => m.UserManagerComponent,
+      ),
+    title: 'User Manager',
+  },
   // routes used in the authentication flows
   {
     path: 'oauth/callback',

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -83,6 +83,15 @@ export const routes: Routes = [
       ),
     title: 'User Manager',
   },
+  {
+    path: 'user-manager/:id',
+    canActivate: [() => inject(AuthService).guardDataSteward()],
+    loadComponent: () =>
+      import('./auth/features/user-manager-detail/user-manager-detail.component').then(
+        (m) => m.UserManagerDetailComponent,
+      ),
+    title: 'User Details',
+  },
   // routes used in the authentication flows
   {
     path: 'oauth/callback',

--- a/src/app/auth/features/register/register.component.spec.ts
+++ b/src/app/auth/features/register/register.component.spec.ts
@@ -6,7 +6,7 @@
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { User } from '@app/auth/models/user';
+import { UserSession } from '@app/auth/models/user';
 import { AuthService } from '@app/auth/services/auth.service';
 import { RegisterComponent } from './register.component';
 
@@ -18,7 +18,7 @@ class MockAuthService {
    * Provide a dummy user with data from first factor authentication
    * @returns a dummy user with all properties set
    */
-  user(): User {
+  user(): UserSession {
     return {
       name: 'John Doe',
       title: 'Dr.',

--- a/src/app/auth/features/user-manager-detail/user-manager-detail.component.html
+++ b/src/app/auth/features/user-manager-detail/user-manager-detail.component.html
@@ -9,7 +9,7 @@
       >
         <mat-icon>chevron_left</mat-icon>
       </button>
-      <h1 class="text-3xl font-bold">User: {{ currentUser.displayName }}</h1>
+      <h1>User: {{ currentUser.displayName }}</h1>
     </div>
 
     <div class="rounded-lg bg-white p-6 shadow-md">

--- a/src/app/auth/features/user-manager-detail/user-manager-detail.component.html
+++ b/src/app/auth/features/user-manager-detail/user-manager-detail.component.html
@@ -1,5 +1,5 @@
 @if (user(); as currentUser) {
-  <div class="container mx-auto p-6">
+  <div class="mx-auto max-w-[1200px] p-6">
     <div class="clearfix mb-6">
       <button
         mat-icon-button

--- a/src/app/auth/features/user-manager-detail/user-manager-detail.component.html
+++ b/src/app/auth/features/user-manager-detail/user-manager-detail.component.html
@@ -53,14 +53,14 @@
                 >Registration Date</span
               >
               <p class="mt-1 text-sm text-gray-900">
-                {{ currentUser.registration_date | date }}
+                {{ currentUser.registration_date | date: friendlyDateFormat }}
               </p>
             </div>
             <div>
               <span class="block text-sm font-medium text-gray-700">Roles</span>
               <div class="mt-1 flex flex-wrap gap-1">
-                @for (role of currentUser.roles; track role) {
-                  <mat-chip>{{ role }}</mat-chip>
+                @for (roleName of currentUser.roleNames; track roleName) {
+                  <mat-chip>{{ roleName }}</mat-chip>
                 } @empty {
                   <p class="text-sm text-gray-500">No roles assigned</p>
                 }

--- a/src/app/auth/features/user-manager-detail/user-manager-detail.component.html
+++ b/src/app/auth/features/user-manager-detail/user-manager-detail.component.html
@@ -1,15 +1,15 @@
 @if (user(); as currentUser) {
   <div class="container mx-auto p-6">
-    <div class="mb-6 flex items-center gap-4">
+    <div class="clearfix mb-6">
       <button
         mat-icon-button
         (click)="goBack()"
         aria-label="Go back to user list"
-        class="text-primary"
+        class="text-primary float-left mt-1 mr-4"
       >
-        <mat-icon>arrow_back</mat-icon>
+        <mat-icon>chevron_left</mat-icon>
       </button>
-      <h1 class="text-3xl font-bold">User: {{ userDisplayName() }}</h1>
+      <h1 class="text-3xl font-bold">User: {{ currentUser.displayName }}</h1>
     </div>
 
     <div class="rounded-lg bg-white p-6 shadow-md">

--- a/src/app/auth/features/user-manager-detail/user-manager-detail.component.html
+++ b/src/app/auth/features/user-manager-detail/user-manager-detail.component.html
@@ -1,0 +1,96 @@
+@if (user(); as currentUser) {
+  <div class="container mx-auto p-6">
+    <div class="mb-6 flex items-center gap-4">
+      <button
+        mat-icon-button
+        (click)="goBack()"
+        aria-label="Go back to user list"
+        class="text-primary"
+      >
+        <mat-icon>arrow_back</mat-icon>
+      </button>
+      <h1 class="text-3xl font-bold">User: {{ userDisplayName() }}</h1>
+    </div>
+
+    <div class="rounded-lg bg-white p-6 shadow-md">
+      <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
+        <div>
+          <h2 class="mb-4 text-xl font-semibold">Basic Information</h2>
+          <div class="space-y-3">
+            <div>
+              <span class="block text-sm font-medium text-gray-700">Name</span>
+              <p class="mt-1 text-sm text-gray-900">{{ currentUser.name }}</p>
+            </div>
+            @if (currentUser.title) {
+              <div>
+                <span class="block text-sm font-medium text-gray-700">Title</span>
+                <p class="mt-1 text-sm text-gray-900">{{ currentUser.title }}</p>
+              </div>
+            }
+            <div>
+              <span class="block text-sm font-medium text-gray-700">Email</span>
+              <p class="mt-1 text-sm text-gray-900">{{ currentUser.email }}</p>
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <h2 class="mb-4 text-xl font-semibold">Account Details</h2>
+          <div class="space-y-3">
+            <div>
+              <span class="block text-sm font-medium text-gray-700">Status</span>
+              <p
+                class="mt-1 text-sm capitalize"
+                [class]="
+                  currentUser.status === 'active' ? 'text-green-600' : 'text-red-600'
+                "
+              >
+                {{ currentUser.status }}
+              </p>
+            </div>
+            <div>
+              <span class="block text-sm font-medium text-gray-700"
+                >Registration Date</span
+              >
+              <p class="mt-1 text-sm text-gray-900">
+                {{ currentUser.registration_date | date }}
+              </p>
+            </div>
+            <div>
+              <span class="block text-sm font-medium text-gray-700">Roles</span>
+              <div class="mt-1 flex flex-wrap gap-1">
+                @for (role of currentUser.roles; track role) {
+                  <mat-chip>{{ role }}</mat-chip>
+                } @empty {
+                  <p class="text-sm text-gray-500">No roles assigned</p>
+                }
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- External ID in full row -->
+      <div class="mt-6 pt-6">
+        <div>
+          <span class="block text-sm font-medium text-gray-700">External ID</span>
+          <p class="mt-1 font-mono text-sm break-all text-gray-900">
+            {{ currentUser.ext_id }}
+          </p>
+        </div>
+      </div>
+
+      <!-- TODO: Detail view functionality still needs to be implemented -->
+    </div>
+  </div>
+} @else {
+  <div class="container mx-auto p-6">
+    <div class="text-center">
+      <h1 class="mb-4 text-2xl font-bold text-red-600">User Not Found</h1>
+      <p class="mb-6 text-gray-600">The requested user could not be found.</p>
+      <button mat-raised-button color="primary" (click)="goBack()">
+        Back to User List
+      </button>
+    </div>
+  </div>
+}

--- a/src/app/auth/features/user-manager-detail/user-manager-detail.component.scss
+++ b/src/app/auth/features/user-manager-detail/user-manager-detail.component.scss
@@ -1,0 +1,24 @@
+/**
+ * User Manager Detail component styles
+ * @copyright The GHGA Authors
+ * @license Apache-2.0
+ */
+
+:host {
+  display: block;
+  min-height: 100vh;
+  background-color: var(--mat-sys-surface-container-low);
+}
+
+.container {
+  max-width: 1200px;
+}
+
+// Status color overrides if needed
+.status-active {
+  color: var(--mat-sys-primary);
+}
+
+.status-inactive {
+  color: var(--mat-sys-error);
+}

--- a/src/app/auth/features/user-manager-detail/user-manager-detail.component.scss
+++ b/src/app/auth/features/user-manager-detail/user-manager-detail.component.scss
@@ -12,10 +12,6 @@
   background-color: var(--mat-sys-surface-container-low);
 }
 
-.container {
-  max-width: 1200px;
-}
-
 // Consistent mat-chip styling with list view
 mat-chip {
   @include mat.chips-overrides(

--- a/src/app/auth/features/user-manager-detail/user-manager-detail.component.scss
+++ b/src/app/auth/features/user-manager-detail/user-manager-detail.component.scss
@@ -8,7 +8,7 @@
 
 :host {
   display: block;
-  min-height: 100vh;
+  padding-bottom: 1em;
   background-color: var(--mat-sys-surface-container-low);
 }
 

--- a/src/app/auth/features/user-manager-detail/user-manager-detail.component.scss
+++ b/src/app/auth/features/user-manager-detail/user-manager-detail.component.scss
@@ -4,6 +4,8 @@
  * @license Apache-2.0
  */
 
+@use '@angular/material' as mat;
+
 :host {
   display: block;
   min-height: 100vh;
@@ -12,6 +14,17 @@
 
 .container {
   max-width: 1200px;
+}
+
+// Consistent mat-chip styling with list view
+mat-chip {
+  @include mat.chips-overrides(
+    (
+      outline-color: var(--mat-sys-tertiary),
+      label-text-color: var(--mat-sys-tertiary),
+      with-trailing-icon-trailing-icon-color: var(--mat-sys-tertiary),
+    )
+  );
 }
 
 // Status color overrides if needed

--- a/src/app/auth/features/user-manager-detail/user-manager-detail.component.scss
+++ b/src/app/auth/features/user-manager-detail/user-manager-detail.component.scss
@@ -6,13 +6,6 @@
 
 @use '@angular/material' as mat;
 
-:host {
-  display: block;
-  padding-bottom: 1em;
-  background-color: var(--mat-sys-surface-container-low);
-}
-
-// Consistent mat-chip styling with list view
 mat-chip {
   @include mat.chips-overrides(
     (
@@ -21,13 +14,4 @@ mat-chip {
       with-trailing-icon-trailing-icon-color: var(--mat-sys-tertiary),
     )
   );
-}
-
-// Status color overrides if needed
-.status-active {
-  color: var(--mat-sys-primary);
-}
-
-.status-inactive {
-  color: var(--mat-sys-error);
 }

--- a/src/app/auth/features/user-manager-detail/user-manager-detail.component.spec.ts
+++ b/src/app/auth/features/user-manager-detail/user-manager-detail.component.spec.ts
@@ -4,9 +4,9 @@
  * @license Apache-2.0
  */
 
+import { DatePipe as CommonDatePipe } from '@angular/common';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
-import { DatePipe as CommonDatePipe } from '@angular/common';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute, Router } from '@angular/router';

--- a/src/app/auth/features/user-manager-detail/user-manager-detail.component.spec.ts
+++ b/src/app/auth/features/user-manager-detail/user-manager-detail.component.spec.ts
@@ -1,0 +1,117 @@
+/**
+ * User Manager Detail component tests
+ * @copyright The GHGA Authors
+ * @license Apache-2.0
+ */
+
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { ActivatedRoute, Router } from '@angular/router';
+import { UserService } from '@app/auth/services/user.service';
+import { UserManagerDetailComponent } from './user-manager-detail.component';
+
+/**
+ * Mock UserService for testing
+ */
+class MockUserService {
+  users = {
+    value: jest.fn(() => [
+      {
+        id: '123',
+        name: 'John Doe',
+        title: 'Dr.',
+        email: 'john@example.com',
+        ext_id: 'ext123',
+        roles: ['data_steward'],
+        status: 'active',
+        registration_date: '2023-01-01',
+      },
+    ]),
+    isLoading: jest.fn(() => false),
+    error: jest.fn(() => null),
+  };
+}
+
+/**
+ * Mock ActivatedRoute for testing
+ */
+class MockActivatedRoute {
+  snapshot = {
+    params: { id: '123' },
+  };
+}
+
+/**
+ * Mock Router for testing
+ */
+class MockRouter {
+  navigate = jest.fn();
+}
+
+describe('UserManagerDetailComponent', () => {
+  let component: UserManagerDetailComponent;
+  let fixture: ComponentFixture<UserManagerDetailComponent>;
+  let mockUserService: MockUserService;
+  let mockRouter: MockRouter;
+
+  beforeEach(async () => {
+    mockUserService = new MockUserService();
+    mockRouter = new MockRouter();
+
+    await TestBed.configureTestingModule({
+      imports: [UserManagerDetailComponent, NoopAnimationsModule],
+      providers: [
+        { provide: UserService, useValue: mockUserService },
+        { provide: ActivatedRoute, useClass: MockActivatedRoute },
+        { provide: Router, useValue: mockRouter },
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(UserManagerDetailComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should find and display user when ID matches', () => {
+    const user = component.user();
+    expect(user).toBeDefined();
+    expect(user?.name).toBe('John Doe');
+    expect(user?.title).toBe('Dr.');
+  });
+
+  it('should format user display name with title', () => {
+    const displayName = component.userDisplayName();
+    expect(displayName).toBe('Dr. John Doe');
+  });
+
+  it('should navigate back when goBack is called', () => {
+    component.goBack();
+    expect(mockRouter.navigate).toHaveBeenCalledWith(['/user-manager']);
+  });
+
+  it('should render user details when user is found', () => {
+    fixture.detectChanges();
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('User: Dr. John Doe');
+    expect(compiled.textContent).toContain('john@example.com');
+    expect(compiled.textContent).toContain('ext123');
+    expect(compiled.textContent).toContain(
+      'Detail view functionality still needs to be implemented',
+    );
+  });
+
+  it('should show not found message when user is not found', () => {
+    // Override the mock to return empty array
+    mockUserService.users.value.mockReturnValue([]);
+    fixture.detectChanges();
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('User Not Found');
+  });
+});

--- a/src/app/auth/features/user-manager-detail/user-manager-detail.component.spec.ts
+++ b/src/app/auth/features/user-manager-detail/user-manager-detail.component.spec.ts
@@ -120,11 +120,6 @@ describe('UserManagerDetailComponent', () => {
     expect(user?.title).toBe('Dr.');
   });
 
-  it('should format user display name with title', () => {
-    const displayName = component.userDisplayName();
-    expect(displayName).toBe('Dr. John Doe');
-  });
-
   it('should navigate back when goBack is called', () => {
     component.goBack();
     expect(mockRouter.navigate).toHaveBeenCalledWith(['/user-manager']);

--- a/src/app/auth/features/user-manager-detail/user-manager-detail.component.ts
+++ b/src/app/auth/features/user-manager-detail/user-manager-detail.component.ts
@@ -47,14 +47,6 @@ export class UserManagerDetailComponent {
   });
 
   /**
-   * Get the display name from the enhanced user
-   */
-  userDisplayName = computed(() => {
-    const user = this.user();
-    return user?.displayName || '';
-  });
-
-  /**
    * Navigate back to the user list
    */
   goBack(): void {

--- a/src/app/auth/features/user-manager-detail/user-manager-detail.component.ts
+++ b/src/app/auth/features/user-manager-detail/user-manager-detail.component.ts
@@ -1,0 +1,62 @@
+/**
+ * Component for displaying detailed information about a specific user.
+ * @copyright The GHGA Authors
+ * @license Apache-2.0
+ */
+
+import { DatePipe as CommonDatePipe } from '@angular/common';
+import { Component, computed, inject } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatIconModule } from '@angular/material/icon';
+import { ActivatedRoute, Router } from '@angular/router';
+import { RegisteredUser } from '@app/auth/models/user';
+import { UserService } from '@app/auth/services/user.service';
+import { DatePipe } from '@app/shared/pipes/date.pipe';
+
+/**
+ * User Manager Detail component.
+ *
+ * This component displays detailed information about a specific user
+ * and allows data stewards to view and manage individual user data.
+ */
+@Component({
+  selector: 'app-user-manager-detail',
+  imports: [MatButtonModule, MatChipsModule, MatIconModule, DatePipe],
+  providers: [UserService, CommonDatePipe],
+  templateUrl: './user-manager-detail.component.html',
+  styleUrl: './user-manager-detail.component.scss',
+})
+export class UserManagerDetailComponent {
+  #route = inject(ActivatedRoute);
+  #router = inject(Router);
+  #userService = inject(UserService);
+
+  #userId = computed(() => this.#route.snapshot.params['id']);
+  #allUsers = this.#userService.users;
+
+  /**
+   * Get the specific user based on the route parameter
+   */
+  user = computed(() => {
+    const userId = this.#userId();
+    const users = this.#allUsers.value();
+    return users.find((user: RegisteredUser) => user.id === userId);
+  });
+
+  /**
+   * Get the display name with title if available
+   */
+  userDisplayName = computed(() => {
+    const user = this.user();
+    if (!user) return '';
+    return user.title ? `${user.title} ${user.name}` : user.name;
+  });
+
+  /**
+   * Navigate back to the user list
+   */
+  goBack(): void {
+    this.#router.navigate(['/user-manager']);
+  }
+}

--- a/src/app/auth/features/user-manager-detail/user-manager-detail.component.ts
+++ b/src/app/auth/features/user-manager-detail/user-manager-detail.component.ts
@@ -10,8 +10,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatIconModule } from '@angular/material/icon';
 import { ActivatedRoute, Router } from '@angular/router';
-import { RegisteredUser } from '@app/auth/models/user';
-import { UserService } from '@app/auth/services/user.service';
+import { EnhancedUser, UserService } from '@app/auth/services/user.service';
 import { DatePipe } from '@app/shared/pipes/date.pipe';
 
 /**
@@ -33,24 +32,23 @@ export class UserManagerDetailComponent {
   #userService = inject(UserService);
 
   #userId = computed(() => this.#route.snapshot.params['id']);
-  #allUsers = this.#userService.users;
+  #users = this.#userService.users;
 
   /**
    * Get the specific user based on the route parameter
    */
   user = computed(() => {
     const userId = this.#userId();
-    const users = this.#allUsers.value();
-    return users.find((user: RegisteredUser) => user.id === userId);
+    const users = this.#users.value();
+    return users.find((user: EnhancedUser) => user.id === userId);
   });
 
   /**
-   * Get the display name with title if available
+   * Get the display name from the enhanced user
    */
   userDisplayName = computed(() => {
     const user = this.user();
-    if (!user) return '';
-    return user.title ? `${user.title} ${user.name}` : user.name;
+    return user?.displayName || '';
   });
 
   /**

--- a/src/app/auth/features/user-manager-detail/user-manager-detail.component.ts
+++ b/src/app/auth/features/user-manager-detail/user-manager-detail.component.ts
@@ -10,8 +10,9 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatIconModule } from '@angular/material/icon';
 import { ActivatedRoute, Router } from '@angular/router';
-import { EnhancedUser, UserService } from '@app/auth/services/user.service';
+import { DisplayUser, UserService } from '@app/auth/services/user.service';
 import { DatePipe } from '@app/shared/pipes/date.pipe';
+import { FRIENDLY_DATE_FORMAT } from '@app/shared/utils/date-formats';
 
 /**
  * User Manager Detail component.
@@ -27,6 +28,8 @@ import { DatePipe } from '@app/shared/pipes/date.pipe';
   styleUrl: './user-manager-detail.component.scss',
 })
 export class UserManagerDetailComponent {
+  readonly friendlyDateFormat = FRIENDLY_DATE_FORMAT;
+
   #route = inject(ActivatedRoute);
   #router = inject(Router);
   #userService = inject(UserService);
@@ -40,7 +43,7 @@ export class UserManagerDetailComponent {
   user = computed(() => {
     const userId = this.#userId();
     const users = this.#users.value();
-    return users.find((user: EnhancedUser) => user.id === userId);
+    return users.find((user: DisplayUser) => user.id === userId);
   });
 
   /**

--- a/src/app/auth/features/user-manager-list/user-manager-list.component.html
+++ b/src/app/auth/features/user-manager-list/user-manager-list.component.html
@@ -20,7 +20,7 @@
       </ng-container>
 
       <ng-container matColumnDef="name">
-        <th mat-header-cell *matHeaderCellDef class="min-w-40" mat-sort-header>
+        <th mat-header-cell *matHeaderCellDef class="min-w-48" mat-sort-header>
           User Name
         </th>
         <td mat-cell *matCellDef="let user">

--- a/src/app/auth/features/user-manager-list/user-manager-list.component.html
+++ b/src/app/auth/features/user-manager-list/user-manager-list.component.html
@@ -48,7 +48,11 @@
         >
           Status
         </th>
-        <td mat-cell class="capitalize" *matCellDef="let user">
+        <td
+          mat-cell
+          class="{{ user.status | UserStatusClassPipe }} capitalize"
+          *matCellDef="let user"
+        >
           {{ user.status }}
         </td>
       </ng-container>

--- a/src/app/auth/features/user-manager-list/user-manager-list.component.html
+++ b/src/app/auth/features/user-manager-list/user-manager-list.component.html
@@ -29,9 +29,13 @@
       </ng-container>
 
       <ng-container matColumnDef="roles">
-        <th mat-header-cell *matHeaderCellDef class="w-32" mat-sort-header>Roles</th>
+        <th mat-header-cell *matHeaderCellDef class="w-40" mat-sort-header>Roles</th>
         <td mat-cell *matCellDef="let user">
-          {{ user.roles.join(', ') }}
+          <span class="flex flex-wrap gap-1">
+            @for (roleName of getRoleNames(user.roles); track roleName) {
+              <mat-chip>{{ roleName }}</mat-chip>
+            }
+          </span>
         </td>
       </ng-container>
 

--- a/src/app/auth/features/user-manager-list/user-manager-list.component.html
+++ b/src/app/auth/features/user-manager-list/user-manager-list.component.html
@@ -1,7 +1,7 @@
 @if (usersAreLoading()) {
   <p class="text-base">Loading users...</p>
 } @else {
-  @let columns = ['email', 'name', 'roles', 'status', 'registration_date'];
+  @let columns = ['email', 'name', 'roles', 'status', 'registration_date', 'details'];
   <div class="overflow-auto">
     <table
       mat-table
@@ -64,6 +64,20 @@
         </td>
       </ng-container>
 
+      <ng-container matColumnDef="details">
+        <th mat-header-cell *matHeaderCellDef class="w-24">Details</th>
+        <td mat-cell *matCellDef="let user">
+          <button
+            mat-icon-button
+            (click)="viewDetails(user); $event.stopPropagation()"
+            aria-label="View user details"
+            class="text-primary"
+          >
+            <mat-icon>chevron_right</mat-icon>
+          </button>
+        </td>
+      </ng-container>
+
       <tr mat-header-row *matHeaderRowDef="columns"></tr>
       <tr
         mat-row
@@ -73,7 +87,7 @@
       ></tr>
 
       <tr class="mat-row" *matNoDataRow>
-        <td class="mat-cell p-4 text-base" colspan="5">
+        <td class="mat-cell p-4 text-base" colspan="6">
           No users found. Try removing some filter conditions.
         </td>
       </tr>

--- a/src/app/auth/features/user-manager-list/user-manager-list.component.html
+++ b/src/app/auth/features/user-manager-list/user-manager-list.component.html
@@ -24,7 +24,7 @@
           User Name
         </th>
         <td mat-cell *matCellDef="let user">
-          {{ getDisplayName(user) }}
+          {{ user.displayName }}
         </td>
       </ng-container>
 
@@ -32,7 +32,7 @@
         <th mat-header-cell *matHeaderCellDef class="w-40" mat-sort-header>Roles</th>
         <td mat-cell *matCellDef="let user">
           <span class="flex flex-wrap gap-1">
-            @for (roleName of getRoleNames(user.roles); track roleName) {
+            @for (roleName of user.roleNames; track roleName) {
               <mat-chip>{{ roleName }}</mat-chip>
             }
           </span>
@@ -80,7 +80,7 @@
     </table>
   </div>
 
-  @if (users.value().length > 10) {
+  @if (users().length > 10) {
     <mat-paginator
       [pageSize]="defaultTablePageSize"
       [pageSizeOptions]="tablePageSizeOptions"

--- a/src/app/auth/features/user-manager-list/user-manager-list.component.html
+++ b/src/app/auth/features/user-manager-list/user-manager-list.component.html
@@ -1,0 +1,87 @@
+@if (usersAreLoading()) {
+  <p class="text-base">Loading users...</p>
+} @else {
+  @let columns = ['email', 'name', 'roles', 'status', 'registration_date'];
+  <div class="overflow-auto">
+    <table
+      mat-table
+      [dataSource]="source"
+      class="mat-elevation-z8"
+      matSort
+      #sort="matSort"
+    >
+      <ng-container matColumnDef="email">
+        <th mat-header-cell *matHeaderCellDef class="min-w-48" mat-sort-header>
+          Email
+        </th>
+        <td mat-cell *matCellDef="let user">
+          {{ user.email }}
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="name">
+        <th mat-header-cell *matHeaderCellDef class="min-w-40" mat-sort-header>
+          User Name
+        </th>
+        <td mat-cell *matCellDef="let user">
+          {{ user.name }}
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="roles">
+        <th mat-header-cell *matHeaderCellDef class="w-32" mat-sort-header>Roles</th>
+        <td mat-cell *matCellDef="let user">
+          {{ user.roles.join(', ') }}
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="status">
+        <th
+          mat-header-cell
+          *matHeaderCellDef
+          class="min-w-24 capitalize"
+          mat-sort-header
+        >
+          Status
+        </th>
+        <td mat-cell class="capitalize" *matCellDef="let user">
+          {{ user.status }}
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="registration_date">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Registration Date</th>
+        <td mat-cell *matCellDef="let user">
+          {{ user.registration_date | date }}
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="columns"></tr>
+      <tr
+        mat-row
+        *matRowDef="let row; columns: columns"
+        class="duration-200 hover:cursor-pointer hover:bg-black/[0.05] hover:transition"
+        (click)="openDetails(row)"
+      ></tr>
+
+      <tr class="mat-row" *matNoDataRow>
+        <td class="mat-cell p-4 text-base" colspan="5">
+          No users found. Try removing some filter conditions.
+        </td>
+      </tr>
+    </table>
+  </div>
+
+  @if (users.value().length > 10) {
+    <mat-paginator
+      [pageSize]="defaultTablePageSize"
+      [pageSizeOptions]="tablePageSizeOptions"
+      showFirstLastButtons
+      class="sticky left-0"
+      itemsPerPageLabel="Users per page"
+      aria-label="Select page of users"
+      #paginator
+    >
+    </mat-paginator>
+  }
+}

--- a/src/app/auth/features/user-manager-list/user-manager-list.component.html
+++ b/src/app/auth/features/user-manager-list/user-manager-list.component.html
@@ -94,7 +94,7 @@
     </table>
   </div>
 
-  @if (users.length > 10) {
+  @if (users().length > 10) {
     <mat-paginator
       [pageSize]="defaultTablePageSize"
       [pageSizeOptions]="tablePageSizeOptions"

--- a/src/app/auth/features/user-manager-list/user-manager-list.component.html
+++ b/src/app/auth/features/user-manager-list/user-manager-list.component.html
@@ -94,7 +94,7 @@
     </table>
   </div>
 
-  @if (users().length > 10) {
+  @if (users.length > 10) {
     <mat-paginator
       [pageSize]="defaultTablePageSize"
       [pageSizeOptions]="tablePageSizeOptions"

--- a/src/app/auth/features/user-manager-list/user-manager-list.component.html
+++ b/src/app/auth/features/user-manager-list/user-manager-list.component.html
@@ -24,7 +24,7 @@
           User Name
         </th>
         <td mat-cell *matCellDef="let user">
-          {{ user.name }}
+          {{ getDisplayName(user) }}
         </td>
       </ng-container>
 

--- a/src/app/auth/features/user-manager-list/user-manager-list.component.scss
+++ b/src/app/auth/features/user-manager-list/user-manager-list.component.scss
@@ -1,0 +1,10 @@
+@use '@angular/material' as mat;
+
+table {
+  @include mat.table-overrides(
+    (
+      header-headline-size: var(--mat-sys-title-medium-size),
+      row-item-label-text-size: var(--mat-sys-body-large-size),
+    )
+  );
+}

--- a/src/app/auth/features/user-manager-list/user-manager-list.component.scss
+++ b/src/app/auth/features/user-manager-list/user-manager-list.component.scss
@@ -8,3 +8,13 @@ table {
     )
   );
 }
+
+mat-chip {
+  @include mat.chips-overrides(
+    (
+      outline-color: var(--mat-sys-tertiary),
+      label-text-color: var(--mat-sys-tertiary),
+      with-trailing-icon-trailing-icon-color: var(--mat-sys-tertiary),
+    )
+  );
+}

--- a/src/app/auth/features/user-manager-list/user-manager-list.component.spec.ts
+++ b/src/app/auth/features/user-manager-list/user-manager-list.component.spec.ts
@@ -4,6 +4,8 @@
  * @license Apache-2.0
  */
 
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { UserService } from '@app/auth/services/user.service';
@@ -13,7 +15,7 @@ import { UserManagerListComponent } from './user-manager-list.component';
  * Mock UserService for testing
  */
 class MockUserService {
-  allUsers = {
+  users = {
     value: jest.fn(() => []),
     isLoading: jest.fn(() => false),
     error: jest.fn(() => null),
@@ -30,7 +32,11 @@ describe('UserManagerListComponent', () => {
 
     await TestBed.configureTestingModule({
       imports: [UserManagerListComponent, NoopAnimationsModule],
-      providers: [{ provide: UserService, useValue: mockUserService }],
+      providers: [
+        { provide: UserService, useValue: mockUserService },
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(UserManagerListComponent);
@@ -42,15 +48,15 @@ describe('UserManagerListComponent', () => {
   });
 
   it('should display loading message when users are loading', () => {
-    mockUserService.allUsers.isLoading.mockReturnValue(true);
+    mockUserService.users.isLoading.mockReturnValue(true);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
     expect(compiled.textContent).toContain('Loading users...');
   });
 
   it('should display "No users found" when no users exist', () => {
-    mockUserService.allUsers.isLoading.mockReturnValue(false);
-    mockUserService.allUsers.value.mockReturnValue([]);
+    mockUserService.users.isLoading.mockReturnValue(false);
+    mockUserService.users.value.mockReturnValue([]);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
     expect(compiled.textContent).toContain('No users found');
@@ -78,27 +84,35 @@ describe('UserManagerListComponent', () => {
         roles: ['data_steward'],
       },
       {
-        name: 'Jeffrey Spence Slate Sr.',
+        name: 'Jeffrey Spencer Slate Sr.',
         title: 'Prof.' as const,
         roles: ['data_steward'],
       },
+      {
+        name: 'Thomas H. Morgan Sr.',
+        title: 'Prof.' as const,
+        roles: [],
+      },
     ] as any;
 
-    mockUserService.allUsers.value.mockReturnValue(usersWithVariousTitles);
+    mockUserService.users.value.mockReturnValue(usersWithVariousTitles);
 
     const enhancedUsers = component.users();
 
     expect(enhancedUsers[0].displayName).toBe('Dr. John Doe');
     expect(enhancedUsers[0].sortName).toBe('Doe, John, Dr.');
+    expect(enhancedUsers[0].roleNames).toEqual(['Data Steward']);
 
     expect(enhancedUsers[1].displayName).toBe('Jane Smith');
     expect(enhancedUsers[1].sortName).toBe('Smith, Jane');
-
-    expect(enhancedUsers[2].displayName).toBe('Prof. Jeffrey Spence Slate Sr.');
-    expect(enhancedUsers[2].sortName).toBe('Slate, Jeffrey Spence Sr., Prof.');
-
-    expect(enhancedUsers[0].roleNames).toEqual(['Data Steward']);
     expect(enhancedUsers[1].roleNames).toEqual(['Data Steward']);
+
+    expect(enhancedUsers[2].displayName).toBe('Prof. Jeffrey Spencer Slate Sr.');
+    expect(enhancedUsers[2].sortName).toBe('Slate, Jeffrey Spencer Sr., Prof.');
     expect(enhancedUsers[2].roleNames).toEqual(['Data Steward']);
+
+    expect(enhancedUsers[3].displayName).toBe('Prof. Thomas H. Morgan Sr.');
+    expect(enhancedUsers[3].sortName).toBe('Morgan, Thomas H. Sr., Prof.');
+    expect(enhancedUsers[3].roleNames).toEqual([]);
   });
 });

--- a/src/app/auth/features/user-manager-list/user-manager-list.component.spec.ts
+++ b/src/app/auth/features/user-manager-list/user-manager-list.component.spec.ts
@@ -1,0 +1,68 @@
+/**
+ * User Manager List component tests
+ * @copyright The GHGA Authors
+ * @license Apache-2.0
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { UserService } from '@app/auth/services/user.service';
+import { UserManagerListComponent } from './user-manager-list.component';
+
+/**
+ * Mock UserService for testing
+ */
+class MockUserService {
+  allUsers = {
+    value: jest.fn(() => []),
+    isLoading: jest.fn(() => false),
+    error: jest.fn(() => null),
+  };
+}
+
+describe('UserManagerListComponent', () => {
+  let component: UserManagerListComponent;
+  let fixture: ComponentFixture<UserManagerListComponent>;
+  let mockUserService: MockUserService;
+
+  beforeEach(async () => {
+    mockUserService = new MockUserService();
+
+    await TestBed.configureTestingModule({
+      imports: [UserManagerListComponent, NoopAnimationsModule],
+      providers: [{ provide: UserService, useValue: mockUserService }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(UserManagerListComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display loading message when users are loading', () => {
+    mockUserService.allUsers.isLoading.mockReturnValue(true);
+    fixture.detectChanges();
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('Loading users...');
+  });
+
+  it('should display "No users found" when no users exist', () => {
+    mockUserService.allUsers.isLoading.mockReturnValue(false);
+    mockUserService.allUsers.value.mockReturnValue([]);
+    fixture.detectChanges();
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('No users found');
+  });
+
+  it('should initialize table data source', () => {
+    expect(component.source).toBeDefined();
+    expect(component.source.data).toEqual([]);
+  });
+
+  it('should have correct default pagination settings', () => {
+    expect(component.defaultTablePageSize).toBe(10);
+    expect(component.tablePageSizeOptions).toEqual([10, 25, 50, 100, 250, 500]);
+  });
+});

--- a/src/app/auth/features/user-manager-list/user-manager-list.component.spec.ts
+++ b/src/app/auth/features/user-manager-list/user-manager-list.component.spec.ts
@@ -10,7 +10,15 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { Router } from '@angular/router';
 import { UserService } from '@app/auth/services/user.service';
+import { ConfigService } from '@app/shared/services/config.service';
 import { UserManagerListComponent } from './user-manager-list.component';
+
+/**
+ * Mock ConfigService for testing
+ */
+class MockConfigService {
+  auth_url = 'https://test-auth.example.com';
+}
 
 /**
  * Mock UserService for testing
@@ -44,6 +52,7 @@ describe('UserManagerListComponent', () => {
       imports: [UserManagerListComponent, NoopAnimationsModule],
       providers: [
         { provide: UserService, useValue: mockUserService },
+        { provide: ConfigService, useClass: MockConfigService },
         { provide: Router, useValue: mockRouter },
         provideHttpClient(),
         provideHttpClientTesting(),
@@ -93,42 +102,54 @@ describe('UserManagerListComponent', () => {
         name: 'John Doe',
         title: 'Dr.' as const,
         roles: ['data_steward'],
+        displayName: 'Dr. John Doe',
+        roleNames: ['Data Steward'],
+        sortName: 'Doe, John, Dr.',
       },
       {
         name: 'Jane Smith',
         roles: ['data_steward'],
+        displayName: 'Jane Smith',
+        roleNames: ['Data Steward'],
+        sortName: 'Smith, Jane',
       },
       {
         name: 'Jeffrey Spencer Slate Sr.',
         title: 'Prof.' as const,
         roles: ['data_steward'],
+        displayName: 'Prof. Jeffrey Spencer Slate Sr.',
+        roleNames: ['Data Steward'],
+        sortName: 'Slate, Jeffrey Spencer Sr., Prof.',
       },
       {
         name: 'Thomas H. Morgan Sr.',
         title: 'Prof.' as const,
         roles: [],
+        displayName: 'Prof. Thomas H. Morgan Sr.',
+        roleNames: [],
+        sortName: 'Morgan, Thomas H. Sr., Prof.',
       },
     ] as any;
 
     mockUserService.users.value.mockReturnValue(usersWithVariousTitles);
 
-    const enhancedUsers = component.users();
+    const users = component.users();
 
-    expect(enhancedUsers[0].displayName).toBe('Dr. John Doe');
-    expect(enhancedUsers[0].sortName).toBe('Doe, John, Dr.');
-    expect(enhancedUsers[0].roleNames).toEqual(['Data Steward']);
+    expect(users[0].displayName).toBe('Dr. John Doe');
+    expect(users[0].sortName).toBe('Doe, John, Dr.');
+    expect(users[0].roleNames).toEqual(['Data Steward']);
 
-    expect(enhancedUsers[1].displayName).toBe('Jane Smith');
-    expect(enhancedUsers[1].sortName).toBe('Smith, Jane');
-    expect(enhancedUsers[1].roleNames).toEqual(['Data Steward']);
+    expect(users[1].displayName).toBe('Jane Smith');
+    expect(users[1].sortName).toBe('Smith, Jane');
+    expect(users[1].roleNames).toEqual(['Data Steward']);
 
-    expect(enhancedUsers[2].displayName).toBe('Prof. Jeffrey Spencer Slate Sr.');
-    expect(enhancedUsers[2].sortName).toBe('Slate, Jeffrey Spencer Sr., Prof.');
-    expect(enhancedUsers[2].roleNames).toEqual(['Data Steward']);
+    expect(users[2].displayName).toBe('Prof. Jeffrey Spencer Slate Sr.');
+    expect(users[2].sortName).toBe('Slate, Jeffrey Spencer Sr., Prof.');
+    expect(users[2].roleNames).toEqual(['Data Steward']);
 
-    expect(enhancedUsers[3].displayName).toBe('Prof. Thomas H. Morgan Sr.');
-    expect(enhancedUsers[3].sortName).toBe('Morgan, Thomas H. Sr., Prof.');
-    expect(enhancedUsers[3].roleNames).toEqual([]);
+    expect(users[3].displayName).toBe('Prof. Thomas H. Morgan Sr.');
+    expect(users[3].sortName).toBe('Morgan, Thomas H. Sr., Prof.');
+    expect(users[3].roleNames).toEqual([]);
   });
 
   it('should navigate to user details when viewDetails is called', () => {

--- a/src/app/auth/features/user-manager-list/user-manager-list.component.spec.ts
+++ b/src/app/auth/features/user-manager-list/user-manager-list.component.spec.ts
@@ -77,15 +77,28 @@ describe('UserManagerListComponent', () => {
         name: 'Jane Smith',
         roles: ['data_steward'],
       },
+      {
+        name: 'Jeffrey Spence Slate Sr.',
+        title: 'Prof.' as const,
+        roles: ['data_steward'],
+      },
     ] as any;
-    
+
     mockUserService.allUsers.value.mockReturnValue(usersWithVariousTitles);
-    
+
     const enhancedUsers = component.users();
-    
+
     expect(enhancedUsers[0].displayName).toBe('Dr. John Doe');
+    expect(enhancedUsers[0].sortName).toBe('Doe, John, Dr.');
+
     expect(enhancedUsers[1].displayName).toBe('Jane Smith');
+    expect(enhancedUsers[1].sortName).toBe('Smith, Jane');
+
+    expect(enhancedUsers[2].displayName).toBe('Prof. Jeffrey Spence Slate Sr.');
+    expect(enhancedUsers[2].sortName).toBe('Slate, Jeffrey Spence Sr., Prof.');
+
     expect(enhancedUsers[0].roleNames).toEqual(['Data Steward']);
     expect(enhancedUsers[1].roleNames).toEqual(['Data Steward']);
+    expect(enhancedUsers[2].roleNames).toEqual(['Data Steward']);
   });
 });

--- a/src/app/auth/features/user-manager-list/user-manager-list.component.spec.ts
+++ b/src/app/auth/features/user-manager-list/user-manager-list.component.spec.ts
@@ -67,16 +67,25 @@ describe('UserManagerListComponent', () => {
   });
 
   it('should format display name with title when available', () => {
-    const userWithTitle = {
-      name: 'John Doe',
-      title: 'Dr.' as const,
-    } as any;
-
-    const userWithoutTitle = {
-      name: 'Jane Smith',
-    } as any;
-
-    expect(component.getDisplayName(userWithTitle)).toBe('Dr. John Doe');
-    expect(component.getDisplayName(userWithoutTitle)).toBe('Jane Smith');
+    const usersWithVariousTitles = [
+      {
+        name: 'John Doe',
+        title: 'Dr.' as const,
+        roles: ['data_steward'],
+      },
+      {
+        name: 'Jane Smith',
+        roles: ['data_steward'],
+      },
+    ] as any;
+    
+    mockUserService.allUsers.value.mockReturnValue(usersWithVariousTitles);
+    
+    const enhancedUsers = component.users();
+    
+    expect(enhancedUsers[0].displayName).toBe('Dr. John Doe');
+    expect(enhancedUsers[1].displayName).toBe('Jane Smith');
+    expect(enhancedUsers[0].roleNames).toEqual(['Data Steward']);
+    expect(enhancedUsers[1].roleNames).toEqual(['Data Steward']);
   });
 });

--- a/src/app/auth/features/user-manager-list/user-manager-list.component.spec.ts
+++ b/src/app/auth/features/user-manager-list/user-manager-list.component.spec.ts
@@ -133,7 +133,7 @@ describe('UserManagerListComponent', () => {
 
     mockUserService.users.value.mockReturnValue(usersWithVariousTitles);
 
-    const users = component.users();
+    const users = component.users.value();
 
     expect(users[0].displayName).toBe('Dr. John Doe');
     expect(users[0].sortName).toBe('Doe, John, Dr.');

--- a/src/app/auth/features/user-manager-list/user-manager-list.component.spec.ts
+++ b/src/app/auth/features/user-manager-list/user-manager-list.component.spec.ts
@@ -8,6 +8,7 @@ import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { Router } from '@angular/router';
 import { UserService } from '@app/auth/services/user.service';
 import { UserManagerListComponent } from './user-manager-list.component';
 
@@ -22,18 +23,28 @@ class MockUserService {
   };
 }
 
+/**
+ * Mock Router for testing
+ */
+class MockRouter {
+  navigate = jest.fn();
+}
+
 describe('UserManagerListComponent', () => {
   let component: UserManagerListComponent;
   let fixture: ComponentFixture<UserManagerListComponent>;
   let mockUserService: MockUserService;
+  let mockRouter: MockRouter;
 
   beforeEach(async () => {
     mockUserService = new MockUserService();
+    mockRouter = new MockRouter();
 
     await TestBed.configureTestingModule({
       imports: [UserManagerListComponent, NoopAnimationsModule],
       providers: [
         { provide: UserService, useValue: mockUserService },
+        { provide: Router, useValue: mockRouter },
         provideHttpClient(),
         provideHttpClientTesting(),
       ],
@@ -60,6 +71,10 @@ describe('UserManagerListComponent', () => {
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
     expect(compiled.textContent).toContain('No users found');
+
+    // Check that the colspan is correct for 6 columns
+    const noDataCell = compiled.querySelector('[colspan="6"]');
+    expect(noDataCell).toBeTruthy();
   });
 
   it('should initialize table data source', () => {
@@ -114,5 +129,11 @@ describe('UserManagerListComponent', () => {
     expect(enhancedUsers[3].displayName).toBe('Prof. Thomas H. Morgan Sr.');
     expect(enhancedUsers[3].sortName).toBe('Morgan, Thomas H. Sr., Prof.');
     expect(enhancedUsers[3].roleNames).toEqual([]);
+  });
+
+  it('should navigate to user details when viewDetails is called', () => {
+    const mockUser = { id: '123', name: 'Test User' } as any;
+    component.viewDetails(mockUser);
+    expect(mockRouter.navigate).toHaveBeenCalledWith(['/user-manager', '123']);
   });
 });

--- a/src/app/auth/features/user-manager-list/user-manager-list.component.spec.ts
+++ b/src/app/auth/features/user-manager-list/user-manager-list.component.spec.ts
@@ -65,4 +65,18 @@ describe('UserManagerListComponent', () => {
     expect(component.defaultTablePageSize).toBe(10);
     expect(component.tablePageSizeOptions).toEqual([10, 25, 50, 100, 250, 500]);
   });
+
+  it('should format display name with title when available', () => {
+    const userWithTitle = {
+      name: 'John Doe',
+      title: 'Dr.' as const,
+    } as any;
+
+    const userWithoutTitle = {
+      name: 'Jane Smith',
+    } as any;
+
+    expect(component.getDisplayName(userWithTitle)).toBe('Dr. John Doe');
+    expect(component.getDisplayName(userWithoutTitle)).toBe('Jane Smith');
+  });
 });

--- a/src/app/auth/features/user-manager-list/user-manager-list.component.spec.ts
+++ b/src/app/auth/features/user-manager-list/user-manager-list.component.spec.ts
@@ -133,7 +133,7 @@ describe('UserManagerListComponent', () => {
 
     mockUserService.users.value.mockReturnValue(usersWithVariousTitles);
 
-    const users = component.users.value();
+    const users = component.users();
 
     expect(users[0].displayName).toBe('Dr. John Doe');
     expect(users[0].sortName).toBe('Doe, John, Dr.');

--- a/src/app/auth/features/user-manager-list/user-manager-list.component.ts
+++ b/src/app/auth/features/user-manager-list/user-manager-list.component.ts
@@ -1,0 +1,113 @@
+/**
+ * Component that lists all the users.
+ * @copyright The GHGA Authors
+ * @license Apache-2.0
+ */
+
+import { DatePipe as CommonDatePipe } from '@angular/common';
+import {
+  AfterViewInit,
+  Component,
+  effect,
+  inject,
+  QueryList,
+  ViewChild,
+  ViewChildren,
+} from '@angular/core';
+import { MatIconModule } from '@angular/material/icon';
+import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
+import { MatSort, MatSortModule } from '@angular/material/sort';
+import { MatTableDataSource, MatTableModule } from '@angular/material/table';
+import { RegisteredUser } from '@app/auth/models/user';
+import { UserService } from '@app/auth/services/user.service';
+import { DatePipe } from '@app/shared/pipes/date.pipe';
+
+/**
+ * User Manager List component.
+ *
+ * This component lists all the registered users
+ * in the User Manager. Filter conditions can be applied to the list.
+ */
+@Component({
+  selector: 'app-user-manager-list',
+  imports: [MatTableModule, MatSortModule, MatPaginatorModule, DatePipe, MatIconModule],
+  providers: [CommonDatePipe],
+  templateUrl: './user-manager-list.component.html',
+  styleUrl: './user-manager-list.component.scss',
+})
+export class UserManagerListComponent implements AfterViewInit {
+  #userService = inject(UserService);
+
+  #users = this.#userService.allUsers;
+  users = this.#userService.allUsers;
+  usersAreLoading = this.#users.isLoading;
+  usersError = this.#users.error;
+
+  source = new MatTableDataSource<RegisteredUser>([]);
+
+  defaultTablePageSize = 10;
+  tablePageSizeOptions = [10, 25, 50, 100, 250, 500];
+
+  #updateSourceEffect = effect(() => (this.source.data = this.users.value()));
+
+  #userSortingAccessor = (user: RegisteredUser, key: string) => {
+    switch (key) {
+      case 'email':
+        return user.email;
+      case 'name':
+        return user.name;
+      case 'roles':
+        return user.roles.join(', ');
+      case 'status':
+        return user.status;
+      case 'registration_date':
+        return user.registration_date;
+      default:
+        const value = user[key as keyof RegisteredUser];
+        if (typeof value === 'string' || typeof value === 'number') {
+          return value;
+        }
+        return '';
+    }
+  };
+
+  @ViewChildren(MatSort) matSorts!: QueryList<MatSort>;
+  @ViewChildren(MatPaginator) matPaginators!: QueryList<MatPaginator>;
+  @ViewChild('paginator') paginator!: MatPaginator;
+  @ViewChild('sort') sort!: MatSort;
+
+  /**
+   * Assign sorting
+   */
+  #addSorting() {
+    if (this.sort) this.source.sort = this.sort;
+  }
+
+  /**
+   * Assign pagination
+   */
+  #addPagination() {
+    if (this.paginator) this.source.paginator = this.paginator;
+  }
+
+  /**
+   * After the view has been initialised
+   * assign the sorting of the table to the data source
+   */
+  ngAfterViewInit() {
+    this.source.sortingDataAccessor = this.#userSortingAccessor;
+    this.#addSorting();
+    this.#addPagination();
+    this.matSorts.changes.subscribe(() => this.#addSorting());
+    this.matPaginators.changes.subscribe(() => this.#addPagination());
+  }
+
+  /**
+   * Open the details view for a user (placeholder for future implementation)
+   * @param row - the selected user row
+   */
+  openDetails(row: RegisteredUser): void {
+    // TODO: Implement user details dialog
+    console.log('User details clicked:', row);
+  }
+}

--- a/src/app/auth/features/user-manager-list/user-manager-list.component.ts
+++ b/src/app/auth/features/user-manager-list/user-manager-list.component.ts
@@ -15,11 +15,13 @@ import {
   ViewChild,
   ViewChildren,
 } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatIconModule } from '@angular/material/icon';
 import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
 import { MatSort, MatSortModule } from '@angular/material/sort';
 import { MatTableDataSource, MatTableModule } from '@angular/material/table';
+import { Router } from '@angular/router';
 import { RegisteredUser, RoleNames } from '@app/auth/models/user';
 import { UserStatusClassPipe } from '@app/auth/pipes/user-status-class.pipe';
 import { UserService } from '@app/auth/services/user.service';
@@ -46,6 +48,7 @@ interface EnhancedUser extends RegisteredUser {
     MatTableModule,
     MatSortModule,
     MatPaginatorModule,
+    MatButtonModule,
     DatePipe,
     MatIconModule,
     MatChipsModule,
@@ -57,6 +60,7 @@ interface EnhancedUser extends RegisteredUser {
 })
 export class UserManagerListComponent implements AfterViewInit {
   #userService = inject(UserService);
+  #router = inject(Router);
 
   #rawUsers = this.#userService.users;
 
@@ -180,11 +184,18 @@ export class UserManagerListComponent implements AfterViewInit {
   }
 
   /**
+   * Navigate to user details page
+   * @param user - the selected user
+   */
+  viewDetails(user: EnhancedUser): void {
+    this.#router.navigate(['/user-manager', user.id]);
+  }
+
+  /**
    * Open the details view for a user (placeholder for future implementation)
    * @param row - the selected user row
    */
   openDetails(row: EnhancedUser): void {
-    // TODO: Implement user details dialog
-    console.log('User details clicked:', row);
+    this.viewDetails(row);
   }
 }

--- a/src/app/auth/features/user-manager-list/user-manager-list.component.ts
+++ b/src/app/auth/features/user-manager-list/user-manager-list.component.ts
@@ -22,7 +22,7 @@ import { MatSort, MatSortModule } from '@angular/material/sort';
 import { MatTableDataSource, MatTableModule } from '@angular/material/table';
 import { Router } from '@angular/router';
 import { UserStatusClassPipe } from '@app/auth/pipes/user-status-class.pipe';
-import { EnhancedUser, UserService } from '@app/auth/services/user.service';
+import { DisplayUser, UserService } from '@app/auth/services/user.service';
 import { DatePipe } from '@app/shared/pipes/date.pipe';
 
 /**
@@ -51,19 +51,18 @@ export class UserManagerListComponent implements AfterViewInit {
   #userService = inject(UserService);
   #router = inject(Router);
 
-  #users = this.#userService.users;
-  users = this.#users.value;
-  usersAreLoading = this.#users.isLoading;
-  usersError = this.#users.error;
+  users = this.#userService.users;
+  usersAreLoading = this.users.isLoading;
+  usersError = this.users.error;
 
-  source = new MatTableDataSource<EnhancedUser>([]);
+  source = new MatTableDataSource<DisplayUser>([]);
 
   defaultTablePageSize = 10;
   tablePageSizeOptions = [10, 25, 50, 100, 250, 500];
 
-  #updateSourceEffect = effect(() => (this.source.data = this.users()));
+  #updateSourceEffect = effect(() => (this.source.data = this.users.value()));
 
-  #userSortingAccessor = (user: EnhancedUser, key: string) => {
+  #userSortingAccessor = (user: DisplayUser, key: string) => {
     switch (key) {
       case 'email':
         return user.email;
@@ -76,7 +75,7 @@ export class UserManagerListComponent implements AfterViewInit {
       case 'registration_date':
         return user.registration_date;
       default:
-        const value = user[key as keyof EnhancedUser];
+        const value = user[key as keyof DisplayUser];
         if (typeof value === 'string' || typeof value === 'number') {
           return value;
         }
@@ -119,7 +118,7 @@ export class UserManagerListComponent implements AfterViewInit {
    * Navigate to user details page
    * @param user - the selected user
    */
-  viewDetails(user: EnhancedUser): void {
+  viewDetails(user: DisplayUser): void {
     this.#router.navigate(['/user-manager', user.id]);
   }
 
@@ -127,7 +126,7 @@ export class UserManagerListComponent implements AfterViewInit {
    * Open the details view for a user (placeholder for future implementation)
    * @param row - the selected user row
    */
-  openDetails(row: EnhancedUser): void {
+  openDetails(row: DisplayUser): void {
     this.viewDetails(row);
   }
 }

--- a/src/app/auth/features/user-manager-list/user-manager-list.component.ts
+++ b/src/app/auth/features/user-manager-list/user-manager-list.component.ts
@@ -20,6 +20,7 @@ import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
 import { MatSort, MatSortModule } from '@angular/material/sort';
 import { MatTableDataSource, MatTableModule } from '@angular/material/table';
 import { RegisteredUser, RoleNames } from '@app/auth/models/user';
+import { UserStatusClassPipe } from '@app/auth/pipes/user-status-class.pipe';
 import { UserService } from '@app/auth/services/user.service';
 import { DatePipe } from '@app/shared/pipes/date.pipe';
 
@@ -38,6 +39,7 @@ import { DatePipe } from '@app/shared/pipes/date.pipe';
     DatePipe,
     MatIconModule,
     MatChipsModule,
+    UserStatusClassPipe,
   ],
   providers: [CommonDatePipe],
   templateUrl: './user-manager-list.component.html',

--- a/src/app/auth/features/user-manager-list/user-manager-list.component.ts
+++ b/src/app/auth/features/user-manager-list/user-manager-list.component.ts
@@ -51,16 +51,17 @@ export class UserManagerListComponent implements AfterViewInit {
   #userService = inject(UserService);
   #router = inject(Router);
 
-  users = this.#userService.users;
-  usersAreLoading = this.users.isLoading;
-  usersError = this.users.error;
+  #users = this.#userService.users;
+  users = this.#users.value;
+  usersAreLoading = this.#users.isLoading;
+  usersError = this.#users.error;
 
   source = new MatTableDataSource<DisplayUser>([]);
 
   defaultTablePageSize = 10;
   tablePageSizeOptions = [10, 25, 50, 100, 250, 500];
 
-  #updateSourceEffect = effect(() => (this.source.data = this.users.value()));
+  #updateSourceEffect = effect(() => (this.source.data = this.#users.value()));
 
   #userSortingAccessor = (user: DisplayUser, key: string) => {
     switch (key) {

--- a/src/app/auth/features/user-manager-list/user-manager-list.component.ts
+++ b/src/app/auth/features/user-manager-list/user-manager-list.component.ts
@@ -14,11 +14,12 @@ import {
   ViewChild,
   ViewChildren,
 } from '@angular/core';
+import { MatChipsModule } from '@angular/material/chips';
 import { MatIconModule } from '@angular/material/icon';
 import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
 import { MatSort, MatSortModule } from '@angular/material/sort';
 import { MatTableDataSource, MatTableModule } from '@angular/material/table';
-import { RegisteredUser } from '@app/auth/models/user';
+import { RegisteredUser, RoleNames } from '@app/auth/models/user';
 import { UserService } from '@app/auth/services/user.service';
 import { DatePipe } from '@app/shared/pipes/date.pipe';
 
@@ -30,7 +31,14 @@ import { DatePipe } from '@app/shared/pipes/date.pipe';
  */
 @Component({
   selector: 'app-user-manager-list',
-  imports: [MatTableModule, MatSortModule, MatPaginatorModule, DatePipe, MatIconModule],
+  imports: [
+    MatTableModule,
+    MatSortModule,
+    MatPaginatorModule,
+    DatePipe,
+    MatIconModule,
+    MatChipsModule,
+  ],
   providers: [CommonDatePipe],
   templateUrl: './user-manager-list.component.html',
   styleUrl: './user-manager-list.component.scss',
@@ -57,7 +65,7 @@ export class UserManagerListComponent implements AfterViewInit {
       case 'name':
         return user.name;
       case 'roles':
-        return user.roles.join(', ');
+        return this.getRoleNames(user.roles).join(', ');
       case 'status':
         return user.status;
       case 'registration_date':
@@ -100,6 +108,15 @@ export class UserManagerListComponent implements AfterViewInit {
     this.#addPagination();
     this.matSorts.changes.subscribe(() => this.#addSorting());
     this.matPaginators.changes.subscribe(() => this.#addPagination());
+  }
+
+  /**
+   * Get readable role names from role keys
+   * @param roles - array of role keys
+   * @returns array of readable role names
+   */
+  getRoleNames(roles: string[]): string[] {
+    return roles.map((role) => RoleNames[role as keyof typeof RoleNames] || role);
   }
 
   /**

--- a/src/app/auth/features/user-manager-list/user-manager-list.component.ts
+++ b/src/app/auth/features/user-manager-list/user-manager-list.component.ts
@@ -122,6 +122,15 @@ export class UserManagerListComponent implements AfterViewInit {
   }
 
   /**
+   * Get the display name with title if available
+   * @param user - the user object
+   * @returns the formatted name with title
+   */
+  getDisplayName(user: RegisteredUser): string {
+    return user.title ? `${user.title} ${user.name}` : user.name;
+  }
+
+  /**
    * Open the details view for a user (placeholder for future implementation)
    * @param row - the selected user row
    */

--- a/src/app/auth/features/user-manager-list/user-manager-list.component.ts
+++ b/src/app/auth/features/user-manager-list/user-manager-list.component.ts
@@ -58,14 +58,13 @@ interface EnhancedUser extends RegisteredUser {
 export class UserManagerListComponent implements AfterViewInit {
   #userService = inject(UserService);
 
-  #rawUsers = this.#userService.allUsers;
+  #rawUsers = this.#userService.users;
 
   /**
-   * Creates a sortable name format by moving the last non-abbreviated word to front
-   * and optionally adding title at the end
+   * Creates a sortable name
    * @param name - the user's full name
    * @param title - optional academic title
-   * @returns formatted sort name (e.g., "Doe, John" or "Slate, Jeffrey Spencer Sr., Prof.")
+   * @returns formatted sort name
    */
   #createSortName(name: string, title?: string): string {
     const words = name.trim().split(/\s+/);
@@ -75,7 +74,7 @@ export class UserManagerListComponent implements AfterViewInit {
       return title ? `${name}, ${title}` : name;
     }
 
-    // Find the last non-abbreviated word (not ending with a period and longer than 2 chars)
+    // Find the last non-abbreviated word
     let lastNameIndex = -1;
     for (let i = words.length - 1; i >= 0; i--) {
       const word = words[i];

--- a/src/app/auth/features/user-manager/user-manager.component.html
+++ b/src/app/auth/features/user-manager/user-manager.component.html
@@ -6,8 +6,5 @@
     <p class="text-sm text-gray-600">User filters will be implemented here</p>
   </div>
 
-  <!-- Placeholder for future user list component -->
-  <div class="rounded border border-gray-300 p-4">
-    <p class="text-sm text-gray-600">User list will be implemented here</p>
-  </div>
+  <app-user-manager-list></app-user-manager-list>
 </div>

--- a/src/app/auth/features/user-manager/user-manager.component.html
+++ b/src/app/auth/features/user-manager/user-manager.component.html
@@ -1,0 +1,13 @@
+<h1>User Management</h1>
+
+<div class="flex flex-col gap-4">
+  <!-- Placeholder for future filter component -->
+  <div class="rounded border border-gray-300 p-4">
+    <p class="text-sm text-gray-600">User filters will be implemented here</p>
+  </div>
+
+  <!-- Placeholder for future user list component -->
+  <div class="rounded border border-gray-300 p-4">
+    <p class="text-sm text-gray-600">User list will be implemented here</p>
+  </div>
+</div>

--- a/src/app/auth/features/user-manager/user-manager.component.spec.ts
+++ b/src/app/auth/features/user-manager/user-manager.component.spec.ts
@@ -12,7 +12,7 @@ import { UserManagerComponent } from './user-manager.component';
  * Mock AuthService for testing
  */
 class MockAuthService {
-  getUsers = jest.fn();
+  loadUsers = jest.fn();
 }
 
 describe('UserManagerComponent', () => {
@@ -38,7 +38,7 @@ describe('UserManagerComponent', () => {
 
   it('should call getUsers on initialization', () => {
     fixture.detectChanges();
-    expect(mockAuthService.getUsers).toHaveBeenCalled();
+    expect(mockAuthService.loadUsers).toHaveBeenCalled();
   });
 
   it('should render the title', () => {

--- a/src/app/auth/features/user-manager/user-manager.component.spec.ts
+++ b/src/app/auth/features/user-manager/user-manager.component.spec.ts
@@ -9,7 +9,15 @@ import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { UserService } from '@app/auth/services/user.service';
+import { ConfigService } from '@app/shared/services/config.service';
 import { UserManagerComponent } from './user-manager.component';
+
+/**
+ * Mock ConfigService for testing
+ */
+class MockConfigService {
+  auth_url = 'https://test-auth.example.com';
+}
 
 /**
  * Mock UserService for testing
@@ -32,7 +40,11 @@ describe('UserManagerComponent', () => {
 
     await TestBed.configureTestingModule({
       imports: [UserManagerComponent, NoopAnimationsModule],
-      providers: [provideHttpClient(), provideHttpClientTesting()],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: ConfigService, useClass: MockConfigService },
+      ],
     })
       .overrideComponent(UserManagerComponent, {
         set: {

--- a/src/app/auth/features/user-manager/user-manager.component.spec.ts
+++ b/src/app/auth/features/user-manager/user-manager.component.spec.ts
@@ -1,0 +1,56 @@
+/**
+ * User Manager component tests
+ * @copyright The GHGA Authors
+ * @license Apache-2.0
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { AuthService } from '@app/auth/services/auth.service';
+import { UserManagerComponent } from './user-manager.component';
+
+/**
+ * Mock AuthService for testing
+ */
+class MockAuthService {
+  getUsers = jest.fn();
+}
+
+describe('UserManagerComponent', () => {
+  let component: UserManagerComponent;
+  let fixture: ComponentFixture<UserManagerComponent>;
+  let mockAuthService: MockAuthService;
+
+  beforeEach(async () => {
+    mockAuthService = new MockAuthService();
+
+    await TestBed.configureTestingModule({
+      imports: [UserManagerComponent],
+      providers: [{ provide: AuthService, useValue: mockAuthService }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(UserManagerComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should call getUsers on initialization', () => {
+    fixture.detectChanges();
+    expect(mockAuthService.getUsers).toHaveBeenCalled();
+  });
+
+  it('should render the title', () => {
+    fixture.detectChanges();
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('h1')?.textContent).toContain('User Management');
+  });
+
+  it('should render placeholder content', () => {
+    fixture.detectChanges();
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('User filters will be implemented here');
+    expect(compiled.textContent).toContain('User list will be implemented here');
+  });
+});

--- a/src/app/auth/features/user-manager/user-manager.component.spec.ts
+++ b/src/app/auth/features/user-manager/user-manager.component.spec.ts
@@ -4,7 +4,10 @@
  * @license Apache-2.0
  */
 
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { UserService } from '@app/auth/services/user.service';
 import { UserManagerComponent } from './user-manager.component';
 
@@ -12,8 +15,10 @@ import { UserManagerComponent } from './user-manager.component';
  * Mock UserService for testing
  */
 class MockUserService {
-  allUsers = {
+  users = {
     value: jest.fn(() => []),
+    isLoading: jest.fn(() => false),
+    error: jest.fn(() => null),
   };
 }
 
@@ -26,7 +31,8 @@ describe('UserManagerComponent', () => {
     mockUserService = new MockUserService();
 
     await TestBed.configureTestingModule({
-      imports: [UserManagerComponent],
+      imports: [UserManagerComponent, NoopAnimationsModule],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
     })
       .overrideComponent(UserManagerComponent, {
         set: {

--- a/src/app/auth/features/user-manager/user-manager.component.spec.ts
+++ b/src/app/auth/features/user-manager/user-manager.component.spec.ts
@@ -5,28 +5,35 @@
  */
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { AuthService } from '@app/auth/services/auth.service';
+import { UserService } from '@app/auth/services/user.service';
 import { UserManagerComponent } from './user-manager.component';
 
 /**
- * Mock AuthService for testing
+ * Mock UserService for testing
  */
-class MockAuthService {
-  loadUsers = jest.fn();
+class MockUserService {
+  allUsers = {
+    value: jest.fn(() => []),
+  };
 }
 
 describe('UserManagerComponent', () => {
   let component: UserManagerComponent;
   let fixture: ComponentFixture<UserManagerComponent>;
-  let mockAuthService: MockAuthService;
+  let mockUserService: MockUserService;
 
   beforeEach(async () => {
-    mockAuthService = new MockAuthService();
+    mockUserService = new MockUserService();
 
     await TestBed.configureTestingModule({
       imports: [UserManagerComponent],
-      providers: [{ provide: AuthService, useValue: mockAuthService }],
-    }).compileComponents();
+    })
+      .overrideComponent(UserManagerComponent, {
+        set: {
+          providers: [{ provide: UserService, useValue: mockUserService }],
+        },
+      })
+      .compileComponents();
 
     fixture = TestBed.createComponent(UserManagerComponent);
     component = fixture.componentInstance;
@@ -36,9 +43,8 @@ describe('UserManagerComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should call getUsers on initialization', () => {
-    fixture.detectChanges();
-    expect(mockAuthService.loadUsers).toHaveBeenCalled();
+  it('should have userService injected', () => {
+    expect(component.userService).toBeDefined();
   });
 
   it('should render the title', () => {

--- a/src/app/auth/features/user-manager/user-manager.component.spec.ts
+++ b/src/app/auth/features/user-manager/user-manager.component.spec.ts
@@ -57,6 +57,6 @@ describe('UserManagerComponent', () => {
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
     expect(compiled.textContent).toContain('User filters will be implemented here');
-    expect(compiled.textContent).toContain('User list will be implemented here');
+    expect(compiled.querySelector('app-user-manager-list')).toBeTruthy();
   });
 });

--- a/src/app/auth/features/user-manager/user-manager.component.ts
+++ b/src/app/auth/features/user-manager/user-manager.component.ts
@@ -4,28 +4,21 @@
  * @license Apache-2.0
  */
 
-import { Component, inject, OnInit } from '@angular/core';
-import { AuthService } from '@app/auth/services/auth.service';
+import { Component, inject } from '@angular/core';
+import { UserService } from '@app/auth/services/user.service';
 
 /**
  * User Manager component.
  *
- * The User Manager allows data stewards to manage registered users,
- * view user user details, their IVAs and access grants and requests,
- * and delete or revoke access to the user or individual datasets.
+ * The User Manager allows data stewards to manage users,
+ * view user details, and perform administrative actions.
  */
 @Component({
   selector: 'app-user-manager',
   imports: [],
+  providers: [UserService],
   templateUrl: './user-manager.component.html',
 })
-export class UserManagerComponent implements OnInit {
-  #authService = inject(AuthService);
-
-  /**
-   * Load the users when the component is initialized
-   */
-  ngOnInit(): void {
-    this.#authService.loadUsers();
-  }
+export class UserManagerComponent {
+  userService = inject(UserService);
 }

--- a/src/app/auth/features/user-manager/user-manager.component.ts
+++ b/src/app/auth/features/user-manager/user-manager.component.ts
@@ -6,6 +6,7 @@
 
 import { Component, inject } from '@angular/core';
 import { UserService } from '@app/auth/services/user.service';
+import { UserManagerListComponent } from '../user-manager-list/user-manager-list.component';
 
 /**
  * User Manager component.
@@ -15,7 +16,7 @@ import { UserService } from '@app/auth/services/user.service';
  */
 @Component({
   selector: 'app-user-manager',
-  imports: [],
+  imports: [UserManagerListComponent],
   providers: [UserService],
   templateUrl: './user-manager.component.html',
 })

--- a/src/app/auth/features/user-manager/user-manager.component.ts
+++ b/src/app/auth/features/user-manager/user-manager.component.ts
@@ -1,0 +1,31 @@
+/**
+ * Component that hosts the User Manager feature.
+ * @copyright The GHGA Authors
+ * @license Apache-2.0
+ */
+
+import { Component, inject, OnInit } from '@angular/core';
+import { AuthService } from '@app/auth/services/auth.service';
+
+/**
+ * User Manager component.
+ *
+ * The User Manager allows data stewards to manage registered users,
+ * view user user details, their IVAs and access grants and requests,
+ * and delete or revoke access to the user or individual datasets.
+ */
+@Component({
+  selector: 'app-user-manager',
+  imports: [],
+  templateUrl: './user-manager.component.html',
+})
+export class UserManagerComponent implements OnInit {
+  #authService = inject(AuthService);
+
+  /**
+   * Load the users when the component is initialized
+   */
+  ngOnInit(): void {
+    this.#authService.getUsers();
+  }
+}

--- a/src/app/auth/features/user-manager/user-manager.component.ts
+++ b/src/app/auth/features/user-manager/user-manager.component.ts
@@ -26,6 +26,6 @@ export class UserManagerComponent implements OnInit {
    * Load the users when the component is initialized
    */
   ngOnInit(): void {
-    this.#authService.getUsers();
+    this.#authService.loadUsers();
   }
 }

--- a/src/app/auth/models/user.ts
+++ b/src/app/auth/models/user.ts
@@ -47,6 +47,21 @@ export interface UserRegisteredData extends UserBasicData {
 export type UserRole = keyof typeof RoleNames;
 
 /**
+ * All possible user states
+ */
+export type UserState = 'active' | 'inactive';
+
+/**
+ * Data of a fully registered user interface
+ */
+export interface RegisteredUser extends UserRegisteredData {
+  id: string;
+  roles: UserRole[];
+  status: UserState;
+  registration_date: string; // ISO date string
+}
+
+/**
  * User session interface
  *
  * Contains all data describing the user and the user session.
@@ -54,7 +69,7 @@ export type UserRole = keyof typeof RoleNames;
  * Note that this is different from the low-level oidcUser object,
  * which does not contain the user data from the backend.
  */
-export interface User extends UserRegisteredData {
+export interface UserSession extends UserRegisteredData {
   id?: string;
   full_name: string;
   state: LoginState;

--- a/src/app/auth/pipes/user-status-class.pipe.spec.ts
+++ b/src/app/auth/pipes/user-status-class.pipe.spec.ts
@@ -1,0 +1,27 @@
+/**
+ * User status class pipe tests
+ * @copyright The GHGA Authors
+ * @license Apache-2.0
+ */
+
+import { UserStatusClassPipe } from './user-status-class.pipe';
+
+describe('UserStatusClassPipe', () => {
+  let pipe: UserStatusClassPipe;
+
+  beforeEach(() => {
+    pipe = new UserStatusClassPipe();
+  });
+
+  it('should create an instance', () => {
+    expect(pipe).toBeTruthy();
+  });
+
+  it('should return text-success for active status', () => {
+    expect(pipe.transform('active')).toBe('text-success');
+  });
+
+  it('should return text-error for inactive status', () => {
+    expect(pipe.transform('inactive')).toBe('text-error');
+  });
+});

--- a/src/app/auth/pipes/user-status-class.pipe.ts
+++ b/src/app/auth/pipes/user-status-class.pipe.ts
@@ -1,0 +1,35 @@
+/**
+ * This pipe takes a user status and returns a specific class for styling
+ * @copyright The GHGA Authors
+ * @license Apache-2.0
+ */
+
+import { Pipe, PipeTransform } from '@angular/core';
+import { UserState } from '../models/user';
+
+/**
+ * Mapping of user status to CSS classes
+ */
+export const UserStatusClass: {
+  [K in UserState]: string;
+} = {
+  active: 'text-success',
+  inactive: 'text-error',
+};
+
+/**
+ * This pipe is used to provide status-specific classes for users.
+ */
+@Pipe({
+  name: 'UserStatusClassPipe',
+})
+export class UserStatusClassPipe implements PipeTransform {
+  /**
+   * This method will return a class based on the user status provided
+   * @param status The user status to process
+   * @returns The CSS class based on the user status
+   */
+  transform(status: UserState): string {
+    return UserStatusClass[status];
+  }
+}

--- a/src/app/auth/services/auth.service.ts
+++ b/src/app/auth/services/auth.service.ts
@@ -625,4 +625,14 @@ export class AuthService {
     }
     this.#router.navigate([path]);
   }
+
+  /**
+   * Get all users (stub method for data stewards)
+   * @returns Observable of User array (currently returns empty array as stub)
+   */
+  getUsers(): Observable<User[]> {
+    // TODO: Implement actual API call to fetch users
+    console.log('getUsers() called - stub implementation');
+    return of([]);
+  }
 }

--- a/src/app/auth/services/auth.service.ts
+++ b/src/app/auth/services/auth.service.ts
@@ -8,6 +8,7 @@ import {
   HttpClient,
   HttpHeaders,
   HttpParams,
+  httpResource,
   HttpResponse,
 } from '@angular/common/http';
 import { computed, inject, Injectable, signal } from '@angular/core';
@@ -30,7 +31,14 @@ import {
   of,
   timeout,
 } from 'rxjs';
-import { LoginState, RoleNames, User, UserBasicData, UserRole } from '../models/user';
+import {
+  LoginState,
+  RegisteredUser,
+  RoleNames,
+  UserBasicData,
+  UserRole,
+  UserSession,
+} from '../models/user';
 import { CsrfService } from './csrf.service';
 
 /**
@@ -46,7 +54,7 @@ export class AuthService {
   #router = inject(Router);
   #csrf = inject(CsrfService);
   #notify = inject(NotificationService);
-  #userSignal = signal<User | null | undefined>(undefined);
+  #userSignal = signal<UserSession | null | undefined>(undefined);
 
   #oidcUserManager: OidcUserManager;
 
@@ -63,7 +71,7 @@ export class AuthService {
    * Null means that the user is not logged in (state is 'Anonymous'), while
    * undefined means that the session has not yet been loaded (state 'Undetermined').
    */
-  user = computed<User | null | undefined>(() => this.#userSignal());
+  user = computed<UserSession | null | undefined>(() => this.#userSignal());
 
   /**
    * Check whether the session state is known as a signal
@@ -389,9 +397,9 @@ export class AuthService {
    * @param session - the session as a JSON-formatted string or null
    * @returns the parsed user or null if no session or undefined if error
    */
-  #parseUserFromSession(session: string): User | null | undefined {
+  #parseUserFromSession(session: string): UserSession | null | undefined {
     if (!session) return null;
-    let user: User | null;
+    let user: UserSession | null;
     try {
       user = JSON.parse(session || 'null');
       if (!user) return null;
@@ -445,7 +453,7 @@ export class AuthService {
           of([401, 403, 404].includes(error?.status) ? null : undefined),
         ),
       )
-      .subscribe((user: User | null | undefined) => {
+      .subscribe((user: UserSession | null | undefined) => {
         if (user) {
           console.debug('User session loaded:', user);
           userSignal.set(user);
@@ -626,13 +634,25 @@ export class AuthService {
     this.#router.navigate([path]);
   }
 
+  // signal to load all users' data
+  #loadUsers = signal<boolean>(false);
+
   /**
-   * Get all users (stub method for data stewards)
-   * @returns Observable of User array (currently returns empty array as stub)
+   * Load all users' data
    */
-  getUsers(): Observable<User[]> {
-    // TODO: Implement actual API call to fetch users
-    console.log('getUsers() called - stub implementation');
-    return of([]);
+  loadUsers(): void {
+    this.#loadUsers.set(true);
   }
+
+  /**
+   * Resource for loading all users.
+   * Note: We do the filtering currently only on the client side,
+   * but in principle we can also do some filtering on the sever.
+   */
+  allUsers = httpResource<RegisteredUser[]>(
+    () => (this.#loadUsers() ? this.#usersUrl : undefined),
+    {
+      defaultValue: [],
+    },
+  );
 }

--- a/src/app/auth/services/auth.service.ts
+++ b/src/app/auth/services/auth.service.ts
@@ -8,7 +8,6 @@ import {
   HttpClient,
   HttpHeaders,
   HttpParams,
-  httpResource,
   HttpResponse,
 } from '@angular/common/http';
 import { computed, inject, Injectable, signal } from '@angular/core';
@@ -33,7 +32,6 @@ import {
 } from 'rxjs';
 import {
   LoginState,
-  RegisteredUser,
   RoleNames,
   UserBasicData,
   UserRole,
@@ -633,26 +631,4 @@ export class AuthService {
     }
     this.#router.navigate([path]);
   }
-
-  // signal to load all users' data
-  #loadUsers = signal<boolean>(false);
-
-  /**
-   * Load all users' data
-   */
-  loadUsers(): void {
-    this.#loadUsers.set(true);
-  }
-
-  /**
-   * Resource for loading all users.
-   * Note: We do the filtering currently only on the client side,
-   * but in principle we can also do some filtering on the sever.
-   */
-  allUsers = httpResource<RegisteredUser[]>(
-    () => (this.#loadUsers() ? this.#usersUrl : undefined),
-    {
-      defaultValue: [],
-    },
-  );
 }

--- a/src/app/auth/services/user.service.spec.ts
+++ b/src/app/auth/services/user.service.spec.ts
@@ -4,6 +4,8 @@
  * @license Apache-2.0
  */
 
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { ConfigService } from '@app/shared/services/config.service';
 import { UserService } from './user.service';
@@ -20,7 +22,12 @@ describe('UserService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [UserService, { provide: ConfigService, useClass: MockConfigService }],
+      providers: [
+        UserService,
+        { provide: ConfigService, useClass: MockConfigService },
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
     });
     service = TestBed.inject(UserService);
   });
@@ -29,7 +36,7 @@ describe('UserService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should have allUsers resource with default empty array', () => {
-    expect(service.allUsers.value()).toEqual([]);
+  it('should have users resource with default empty array', () => {
+    expect(service.users.value()).toEqual([]);
   });
 });

--- a/src/app/auth/services/user.service.spec.ts
+++ b/src/app/auth/services/user.service.spec.ts
@@ -1,0 +1,35 @@
+/**
+ * User service tests
+ * @copyright The GHGA Authors
+ * @license Apache-2.0
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { ConfigService } from '@app/shared/services/config.service';
+import { UserService } from './user.service';
+
+/**
+ * Mock ConfigService for testing
+ */
+class MockConfigService {
+  authUrl = 'http://mock.dev/auth';
+}
+
+describe('UserService', () => {
+  let service: UserService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [UserService, { provide: ConfigService, useClass: MockConfigService }],
+    });
+    service = TestBed.inject(UserService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should have allUsers resource with default empty array', () => {
+    expect(service.allUsers.value()).toEqual([]);
+  });
+});

--- a/src/app/auth/services/user.service.ts
+++ b/src/app/auth/services/user.service.ts
@@ -10,9 +10,9 @@ import { ConfigService } from '@app/shared/services/config.service';
 import { RegisteredUser, RoleNames } from '../models/user';
 
 /**
- * Enhanced user interface with computed display properties for template use
+ * Display user interface with additional properties for template use
  */
-export interface EnhancedUser extends RegisteredUser {
+export interface DisplayUser extends RegisteredUser {
   displayName: string;
   roleNames: string[];
   sortName: string;
@@ -76,11 +76,11 @@ export class UserService {
   }
 
   /**
-   * Enhances a raw user with computed properties
+   * Creates a display user with computed properties for UI consumption
    * @param user - raw user from backend
-   * @returns enhanced user with display properties
+   * @returns display user with additional display properties
    */
-  #enhanceUser(user: RegisteredUser): EnhancedUser {
+  #createDisplayUser(user: RegisteredUser): DisplayUser {
     return {
       ...user,
       displayName: user.title ? `${user.title} ${user.name}` : user.name,
@@ -92,15 +92,15 @@ export class UserService {
   }
 
   /**
-   * Resource for loading all users with enhanced properties.
+   * Resource for loading all users with display properties.
    * Automatically loads when the service is instantiated and transforms
    * raw user data to include computed display properties.
    * Note: We do the filtering currently only on the client side,
    * but in principle we can also do some filtering on the server.
    */
-  users = httpResource<EnhancedUser[]>(() => ({ url: this.#usersUrl }), {
+  users = httpResource<DisplayUser[]>(() => ({ url: this.#usersUrl }), {
     parse: (rawUsers: unknown) =>
-      (rawUsers as RegisteredUser[]).map((user) => this.#enhanceUser(user)),
+      (rawUsers as RegisteredUser[]).map((user) => this.#createDisplayUser(user)),
     defaultValue: [],
   });
 }

--- a/src/app/auth/services/user.service.ts
+++ b/src/app/auth/services/user.service.ts
@@ -26,7 +26,7 @@ export class UserService {
    * Note: We do the filtering currently only on the client side,
    * but in principle we can also do some filtering on the server.
    */
-  allUsers = httpResource<RegisteredUser[]>(() => this.#usersUrl, {
+  users = httpResource<RegisteredUser[]>(() => this.#usersUrl, {
     defaultValue: [],
   });
 }

--- a/src/app/auth/services/user.service.ts
+++ b/src/app/auth/services/user.service.ts
@@ -1,0 +1,32 @@
+/**
+ * User management service
+ * @copyright The GHGA Authors
+ * @license Apache-2.0
+ */
+
+import { httpResource } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { ConfigService } from '@app/shared/services/config.service';
+import { RegisteredUser } from '../models/user';
+
+/**
+ * Service for managing users in the GHGA Data Portal.
+ * This service handles fetching and managing user data for data stewards.
+ */
+@Injectable()
+export class UserService {
+  #config = inject(ConfigService);
+
+  #authUrl = this.#config.authUrl;
+  #usersUrl = `${this.#authUrl}/users`;
+
+  /**
+   * Resource for loading all users.
+   * Automatically loads when the service is instantiated.
+   * Note: We do the filtering currently only on the client side,
+   * but in principle we can also do some filtering on the server.
+   */
+  allUsers = httpResource<RegisteredUser[]>(() => this.#usersUrl, {
+    defaultValue: [],
+  });
+}

--- a/src/app/auth/services/user.service.ts
+++ b/src/app/auth/services/user.service.ts
@@ -7,7 +7,16 @@
 import { httpResource } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { ConfigService } from '@app/shared/services/config.service';
-import { RegisteredUser } from '../models/user';
+import { RegisteredUser, RoleNames } from '../models/user';
+
+/**
+ * Enhanced user interface with computed display properties for template use
+ */
+export interface EnhancedUser extends RegisteredUser {
+  displayName: string;
+  roleNames: string[];
+  sortName: string;
+}
 
 /**
  * Service for managing users in the GHGA Data Portal.
@@ -21,12 +30,77 @@ export class UserService {
   #usersUrl = `${this.#authUrl}/users`;
 
   /**
-   * Resource for loading all users.
-   * Automatically loads when the service is instantiated.
+   * Creates a sortable name format by moving the last non-abbreviated word to front
+   * and optionally adding title at the end
+   * @param name - the user's full name
+   * @param title - optional academic title
+   * @returns formatted sort name (e.g., "Doe, John" or "Slate, Jeffrey Spencer Sr., Prof.")
+   */
+  #createSortName(name: string, title?: string): string {
+    const words = name.trim().split(/\s+/);
+
+    if (words.length === 1) {
+      // Single name, just return as is with optional title
+      return title ? `${name}, ${title}` : name;
+    }
+
+    // Find the last non-abbreviated word (not ending with a period and longer than 2 chars)
+    let lastNameIndex = -1;
+    for (let i = words.length - 1; i >= 0; i--) {
+      const word = words[i];
+      if (!word.endsWith('.') && word.length > 2) {
+        lastNameIndex = i;
+        break;
+      }
+    }
+
+    // If no suitable last name found, use the last word
+    if (lastNameIndex === -1) {
+      lastNameIndex = words.length - 1;
+    }
+
+    const lastName = words[lastNameIndex];
+    const beforeLastName = words.slice(0, lastNameIndex);
+    const afterLastName = words.slice(lastNameIndex + 1);
+
+    // Construct the sort name: "LastName, FirstName Middle Suffix"
+    const restOfName = [...beforeLastName, ...afterLastName].join(' ');
+    let sortName = restOfName ? `${lastName}, ${restOfName}` : lastName;
+
+    // Add title at the end if present
+    if (title) {
+      sortName += `, ${title}`;
+    }
+
+    return sortName;
+  }
+
+  /**
+   * Enhances a raw user with computed properties
+   * @param user - raw user from backend
+   * @returns enhanced user with display properties
+   */
+  #enhanceUser(user: RegisteredUser): EnhancedUser {
+    return {
+      ...user,
+      displayName: user.title ? `${user.title} ${user.name}` : user.name,
+      roleNames: user.roles.map(
+        (role) => RoleNames[role as keyof typeof RoleNames] || role,
+      ),
+      sortName: this.#createSortName(user.name, user.title || undefined),
+    };
+  }
+
+  /**
+   * Resource for loading all users with enhanced properties.
+   * Automatically loads when the service is instantiated and transforms
+   * raw user data to include computed display properties.
    * Note: We do the filtering currently only on the client side,
    * but in principle we can also do some filtering on the server.
    */
-  users = httpResource<RegisteredUser[]>(() => this.#usersUrl, {
+  users = httpResource<EnhancedUser[]>(() => ({ url: this.#usersUrl }), {
+    parse: (rawUsers: unknown) =>
+      (rawUsers as RegisteredUser[]).map((user) => this.#enhanceUser(user)),
     defaultValue: [],
   });
 }

--- a/src/app/portal/features/account-button/account-button.component.spec.ts
+++ b/src/app/portal/features/account-button/account-button.component.spec.ts
@@ -9,7 +9,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { screen } from '@testing-library/angular';
 
-import { RoleNames, User } from '@app/auth/models/user';
+import { RoleNames, UserSession } from '@app/auth/models/user';
 import { AuthService } from '@app/auth/services/auth.service';
 
 import { AccountButtonComponent } from './account-button.component';
@@ -23,7 +23,7 @@ export const USER = {
   full_name: 'Dr. John Doe',
   roles: ['data_steward'],
   state: 'Authenticated',
-} as User;
+} as UserSession;
 
 /**
  * Mock the auth service as needed for the account button

--- a/src/app/portal/features/admin-menu/admin-menu.component.html
+++ b/src/app/portal/features/admin-menu/admin-menu.component.html
@@ -10,6 +10,14 @@
   </a>
   <mat-menu #menu="matMenu">
     <a
+      [id]="isUserManagerRoute() ? 'activePage' : ''"
+      mat-menu-item
+      routerLink="/user-manager"
+      class="mx-1"
+      data-umami-event="Admin Menu User Manager Clicked"
+      ><mat-icon>people</mat-icon> User Manager</a
+    >
+    <a
       [id]="isIvaManagerRoute() ? 'activePage' : ''"
       mat-menu-item
       routerLink="/iva-manager"

--- a/src/app/portal/features/admin-menu/admin-menu.component.ts
+++ b/src/app/portal/features/admin-menu/admin-menu.component.ts
@@ -26,11 +26,15 @@ export class AdminMenuComponent {
   #baseRoute = inject(BaseRouteService);
   #route = this.#baseRoute.route;
   isDataSteward = computed(() => this.#auth.roles().includes('data_steward'));
+  isUserManagerRoute = computed<boolean>(() => this.#route() === 'user-manager');
   isIvaManagerRoute = computed<boolean>(() => this.#route() === 'iva-manager');
   isAccessRequestsManagerRoute = computed<boolean>(
     () => this.#route() === 'access-request-manager',
   );
   isAdminRoute = computed<boolean>(
-    () => this.isIvaManagerRoute() || this.isAccessRequestsManagerRoute(),
+    () =>
+      this.isUserManagerRoute() ||
+      this.isIvaManagerRoute() ||
+      this.isAccessRequestsManagerRoute(),
   );
 }

--- a/src/mocks/auth.ts
+++ b/src/mocks/auth.ts
@@ -4,7 +4,7 @@
  * @license Apache-2.0
  */
 
-import { LoginState, User } from '@app/auth/models/user';
+import { LoginState, UserSession } from '@app/auth/models/user';
 import { http, HttpResponse } from 'msw';
 
 /**
@@ -39,7 +39,7 @@ const USER_STATE_KEY = 'user.state';
 /**
  * The dummy user object for MSW
  */
-export const user: User = {
+export const user: UserSession = {
   ext_id: 'aacaffeecaffeecaffeecaffeecaffeecaffeeaad@lifescience-ri.eu',
   name: 'John Doe',
   title: 'Dr.',

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -4,6 +4,7 @@
  * @license Apache-2.0
  */
 
+import { RegisteredUser } from '@app/auth/models/user';
 import { DatasetDetailsRaw } from '@app/metadata/models/dataset-details';
 import { DatasetInformation } from '@app/metadata/models/dataset-information';
 import { DatasetSummary } from '@app/metadata/models/dataset-summary';
@@ -13,6 +14,73 @@ import { BaseStorageLabels } from '@app/metadata/models/well-known-values';
 import { IvaState, IvaType, UserWithIva } from '@app/verification-addresses/models/iva';
 import { DatasetWithExpiration } from '@app/work-packages/models/dataset';
 import { WorkPackageResponse } from '@app/work-packages/models/work-package';
+
+/**
+ * Users
+ */
+
+export const users: RegisteredUser[] = [
+  {
+    id: 'doe@test.dev',
+    ext_id: 'aacaffeecaffeecaffeecaffeecaffeecaffeeaad@lifescience-ri.eu',
+    name: 'John Doe',
+    title: 'Dr.',
+    email: 'doe@home.org',
+    roles: ['data_steward'],
+    status: 'active',
+    registration_date: '2022-06-01T00:00:00',
+  },
+  {
+    id: 'roe@test.dev',
+    ext_id: 'aacaffeecaffeecaffeecaffeecaffeecaffeeaae@lifescience-ri.eu',
+    name: 'Jane Roe',
+    title: 'Prof.',
+    email: 'roe@home.org',
+    roles: [],
+    status: 'active',
+    registration_date: '2023-01-01T00:00:00',
+  },
+  {
+    id: 'fred.flintstone@test.dev',
+    ext_id: 'caffeecaffeecaffeecaffeecaffeecaffeeaafaa@lifescience-ri.eu',
+    name: 'Fred Flintstone',
+    title: null,
+    email: 'fred@flintstones.org',
+    roles: [],
+    status: 'active',
+    registration_date: '2023-08-15T00:00:00',
+  },
+  {
+    id: 'wilma.flintstone@test.dev',
+    ext_id: 'caffeecaffeecaffeecaffeecaffeecaffeeabaaa@lifescience-ri.eu',
+    name: 'Wilma Flintstone',
+    title: null,
+    email: 'wilma@flintstones.org',
+    roles: [],
+    status: 'active',
+    registration_date: '2023-08-15T00:00:00',
+  },
+  {
+    id: 'barney.gumble@test.dev',
+    ext_id: 'caffeecaffeecaffeecaffeecaffeecaffeeacdaa@lifescience-ri.eu',
+    name: 'Barney Gumble',
+    title: null,
+    email: 'barnie@flintstones.org',
+    roles: [],
+    status: 'inactive',
+    registration_date: '2024-08-15T00:00:00',
+  },
+  {
+    id: 'oscar.flintstone@test.dev',
+    ext_id: 'caffeecaffeecaffeecaffeecaffeecaffeeadeaa@lifescience-ri.eu',
+    name: 'Jeffrey Spencer Slate',
+    title: null,
+    email: 'jeff@flintstones.org',
+    roles: ['data_steward'],
+    status: 'inactive',
+    registration_date: '2024-09-01T00:00:00',
+  },
+];
 
 /**
  * IVAs

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -73,8 +73,8 @@ export const users: RegisteredUser[] = [
   {
     id: 'oscar.flintstone@test.dev',
     ext_id: 'caffeecaffeecaffeecaffeecaffeecaffeeadeaa@lifescience-ri.eu',
-    name: 'Jeffrey Spencer Slate',
-    title: null,
+    name: 'Jeffrey Spencer Slate Sr.',
+    title: 'Prof.',
     email: 'jeff@flintstones.org',
     roles: ['data_steward'],
     status: 'inactive',

--- a/src/mocks/responses.ts
+++ b/src/mocks/responses.ts
@@ -19,6 +19,7 @@ import {
   metadataGlobalSummary,
   searchResults,
   storageLabels,
+  users,
   workPackageResponse,
 } from './data';
 
@@ -39,6 +40,8 @@ export const responses: { [endpoint: string]: ResponseValue } = {
 
   // User Data
   'GET /api/auth/users/doe@test.dev': user,
+
+  'GET /api/auth/users': users,
 
   // User IVAs
   'GET /api/auth/users/doe@test.dev/ivas': allIvasOfDoe,


### PR DESCRIPTION
This PR implements the main list view for the user management page.

It already includes a stub for the detail page and the navigation between the two.

The corresponding view transition will be implemented in a separate PR since it turned out to be not so easy as anticipated.

The filter section will also be implemented in a separate PR.