### PR TITLE
Allow denying access requests without an IVA

### DIFF
--- a/src/app/access-requests/features/access-request-manager-detail/access-request-manager-detail.component.html
+++ b/src/app/access-requests/features/access-request-manager-detail/access-request-manager-detail.component.html
@@ -172,7 +172,10 @@
               <p>Loading verification addresses...</p>
             } @else if (ivasError() || !ivas().length) {
               <p>
-                No corresponding verification addresses found, cannot process request.
+                No corresponding verification addresses found.
+                @if (ar.status === 'pending') {
+                  The request can only be allowed when there is a corresponding IVA.
+                }
               </p>
             } @else if (!changeable()) {
               @let iva = associatedIva();
@@ -251,7 +254,7 @@
     </div>
 
     <div class="mt-8 flex">
-      @if (ivasAreLoading() || ivasError() || !ivas().length || !changeable()) {
+      @if (ivasAreLoading() || !changeable()) {
         <button
           mat-stroked-button
           (click)="goBack()"
@@ -281,11 +284,7 @@
               data-umami-event="Access Request Manager Deny Clicked"
               [disabled]="ar.status === 'denied'"
             >
-              @if (ar.status === 'allowed') {
-                Revoke access
-              } @else {
-                Deny
-              }
+              Deny
             </button>
           </div>
           <div class="w-full sm:w-auto">
@@ -294,17 +293,9 @@
               class="success w-full sm:w-auto"
               (click)="saveBeforeStatusChange('allow')"
               data-umami-event="Access Request Manager Allow Clicked"
-              [disabled]="
-                ar.status === 'allowed' &&
-                (!selectedIvaIdRadioButton() ||
-                  ar.iva_id === selectedIvaIdRadioButton())
-              "
+              [disabled]="ar.status === 'allowed' || ivasError() || !ivas().length"
             >
-              @if (ar.status === 'allowed') {
-                Change address
-              } @else {
-                Allow
-              }
+              Allow
             </button>
           </div>
         </div>

--- a/src/app/shared/features/pending-edits.guard.ts
+++ b/src/app/shared/features/pending-edits.guard.ts
@@ -22,7 +22,7 @@ export interface HasPendingEdits {
 /**
  * Generic guard to prevent navigation away from components with unsaved changes.
  * Components must implement the HasPendingEdits interface.
- * @param component
+ * @param component the component to check for pending edits
  * @returns a guard result which is or can be resolved to a boolean
  */
 export const pendingEditsGuard: CanDeactivateFn<HasPendingEdits> = (component) => {


### PR DESCRIPTION
This PR fixes the problem that access requests cannot be denied, if the user doesn't have any IVA.

It also removes some code in the tempalte that assumed allowed/denied requests can still be processed, which is no longer the case, and that changing the IVA only happens on approval which is no longer the case either.