### PR TITLE
Improve local cache updates

### DIFF
--- a/src/app/auth/services/user.service.ts
+++ b/src/app/auth/services/user.service.ts
@@ -167,6 +167,7 @@ export class UserService {
    * Signal that gets all users filtered by the current filter
    */
   usersFiltered = computed(() => {
+    if (this.users.error()) return [];
     let users = this.users.value();
     const filter = this.#usersFilter();
     filter
@@ -225,15 +226,22 @@ export class UserService {
    * @param changes - the changes to the user which may be partial
    */
   #updateUserLocally(id: string, changes: any): void {
-    const oldUser = this.users.value().find((user) => user.id === id);
-    if (!oldUser) return;
-
-    const newUser = { ...oldUser, ...changes };
-
-    const update = (users: DisplayUser[]) =>
-      users.map((user) => (user.id === id ? newUser : user));
-
-    this.users.value.set(update(this.users.value()));
+    if (!this.user.error()) {
+      const oldUser = this.user.value();
+      if (oldUser && oldUser.id === id) {
+        const newUser = { ...oldUser, ...changes };
+        this.user.value.set(this.#createDisplayUser(newUser));
+      }
+    }
+    if (!this.users.error()) {
+      const oldUser = this.users.value().find((user) => user.id === id);
+      if (oldUser) {
+        const newUser = { ...oldUser, ...changes };
+        const update = (users: DisplayUser[]) =>
+          users.map((user) => (user.id === id ? newUser : user));
+        this.users.value.set(update(this.users.value()));
+      }
+    }
   }
 
   /**
@@ -255,15 +263,14 @@ export class UserService {
    * @param id - the ID of the user to remove
    */
   #removeUserLocally(id: string): void {
+    if (this.users.error()) return;
     const oldUser = this.users.value().find((user) => user.id === id);
-    if (!oldUser) return;
-
-    const newUser = { ...oldUser };
-
-    const update = (users: DisplayUser[]) =>
-      users.map((user) => (user.id === id ? newUser : user));
-
-    this.users.value.set(update(this.users.value()));
+    if (oldUser) {
+      const newUser = { ...oldUser };
+      const update = (users: DisplayUser[]) =>
+        users.map((user) => (user.id === id ? newUser : user));
+      this.users.value.set(update(this.users.value()));
+    }
   }
 
   /**

--- a/src/app/verification-addresses/services/iva.service.ts
+++ b/src/app/verification-addresses/services/iva.service.ts
@@ -125,6 +125,7 @@ export class IvaService {
    * Signal that gets all IVAs filtered by the current filter
    */
   allIvasFiltered = computed(() => {
+    if (this.allIvas.error()) return [];
     let ivas = this.allIvas.value();
     const filter = this.#allIvasFilter();
     if (ivas.length && filter) {
@@ -175,15 +176,19 @@ export class IvaService {
       state: IvaState.Unverified,
       changed: new Date().toISOString(),
     };
-    this.userIvas.value.set([...this.userIvas.value(), iva]);
-    const user = this.#auth.user();
-    const userWithIva: UserWithIva = {
-      ...iva,
-      user_id: userId ?? user?.id ?? '',
-      user_name: user?.name ?? '',
-      user_email: user?.email ?? '',
-    };
-    this.allIvas.value.set([...this.allIvas.value(), userWithIva]);
+    if (!this.userIvas.error()) {
+      this.userIvas.value.set([...this.userIvas.value(), iva]);
+    }
+    if (!this.allIvas.error()) {
+      const user = this.#auth.user();
+      const userWithIva: UserWithIva = {
+        ...iva,
+        user_id: userId ?? user?.id ?? '',
+        user_name: user?.name ?? '',
+        user_email: user?.email ?? '',
+      };
+      this.allIvas.value.set([...this.allIvas.value(), userWithIva]);
+    }
   }
 
   /**
@@ -225,9 +230,12 @@ export class IvaService {
   #deleteIvaLocally(ivaId: string): void {
     const update = <T extends { id: string }>(ivas: T[]): T[] =>
       ivas.filter((iva) => iva.id !== ivaId);
-
-    this.userIvas.value.set(update(this.userIvas.value()));
-    this.allIvas.value.set(update(this.allIvas.value()));
+    if (!this.userIvas.error()) {
+      this.userIvas.value.set(update(this.userIvas.value()));
+    }
+    if (!this.allIvas.error()) {
+      this.allIvas.value.set(update(this.allIvas.value()));
+    }
   }
 
   /**
@@ -261,9 +269,12 @@ export class IvaService {
   #updateIvaStateLocally(ivaId: string, state: IvaState): void {
     const update = <T extends { id: string }>(ivas: T[]): T[] =>
       ivas.map((iva) => (iva.id === ivaId ? { ...iva, state } : iva));
-
-    this.userIvas.value.set(update(this.userIvas.value()));
-    this.allIvas.value.set(update(this.allIvas.value()));
+    if (!this.userIvas.error()) {
+      this.userIvas.value.set(update(this.userIvas.value()));
+    }
+    if (!this.allIvas.error()) {
+      this.allIvas.value.set(update(this.allIvas.value()));
+    }
   }
 
   /**


### PR DESCRIPTION
This PR improves the methods that update resources locally where data is changed in the backend, so that no reload is required.

We now only update resources that aren't in an error state, because otherwise the update will raise an error. We now also update the new resources that fetch single objects instead of an array of objects.