### PR TITLE
Add link to user and filter by email (GSI-1745)

### DIFF
--- a/src/app/access-requests/features/access-grant-details/access-grant-manager-details.component.html
+++ b/src/app/access-requests/features/access-grant-details/access-grant-manager-details.component.html
@@ -26,7 +26,11 @@
           <span class="font-bold">Dataset:</span>
           <span class="w-24 capitalize"
             >&nbsp;
-            <a href="/dataset/{{ ag?.dataset_id }}">{{ ag?.dataset_id }}</a>
+            <a
+              routerLink="/dataset/{{ ag?.dataset_id }}"
+              data-umami-event="Access Grant Details Dataset Clicked"
+              >{{ ag?.dataset_id }}</a
+            >
           </span>
         </div>
       </div>

--- a/src/app/access-requests/features/access-request-manager-detail/access-request-manager-detail.component.ts
+++ b/src/app/access-requests/features/access-request-manager-detail/access-request-manager-detail.component.ts
@@ -263,7 +263,6 @@ export class AccessRequestManagerDetailComponent implements OnInit, HasPendingEd
    */
   edited(event: [keyof AccessRequest, boolean]): void {
     const [name, edited] = event;
-    console.log('EDITED', name, edited);
     if (edited) this.#pendingEdits.add(name);
     else this.#pendingEdits.delete(name);
   }

--- a/src/app/auth/features/user-manager-detail/user-manager-detail.component.ts
+++ b/src/app/auth/features/user-manager-detail/user-manager-detail.component.ts
@@ -78,7 +78,6 @@ export class UserManagerDetailComponent implements OnInit {
   error = computed<undefined | 'not found' | 'other'>(() => {
     if (this.#cachedUser()) return undefined;
     const error = this.#user.error();
-    console.log(error);
     if (!error) return undefined;
 
     return (error as HttpErrorResponse)?.status === 404 ? 'not found' : 'other';

--- a/src/app/verification-addresses/features/iva-manager-filter/iva-manager-filter.component.html
+++ b/src/app/verification-addresses/features/iva-manager-filter/iva-manager-filter.component.html
@@ -22,9 +22,9 @@
         <div class="flex grow flex-col gap-2">
           <div class="flex items-baseline gap-2">
             <mat-form-field class="grow">
-              <mat-label>Name of user</mat-label>
+              <mat-label>Name or email of user</mat-label>
               <input matInput [(ngModel)]="name" />
-              <mat-hint>You can also filter with partial names</mat-hint>
+              <mat-hint>You can also filter with partial names or emails</mat-hint>
             </mat-form-field>
             <button
               mat-icon-button

--- a/src/app/verification-addresses/features/iva-manager-list/iva-manager-list.component.html
+++ b/src/app/verification-addresses/features/iva-manager-list/iva-manager-list.component.html
@@ -7,7 +7,11 @@
       <ng-container matColumnDef="user">
         <th mat-header-cell *matHeaderCellDef mat-sort-header>User</th>
         <td mat-cell *matCellDef="let iva" class="min-w-48">
-          {{ iva.user_name }}
+          <a
+            routerLink="/user-manager/{{ iva.user_id }}"
+            data-umami-event="IVA Manager User Name Clicked"
+            >{{ iva.user_name }}</a
+          >
         </td>
       </ng-container>
       <ng-container matColumnDef="type">

--- a/src/app/verification-addresses/features/iva-manager-list/iva-manager-list.component.ts
+++ b/src/app/verification-addresses/features/iva-manager-list/iva-manager-list.component.ts
@@ -21,6 +21,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
 import { MatSort, MatSortModule } from '@angular/material/sort';
 import { MatTableDataSource, MatTableModule } from '@angular/material/table';
+import { RouterLink } from '@angular/router';
 import { ConfirmationService } from '@app/shared/services/confirmation.service';
 import { NotificationService } from '@app/shared/services/notification.service';
 import { UserWithIva } from '@app/verification-addresses/models/iva';
@@ -46,6 +47,7 @@ import { CodeCreationDialogComponent } from '../code-creation-dialog/code-creati
     MatPaginatorModule,
     IvaTypePipe,
     IvaStatePipe,
+    RouterLink,
   ],
   providers: [IvaTypePipe],
   templateUrl: './iva-manager-list.component.html',

--- a/src/app/verification-addresses/services/iva.service.ts
+++ b/src/app/verification-addresses/services/iva.service.ts
@@ -130,7 +130,11 @@ export class IvaService {
     if (ivas.length && filter) {
       const name = filter.name.trim().toLowerCase();
       if (name) {
-        ivas = ivas.filter((iva) => iva.user_name.toLowerCase().includes(name));
+        ivas = ivas.filter(
+          (iva) =>
+            iva.user_name.toLowerCase().includes(name) ||
+            iva.user_email.toLowerCase().includes(name),
+        );
       }
       if (filter.fromDate) {
         const fromDate = filter.fromDate.toISOString();

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -46,7 +46,7 @@ export const users: RegisteredUser[] = [
     ext_id: 'aacaffeecaffeecaffeecaffeecaffeecaffeeaaf@lifescience-ri.eu',
     name: 'Joan Mar',
     title: 'Dr.',
-    email: 'mar@home.or',
+    email: 'mar@home.org',
     roles: [],
     status: UserStatus.active,
     registration_date: '2023-03-01T00:00:00',


### PR DESCRIPTION
Because the IVA manager does not show much information about the user, I added a link to the user detail page.

Also allowed searching for email addresses with the name field, like in the other editors.

We can consider showing the email in parens after the user name, but then the table would probably look too growded and overflow.