### PR TITLE
Add method to fetch all studies

### DIFF
--- a/src/app/metadata/features/dataset-summary/dataset-summary.html
+++ b/src/app/metadata/features/dataset-summary/dataset-summary.html
@@ -49,24 +49,26 @@
             <mat-icon inline fontIcon="book_2"></mat-icon>
           </div>
           <div class="*:mb-0.5">
-            @if(studiesSummary().count > 0) {
+            @if (studiesSummary().count > 0) {
               <p>
                 <strong>Part of study: </strong>
               </p>
               <p>
                 <a
-                  routerLink="/study/{{ studiesSummaryStats().accession }}"
+                  routerLink="/study/{{ studiesSummaryStats().accession[0] }}"
                   data-umami-event="Dataset Summary Study Title Clicked"
-                  >{{  studiesSummaryStats().title }}</a>
+                  >{{ studiesSummaryStats().title[0] }}</a
+                >
               </p>
               <p>
                 <strong>Accession ID: </strong>
               </p>
               <p>
                 <a
-                  routerLink="/study/{{ studiesSummaryStats().accession }}"
+                  routerLink="/study/{{ studiesSummaryStats().accession[0] }}"
                   data-umami-event="Dataset Summary Study Accession Clicked"
-                  >{{  studiesSummaryStats().accession }}</a>
+                  >{{ studiesSummaryStats().accession[0] }}</a
+                >
               </p>
             } @else {
               <p>

--- a/src/app/metadata/models/dataset-details.ts
+++ b/src/app/metadata/models/dataset-details.ts
@@ -59,6 +59,7 @@ interface Publication {
 
 export interface File {
   accession: string;
+  alias?: string;
   format: string;
   name: string;
   ega_accession: string;

--- a/src/app/metadata/models/dataset-information.ts
+++ b/src/app/metadata/models/dataset-information.ts
@@ -18,6 +18,12 @@ export interface FileInformation {
   storage_alias?: string;
 }
 
+export interface EmFileDescriptor {
+  alias: string;
+  name: string;
+  format: string;
+}
+
 export const emptyDatasetInformation: DatasetInformation = {
   accession: '',
   file_information: [],

--- a/src/app/metadata/models/dataset-information.ts
+++ b/src/app/metadata/models/dataset-information.ts
@@ -18,7 +18,8 @@ export interface FileInformation {
   storage_alias?: string;
 }
 
-export interface EmFileDescriptor {
+export interface EmFile {
+  accession: string;
   alias: string;
   name: string;
   format: string;

--- a/src/app/metadata/models/dataset-summary.ts
+++ b/src/app/metadata/models/dataset-summary.ts
@@ -19,8 +19,8 @@ export interface DatasetSummary {
 interface StudiesSummary {
   count: number;
   stats: {
-    accession: string;
-    title: string;
+    accession: string[];
+    title: string[];
   };
 }
 
@@ -62,7 +62,7 @@ export const emptyDatasetSummary: DatasetSummary = {
   description: '',
   dac_email: '',
   types: [],
-  studies_summary: { count: 0, stats: { accession: '', title: '' } },
+  studies_summary: { count: 0, stats: { accession: [], title: [] } },
   files_summary: { count: 0, stats: { format: [] } },
   samples_summary: {
     count: 0,

--- a/src/app/metadata/services/metadata-search.ts
+++ b/src/app/metadata/services/metadata-search.ts
@@ -4,9 +4,11 @@
  * @license Apache-2.0
  */
 
-import { httpResource } from '@angular/common/http';
+import { HttpClient, httpResource } from '@angular/common/http';
 import { Injectable, Signal, computed, inject, signal } from '@angular/core';
 import { ConfigService } from '@app/shared/services/config';
+import { lastValueFrom } from 'rxjs';
+import { DatasetSummary } from '../models/dataset-summary';
 import { FacetFilterSetting } from '../models/facet-filter';
 import {
   DEFAULT_PAGE_SIZE,
@@ -14,6 +16,7 @@ import {
   SearchResults,
   emptySearchResults,
 } from '../models/search-results';
+import { Study } from '../models/study';
 
 /**
  * Metadata search service
@@ -25,6 +28,10 @@ export class MetadataSearchService {
   #config = inject(ConfigService);
   #massUrl = this.#config.massUrl;
   #searchUrl = `${this.#massUrl}/search`;
+  #metldataUrl = this.#config.metldataUrl;
+  #datasetSummaryUrl = `${this.#metldataUrl}/artifacts/stats_public/classes/DatasetStats/resources`;
+  #studyUrl = `${this.#metldataUrl}/artifacts/embedded_public/classes/Study/resources`;
+  #http = inject(HttpClient);
   #className = signal<string | undefined>(undefined);
   #limit = signal<number | undefined>(undefined);
   #skip = signal<number | undefined>(undefined);
@@ -167,5 +174,54 @@ export class MetadataSearchService {
       massQueryUrl += `&skip=${skip}`;
     }
     return massQueryUrl;
+  }
+
+  /**
+   * Fetch a map of all studies keyed by study accession.
+   *
+   * Because there is no dedicated backend endpoint for listing studies, this
+   * method first fetches all dataset IDs via a MASS search, then walks each
+   * dataset summary to discover study accessions and fetches each study
+   * individually. Dataset IDs that are already accounted for by a fetched
+   * study's datasets list are skipped so each study is fetched at most once.
+   *
+   * This approach is a bit inefficient, but it is only temporary until we
+   * switch to a study-based backend.
+   * @returns A promise that resolves to a Map from study accession to Study
+   */
+  async fetchStudyMap(): Promise<Map<string, Study>> {
+    const searchResults = await lastValueFrom(
+      this.#http.get<SearchResults>(`${this.#searchUrl}?class_name=EmbeddedDataset`),
+    );
+
+    const datasetIdSet = new Set<string>(searchResults.hits.map((hit) => hit.id_));
+    const studyMap = new Map<string, Study>();
+
+    while (datasetIdSet.size > 0) {
+      const datasetId = datasetIdSet.values().next().value as string;
+
+      const summary = await lastValueFrom(
+        this.#http.get<DatasetSummary>(`${this.#datasetSummaryUrl}/${datasetId}`),
+      );
+
+      for (const studyAccession of summary.studies_summary.stats.accession) {
+        if (studyMap.has(studyAccession)) {
+          continue;
+        }
+
+        const study = await lastValueFrom(
+          this.#http.get<Study>(`${this.#studyUrl}/${studyAccession}`),
+        );
+        studyMap.set(studyAccession, study);
+
+        for (const linkedDatasetId of study.datasets) {
+          datasetIdSet.delete(linkedDatasetId);
+        }
+      }
+
+      datasetIdSet.delete(datasetId);
+    }
+
+    return studyMap;
   }
 }

--- a/src/app/metadata/services/metadata-search.ts
+++ b/src/app/metadata/services/metadata-search.ts
@@ -7,7 +7,17 @@
 import { HttpClient, httpResource } from '@angular/common/http';
 import { Injectable, Signal, computed, inject, signal } from '@angular/core';
 import { ConfigService } from '@app/shared/services/config';
-import { lastValueFrom } from 'rxjs';
+import {
+  Observable,
+  concatMap,
+  from,
+  last,
+  map,
+  mergeMap,
+  mergeScan,
+  of,
+  reduce,
+} from 'rxjs';
 import { DatasetSummary } from '../models/dataset-summary';
 import { FacetFilterSetting } from '../models/facet-filter';
 import {
@@ -17,6 +27,12 @@ import {
   emptySearchResults,
 } from '../models/search-results';
 import { Study } from '../models/study';
+
+interface StudyMapAccumulator {
+  studyMap: Map<string, Study>;
+  skippedDatasetIds: Set<string>;
+  fetchedStudyAccessions: Set<string>;
+}
 
 /**
  * Metadata search service
@@ -187,41 +203,64 @@ export class MetadataSearchService {
    *
    * This approach is a bit inefficient, but it is only temporary until we
    * switch to a study-based backend.
-   * @returns A promise that resolves to a Map from study accession to Study
+   * @returns An observable that emits a Map from study accession to Study
    */
-  async fetchStudyMap(): Promise<Map<string, Study>> {
-    const searchResults = await lastValueFrom(
-      this.#http.get<SearchResults>(`${this.#searchUrl}?class_name=EmbeddedDataset`),
-    );
+  fetchStudyMap(): Observable<Map<string, Study>> {
+    const initialState: StudyMapAccumulator = {
+      studyMap: new Map<string, Study>(),
+      skippedDatasetIds: new Set<string>(),
+      fetchedStudyAccessions: new Set<string>(),
+    };
 
-    const datasetIdSet = new Set<string>(searchResults.hits.map((hit) => hit.id_));
-    const studyMap = new Map<string, Study>();
+    return this.#http
+      .get<SearchResults>(`${this.#searchUrl}?class_name=EmbeddedDataset`)
+      .pipe(
+        map((searchResults) => searchResults.hits.map((hit) => hit.id_)),
+        mergeMap((datasetIds) => from(datasetIds)),
+        mergeScan(
+          (acc: StudyMapAccumulator, datasetId: string) => {
+            if (acc.skippedDatasetIds.has(datasetId)) {
+              return of(acc);
+            }
 
-    while (datasetIdSet.size > 0) {
-      const datasetId = datasetIdSet.values().next().value as string;
+            return this.#http
+              .get<DatasetSummary>(`${this.#datasetSummaryUrl}/${datasetId}`)
+              .pipe(
+                mergeMap((summary) => from(summary.studies_summary.stats.accession)),
+                concatMap((studyAccession) => {
+                  if (acc.fetchedStudyAccessions.has(studyAccession)) {
+                    return of(undefined);
+                  }
 
-      const summary = await lastValueFrom(
-        this.#http.get<DatasetSummary>(`${this.#datasetSummaryUrl}/${datasetId}`),
+                  return this.#http.get<Study>(`${this.#studyUrl}/${studyAccession}`);
+                }),
+                reduce((datasetAcc: StudyMapAccumulator, study: Study | undefined) => {
+                  if (!study) {
+                    return datasetAcc;
+                  }
+
+                  const studyMap = new Map(datasetAcc.studyMap);
+                  studyMap.set(study.accession, study);
+
+                  const skippedDatasetIds = new Set(datasetAcc.skippedDatasetIds);
+                  for (const linkedDatasetId of study.datasets) {
+                    skippedDatasetIds.add(linkedDatasetId);
+                  }
+
+                  const fetchedStudyAccessions = new Set(
+                    datasetAcc.fetchedStudyAccessions,
+                  );
+                  fetchedStudyAccessions.add(study.accession);
+
+                  return { studyMap, skippedDatasetIds, fetchedStudyAccessions };
+                }, acc),
+              );
+          },
+          initialState,
+          1,
+        ),
+        last(),
+        map((acc) => acc.studyMap),
       );
-
-      for (const studyAccession of summary.studies_summary.stats.accession) {
-        if (studyMap.has(studyAccession)) {
-          continue;
-        }
-
-        const study = await lastValueFrom(
-          this.#http.get<Study>(`${this.#studyUrl}/${studyAccession}`),
-        );
-        studyMap.set(studyAccession, study);
-
-        for (const linkedDatasetId of study.datasets) {
-          datasetIdSet.delete(linkedDatasetId);
-        }
-      }
-
-      datasetIdSet.delete(datasetId);
-    }
-
-    return studyMap;
   }
 }

--- a/src/app/metadata/services/metadata-search.ts
+++ b/src/app/metadata/services/metadata-search.ts
@@ -193,7 +193,7 @@ export class MetadataSearchService {
   }
 
   /**
-   * Fetch a map of all studies keyed by study accession.
+   * Load a map of all studies keyed by study accession.
    *
    * Because there is no dedicated backend endpoint for listing studies, this
    * method first fetches all dataset IDs via a MASS search, then walks each
@@ -201,17 +201,11 @@ export class MetadataSearchService {
    * individually. Dataset IDs that are already accounted for by a fetched
    * study's datasets list are skipped so each study is fetched at most once.
    *
-   * This approach is a bit inefficient, but it is only temporary until we
-   * switch to a study-based backend.
+   * Unfortunately, this method is not efficient, but it is only used temporarily
+   * until we switch to a study-based backend.
    * @returns An observable that emits a Map from study accession to Study
    */
-  fetchStudyMap(): Observable<Map<string, Study>> {
-    const initialState: StudyMapAccumulator = {
-      studyMap: new Map<string, Study>(),
-      skippedDatasetIds: new Set<string>(),
-      fetchedStudyAccessions: new Set<string>(),
-    };
-
+  loadStudiesMap(): Observable<Map<string, Study>> {
     return this.#http
       .get<SearchResults>(`${this.#searchUrl}?class_name=EmbeddedDataset`)
       .pipe(
@@ -256,7 +250,11 @@ export class MetadataSearchService {
                 }, acc),
               );
           },
-          initialState,
+          {
+            studyMap: new Map<string, Study>(),
+            skippedDatasetIds: new Set<string>(),
+            fetchedStudyAccessions: new Set<string>(),
+          },
           1,
         ),
         last(),

--- a/src/app/metadata/services/metadata.spec.ts
+++ b/src/app/metadata/services/metadata.spec.ts
@@ -7,8 +7,14 @@
 import { TestBed } from '@angular/core/testing';
 
 import { provideHttpClient } from '@angular/common/http';
-import { provideHttpClientTesting } from '@angular/common/http/testing';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
 import { ConfigService } from '@app/shared/services/config';
+import { firstValueFrom } from 'rxjs';
+import { emptyDatasetDetails } from '../models/dataset-details';
+import { emptyStudy, Study } from '../models/study';
 import { MetadataService } from './metadata';
 
 /**
@@ -20,6 +26,7 @@ class MockConfigService {
 
 describe('MetadataService', () => {
   let service: MetadataService;
+  let httpMock: HttpTestingController;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -31,9 +38,129 @@ describe('MetadataService', () => {
       ],
     });
     service = TestBed.inject(MetadataService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('should return an empty file map for studies without datasets', async () => {
+    const study: Study = {
+      ...emptyStudy,
+      accession: 'STU1',
+      datasets: [],
+    };
+
+    const fileMap = await firstValueFrom(service.fetchStudyFileMap(study));
+
+    expect(fileMap.size).toBe(0);
+  });
+
+  it('should build a deduplicated file map from all *_files fields', async () => {
+    const study: Study = {
+      ...emptyStudy,
+      accession: 'STU1',
+      datasets: ['DS1', 'DS2'],
+    };
+
+    const fileMapPromise = firstValueFrom(service.fetchStudyFileMap(study));
+
+    const ds1Req = httpMock.expectOne(
+      'http://mock.dev/metldata/artifacts/embedded_public/classes/EmbeddedDataset/resources/DS1',
+    );
+    ds1Req.flush({
+      ...emptyDatasetDetails,
+      accession: 'DS1',
+      process_data_files: [
+        {
+          accession: 'FILE-1',
+          alias: 'ALIAS-1',
+          format: 'BAM',
+          name: 'first-file',
+          ega_accession: 'EGA1',
+          file_information: { accession: 'FILE-1', storage_alias: 'LOC-1' },
+        },
+      ],
+      research_data_files: [
+        {
+          accession: 'FILE-2',
+          alias: 'ALIAS-2',
+          format: 'VCF',
+          name: 'second-file',
+          ega_accession: 'EGA2',
+          file_information: { accession: 'FILE-2', storage_alias: 'LOC-2' },
+        },
+      ],
+    });
+
+    await Promise.resolve();
+
+    const ds2Req = httpMock.expectOne(
+      'http://mock.dev/metldata/artifacts/embedded_public/classes/EmbeddedDataset/resources/DS2',
+    );
+    ds2Req.flush({
+      ...emptyDatasetDetails,
+      accession: 'DS2',
+      experiment_method_supporting_files: [
+        {
+          accession: 'FILE-3',
+          format: 'CRAM',
+          name: 'third-file',
+          ega_accession: 'EGA3',
+          file_information: { accession: 'FILE-3' },
+        },
+      ],
+      individual_supporting_files: [
+        {
+          accession: 'FILE-1',
+          alias: 'ALIAS-DUPE',
+          format: 'FASTQ',
+          name: 'duplicate-should-be-ignored',
+          ega_accession: 'EGA4',
+          file_information: { accession: 'FILE-1', storage_alias: 'LOC-DUPE' },
+        },
+      ],
+    });
+
+    const fileMap = await fileMapPromise;
+
+    expect(fileMap.size).toBe(3);
+    expect(fileMap.get('FILE-1')).toEqual({
+      alias: 'ALIAS-1',
+      name: 'first-file',
+      format: 'BAM',
+    });
+    expect(fileMap.get('FILE-2')).toEqual({
+      alias: 'ALIAS-2',
+      name: 'second-file',
+      format: 'VCF',
+    });
+    expect(fileMap.get('FILE-3')).toEqual({
+      alias: '',
+      name: 'third-file',
+      format: 'CRAM',
+    });
+  });
+
+  it('should reject when a dataset details request fails', async () => {
+    const study: Study = {
+      ...emptyStudy,
+      accession: 'STU1',
+      datasets: ['DS1'],
+    };
+
+    const fileMapPromise = firstValueFrom(service.fetchStudyFileMap(study));
+
+    const req = httpMock.expectOne(
+      'http://mock.dev/metldata/artifacts/embedded_public/classes/EmbeddedDataset/resources/DS1',
+    );
+    req.flush({ detail: 'failed' }, { status: 500, statusText: 'Server Error' });
+
+    await expect(fileMapPromise).rejects.toBeDefined();
   });
 });

--- a/src/app/metadata/services/metadata.spec.ts
+++ b/src/app/metadata/services/metadata.spec.ts
@@ -49,26 +49,26 @@ describe('MetadataService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should return an empty file map for studies without datasets', async () => {
+  it('should return an empty file list for studies without datasets', async () => {
     const study: Study = {
       ...emptyStudy,
       accession: 'STU1',
       datasets: [],
     };
 
-    const fileMap = await firstValueFrom(service.fetchStudyFileMap(study));
+    const files = await firstValueFrom(service.filesOfStudy(study));
 
-    expect(fileMap.size).toBe(0);
+    expect(files).toEqual([]);
   });
 
-  it('should build a deduplicated file map from all *_files fields', async () => {
+  it('should build a deduplicated file list from all *_files fields', async () => {
     const study: Study = {
       ...emptyStudy,
       accession: 'STU1',
       datasets: ['DS1', 'DS2'],
     };
 
-    const fileMapPromise = firstValueFrom(service.fetchStudyFileMap(study));
+    const filesPromise = firstValueFrom(service.filesOfStudy(study));
 
     const ds1Req = httpMock.expectOne(
       'http://mock.dev/metldata/artifacts/embedded_public/classes/EmbeddedDataset/resources/DS1',
@@ -109,6 +109,7 @@ describe('MetadataService', () => {
       experiment_method_supporting_files: [
         {
           accession: 'FILE-3',
+          alias: 'ALIAS-3',
           format: 'CRAM',
           name: 'third-file',
           ega_accession: 'EGA3',
@@ -127,21 +128,25 @@ describe('MetadataService', () => {
       ],
     });
 
-    const fileMap = await fileMapPromise;
+    const files = await filesPromise;
+    const filesByAccession = new Map(files.map((file) => [file.accession, file]));
 
-    expect(fileMap.size).toBe(3);
-    expect(fileMap.get('FILE-1')).toEqual({
+    expect(files).toHaveLength(3);
+    expect(filesByAccession.get('FILE-1')).toEqual({
+      accession: 'FILE-1',
       alias: 'ALIAS-1',
       name: 'first-file',
       format: 'BAM',
     });
-    expect(fileMap.get('FILE-2')).toEqual({
+    expect(filesByAccession.get('FILE-2')).toEqual({
+      accession: 'FILE-2',
       alias: 'ALIAS-2',
       name: 'second-file',
       format: 'VCF',
     });
-    expect(fileMap.get('FILE-3')).toEqual({
-      alias: '',
+    expect(filesByAccession.get('FILE-3')).toEqual({
+      accession: 'FILE-3',
+      alias: 'ALIAS-3',
       name: 'third-file',
       format: 'CRAM',
     });
@@ -154,13 +159,13 @@ describe('MetadataService', () => {
       datasets: ['DS1'],
     };
 
-    const fileMapPromise = firstValueFrom(service.fetchStudyFileMap(study));
+    const filesPromise = firstValueFrom(service.filesOfStudy(study));
 
     const req = httpMock.expectOne(
       'http://mock.dev/metldata/artifacts/embedded_public/classes/EmbeddedDataset/resources/DS1',
     );
     req.flush({ detail: 'failed' }, { status: 500, statusText: 'Server Error' });
 
-    await expect(fileMapPromise).rejects.toBeDefined();
+    await expect(filesPromise).rejects.toBeDefined();
   });
 });

--- a/src/app/metadata/services/metadata.ts
+++ b/src/app/metadata/services/metadata.ts
@@ -51,8 +51,8 @@ export class MetadataService {
   );
 
   /**
-   * Load the study details for the given ID
-   * @param id study ID
+   * Load the study details for the given study ID
+   * @param id Study ID
    */
   loadStudy(id: string): void {
     this.#studyID.set(id);

--- a/src/app/metadata/services/metadata.ts
+++ b/src/app/metadata/services/metadata.ts
@@ -7,7 +7,7 @@
 import { HttpClient, httpResource } from '@angular/common/http';
 import { inject, Injectable, signal } from '@angular/core';
 import { ConfigService } from '@app/shared/services/config';
-import { concatMap, from, Observable, reduce } from 'rxjs';
+import { concatMap, from, map, Observable, reduce } from 'rxjs';
 import {
   DatasetDetails,
   DatasetDetailsRaw,
@@ -16,7 +16,7 @@ import {
   ExperimentMethod,
   Individual,
 } from '../models/dataset-details';
-import { EmFileDescriptor } from '../models/dataset-information';
+import { EmFile } from '../models/dataset-information';
 import { DatasetSummary, emptyDatasetSummary } from '../models/dataset-summary';
 import { emptyStudy, Study } from '../models/study';
 
@@ -104,12 +104,14 @@ export class MetadataService {
   }
 
   /**
-   * Fetch a map of unique files for a study, keyed by file accession.
+   * Fetch the unique files for a study.
+   *
+   * Unfortunately, this method is not efficient, but it is only used temporarily
+   * until we switch to a study-based backend.
    * @param study Study containing the list of dataset accessions to inspect
-   * @returns An observable emitting a map from file accession to descriptor
-   * (name, alias and format)
+   * @returns An observable emitting a list of unique EM files
    */
-  fetchStudyFileMap(study: Study): Observable<Map<string, EmFileDescriptor>> {
+  filesOfStudy(study: Study): Observable<EmFile[]> {
     return from(study.datasets).pipe(
       concatMap((datasetAccession) =>
         this.#http.get<DatasetDetails>(
@@ -124,18 +126,20 @@ export class MetadataService {
 
         return from(propertyValue);
       }),
-      reduce((fileMap, file) => {
-        if (!this.#isDatasetFile(file) || fileMap.has(file.accession)) {
-          return fileMap;
+      reduce((filesByAccession, file) => {
+        if (!this.#isDatasetFile(file) || filesByAccession.has(file.accession)) {
+          return filesByAccession;
         }
 
-        fileMap.set(file.accession, {
-          alias: file.alias ?? '',
+        filesByAccession.set(file.accession, {
+          accession: file.accession,
+          alias: file.alias,
           name: file.name,
           format: file.format,
         });
-        return fileMap;
-      }, new Map<string, EmFileDescriptor>()),
+        return filesByAccession;
+      }, new Map<string, EmFile>()),
+      map((filesByAccession) => Array.from(filesByAccession.values())),
     );
   }
 
@@ -186,7 +190,7 @@ export class MetadataService {
    * @param value Value from a dynamic dataset details property
    * @returns True when value is a dataset file with required fields
    */
-  #isDatasetFile(value: unknown): value is DatasetFile {
+  #isDatasetFile(value: unknown): value is DatasetFile & { alias: string } {
     if (!value || typeof value !== 'object') {
       return false;
     }
@@ -194,6 +198,7 @@ export class MetadataService {
     const candidate = value as Partial<DatasetFile>;
     return (
       typeof candidate.accession === 'string' &&
+      typeof candidate.alias === 'string' &&
       typeof candidate.name === 'string' &&
       typeof candidate.format === 'string'
     );

--- a/src/app/metadata/services/metadata.ts
+++ b/src/app/metadata/services/metadata.ts
@@ -4,16 +4,19 @@
  * @license Apache-2.0
  */
 
-import { httpResource } from '@angular/common/http';
+import { HttpClient, httpResource } from '@angular/common/http';
 import { inject, Injectable, signal } from '@angular/core';
 import { ConfigService } from '@app/shared/services/config';
+import { concatMap, from, Observable, reduce } from 'rxjs';
 import {
   DatasetDetails,
   DatasetDetailsRaw,
+  File as DatasetFile,
   emptyDatasetDetails,
   ExperimentMethod,
   Individual,
 } from '../models/dataset-details';
+import { EmFileDescriptor } from '../models/dataset-information';
 import { DatasetSummary, emptyDatasetSummary } from '../models/dataset-summary';
 import { emptyStudy, Study } from '../models/study';
 
@@ -29,6 +32,7 @@ import { emptyStudy, Study } from '../models/study';
 @Injectable()
 export class MetadataService {
   #config = inject(ConfigService);
+  #http = inject(HttpClient);
   #metldataUrl = this.#config.metldataUrl;
 
   #datasetSummaryUrl = `${this.#metldataUrl}/artifacts/stats_public/classes/DatasetStats/resources`;
@@ -98,6 +102,43 @@ export class MetadataService {
   loadDatasetDetails(id: string): void {
     this.#detailsID.set(id);
   }
+
+  /**
+   * Fetch a map of unique files for a study, keyed by file accession.
+   * @param study Study containing the list of dataset accessions to inspect
+   * @returns An observable emitting a map from file accession to descriptor
+   * (name, alias and format)
+   */
+  fetchStudyFileMap(study: Study): Observable<Map<string, EmFileDescriptor>> {
+    return from(study.datasets).pipe(
+      concatMap((datasetAccession) =>
+        this.#http.get<DatasetDetails>(
+          `${this.#datasetDetailsUrl}/${datasetAccession}`,
+        ),
+      ),
+      concatMap((details) => from(Object.entries(details))),
+      concatMap(([propertyName, propertyValue]) => {
+        if (!propertyName.endsWith('_files') || !Array.isArray(propertyValue)) {
+          return from([] as unknown[]);
+        }
+
+        return from(propertyValue);
+      }),
+      reduce((fileMap, file) => {
+        if (!this.#isDatasetFile(file) || fileMap.has(file.accession)) {
+          return fileMap;
+        }
+
+        fileMap.set(file.accession, {
+          alias: file.alias ?? '',
+          name: file.name,
+          format: file.format,
+        });
+        return fileMap;
+      }, new Map<string, EmFileDescriptor>()),
+    );
+  }
+
   /**
    * Resolve dataset details
    * @param raw The raw dataset details object
@@ -138,5 +179,23 @@ export class MetadataService {
         individual: getIndividual(s.individual),
       })),
     };
+  }
+
+  /**
+   * Check if an unknown value looks like a dataset file object.
+   * @param value Value from a dynamic dataset details property
+   * @returns True when value is a dataset file with required fields
+   */
+  #isDatasetFile(value: unknown): value is DatasetFile {
+    if (!value || typeof value !== 'object') {
+      return false;
+    }
+
+    const candidate = value as Partial<DatasetFile>;
+    return (
+      typeof candidate.accession === 'string' &&
+      typeof candidate.name === 'string' &&
+      typeof candidate.format === 'string'
+    );
   }
 }

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -417,8 +417,8 @@ export const datasetSummary: DatasetSummary = {
   studies_summary: {
     count: 1,
     stats: {
-      accession: 'GHGAS12345678901234',
-      title: 'Test Study',
+      accession: ['GHGAS12345678901234'],
+      title: ['Test Study'],
     },
   },
   experiments_summary: {


### PR DESCRIPTION
In order to let the data steward select the study for an upload box, we need to fetch the list of all studies.

This PR adds a method `loadStudiesMap` that does this. Unfortunately, the backend does not provide an efficient way to do that, so this is a bit slow. However, since we will switch to a study based backend soon anyway, it does not make sense to add such functionality on the backend side. And since we cache HTTP GET requests, this will be only slow on the first use. Since this is only temporary, we also don't bother to add a resource API facade but use rxjs.

Note: We could fetch the study description lazily only when the study is selected, but we do it eagerly because it contains the list of its datasets and we can use that to optimize the loading, since some studies have many datasets. Alternatively, instead of getting the dataset summary and the study, we could fetch the dataset details (embedded datasets). That might result in less requests, but more transferred data.

This PR also adds a method `filesOfStudy` to load all file names belonging to a study, with the same caveat of inefficiency.

The PR also fixes a small mistake in the type of the dataset summary.