### PR TITLE
Add research data mapping tool

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -133,7 +133,13 @@ export default [
                 ],
               },
             },
-            // upload context may import from ivas context
+            {
+              from: { type: 'model', captured: { context: 'access-requests' } },
+              allow: {
+                to: [{ type: 'model', captured: { context: 'ivas' } }],
+              },
+            },
+            // upload context may import from verification addresses and metadata context
             {
               from: { type: 'features', captured: { context: 'upload' } },
               allow: {
@@ -141,12 +147,10 @@ export default [
                   { type: 'service', captured: { context: 'ivas' } },
                   { type: 'model', captured: { context: 'ivas' } },
                   { type: 'pipe', captured: { context: 'ivas' } },
+                  { type: 'service', captured: { context: 'metadata' } },
+                  { type: 'model', captured: { context: 'metadata' } },
                 ],
               },
-            },
-            {
-              from: { type: 'model', captured: { context: 'access-requests' } },
-              allow: { to: { type: 'model', captured: { context: 'ivas' } } },
             },
             // work-package context may import from some other contexts
             {
@@ -161,7 +165,7 @@ export default [
                 ],
               },
             },
-            // auth context may import from verification addresses context
+            // auth context may import from verification addresses and access request context
             {
               from: { type: 'features', captured: { context: 'auth' } },
               allow: {
@@ -170,14 +174,6 @@ export default [
                   { type: 'model', captured: { context: 'ivas' } },
                   { type: 'pipe', captured: { context: 'ivas' } },
                   { type: 'features', captured: { context: 'ivas' } },
-                ],
-              },
-            },
-            // auth context may import from access request context
-            {
-              from: { type: 'features', captured: { context: 'auth' } },
-              allow: {
-                to: [
                   { type: 'service', captured: { context: 'access-requests' } },
                   { type: 'model', captured: { context: 'access-requests' } },
                   { type: 'pipe', captured: { context: 'access-requests' } },

--- a/src/app/metadata/services/metadata-search.spec.ts
+++ b/src/app/metadata/services/metadata-search.spec.ts
@@ -7,7 +7,10 @@
 import { TestBed } from '@angular/core/testing';
 
 import { provideHttpClient } from '@angular/common/http';
-import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
 import { ConfigService } from '@app/shared/services/config';
 import { MetadataSearchService } from './metadata-search';
 

--- a/src/app/upload/features/upload-box-manager-detail/upload-box-manager-detail.html
+++ b/src/app/upload/features/upload-box-manager-detail/upload-box-manager-detail.html
@@ -187,17 +187,16 @@
                 aria-label="Select page of files"
               ></mat-paginator>
             }
-            @if (showMapFilesButton()) {
-              <button mat-raised-button color="primary" class="mt-4" disabled>
-                <mat-icon fontIcon="check"></mat-icon>
-                Map files to metadata and archive
-              </button>
-            }
           } @else {
             <p class="text-warning mt-2">This upload box is still empty.</p>
           }
         </mat-card-content>
       </mat-card>
+
+      <!-- File Mapping -->
+      @if (box.state === 'locked') {
+        <app-upload-box-mapping [box]="box" (archived)="onBoxArchived()" />
+      }
     </div>
   }
 </div>

--- a/src/app/upload/features/upload-box-manager-detail/upload-box-manager-detail.html
+++ b/src/app/upload/features/upload-box-manager-detail/upload-box-manager-detail.html
@@ -148,7 +148,7 @@
             <div class="overflow-auto">
               <table mat-table [dataSource]="fileUploadsDataSource" class="w-full">
                 <ng-container matColumnDef="alias">
-                  <th mat-header-cell *matHeaderCellDef>Alias</th>
+                  <th mat-header-cell *matHeaderCellDef>Filename</th>
                   <td mat-cell *matCellDef="let file">{{ file.alias }}</td>
                 </ng-container>
                 <ng-container matColumnDef="status">
@@ -171,9 +171,13 @@
                     file.state_updated | date: friendlyDateFormat : timeZone
                   }}</td>
                 </ng-container>
+                <ng-container matColumnDef="accession">
+                  <th mat-header-cell *matHeaderCellDef>Accession</th>
+                  <td mat-cell *matCellDef="let file">{{ file.accession ?? '—' }}</td>
+                </ng-container>
 
-                <tr mat-header-row *matHeaderRowDef="fileColumns"></tr>
-                <tr mat-row *matRowDef="let row; columns: fileColumns"></tr>
+                <tr mat-header-row *matHeaderRowDef="fileColumns()"></tr>
+                <tr mat-row *matRowDef="let row; columns: fileColumns()"></tr>
 
                 <tr class="mat-row" *matNoDataRow>
                   <td class="mat-cell p-4 text-base" colspan="4">Loading files...</td>

--- a/src/app/upload/features/upload-box-manager-detail/upload-box-manager-detail.ts
+++ b/src/app/upload/features/upload-box-manager-detail/upload-box-manager-detail.ts
@@ -221,9 +221,11 @@ export class UploadBoxManagerDetailComponent implements OnInit {
   }
 
   /**
-   * Handle the archived event from the mapping component by reloading the box.
+   * Handle the archived event from the mapping component by clearing the cached
+   * box and reloading fresh data, so the UI transitions out of the locked state.
    */
   onBoxArchived(): void {
+    this.#cachedBox.set(undefined);
     const id = this.id();
     if (id) this.#uploadBoxService.loadUploadBox(id);
   }

--- a/src/app/upload/features/upload-box-manager-detail/upload-box-manager-detail.ts
+++ b/src/app/upload/features/upload-box-manager-detail/upload-box-manager-detail.ts
@@ -34,7 +34,11 @@ import {
   DEFAULT_TIME_ZONE,
   FRIENDLY_DATE_FORMAT,
 } from '@app/shared/utils/date-formats';
-import { ResearchDataUploadBox, UploadBoxStateClass } from '@app/upload/models/box';
+import {
+  ResearchDataUploadBox,
+  UploadBoxState,
+  UploadBoxStateClass,
+} from '@app/upload/models/box';
 import {
   FileUploadState,
   FileUploadWithAccession,
@@ -159,7 +163,11 @@ export class UploadBoxManagerDetailComponent implements OnInit {
   readonly grantColumns = ['grantee', 'status', 'validity', 'details'];
 
   /** Columns for the file uploads table. */
-  readonly fileColumns = ['alias', 'status', 'size', 'uploaded'];
+  fileColumns = computed<string[]>(() =>
+    this.uploadBox()?.state === UploadBoxState.archived
+      ? ['alias', 'accession', 'size', 'uploaded']
+      : ['alias', 'status', 'size', 'uploaded'],
+  );
 
   /** The upload grants for this box. */
   grants = computed<UploadGrant[]>(() => this.#uploadBoxService.boxGrants.value());

--- a/src/app/upload/features/upload-box-manager-detail/upload-box-manager-detail.ts
+++ b/src/app/upload/features/upload-box-manager-detail/upload-box-manager-detail.ts
@@ -41,6 +41,7 @@ import {
 } from '@app/upload/models/file-upload';
 import { UploadGrant } from '@app/upload/models/grant';
 import { UploadBoxService } from '@app/upload/services/upload-box';
+import { UploadBoxMappingComponent } from '../upload-box-mapping/upload-box-mapping';
 
 /**
  * Detail view component for managing an individual upload box.
@@ -58,6 +59,7 @@ import { UploadBoxService } from '@app/upload/services/upload-box';
     RouterLink,
     Capitalise,
     ParseBytes,
+    UploadBoxMappingComponent,
   ],
   providers: [CommonDatePipe],
   templateUrl: './upload-box-manager-detail.html',
@@ -178,9 +180,6 @@ export class UploadBoxManagerDetailComponent implements OnInit {
     }
   });
 
-  /** Whether to show the "Map files to metadata and archive" button. */
-  showMapFilesButton = computed<boolean>(() => this.uploadBox()?.state === 'locked');
-
   /**
    * Check if an upload grant is currently active.
    * @param grant - the upload grant to check
@@ -211,6 +210,14 @@ export class UploadBoxManagerDetailComponent implements OnInit {
       default:
         return 'text-warning';
     }
+  }
+
+  /**
+   * Handle the archived event from the mapping component by reloading the box.
+   */
+  onBoxArchived(): void {
+    const id = this.id();
+    if (id) this.#uploadBoxService.loadUploadBox(id);
   }
 
   /**

--- a/src/app/upload/features/upload-box-mapping/upload-box-mapping-confirm-dialog.html
+++ b/src/app/upload/features/upload-box-mapping/upload-box-mapping-confirm-dialog.html
@@ -1,57 +1,82 @@
 <h2 mat-dialog-title>Confirm Mapping and Archive</h2>
-<div mat-dialog-content class="flex flex-col gap-4">
+<div mat-dialog-content>
   @if (data.unmappedBoxFileAliases.length > 0) {
-    <div class="border-error bg-error/10 text-error rounded border p-3">
+    <div class="border-error bg-error/10 text-error rounded border px-3 pt-3 pb-2">
       <div class="flex items-center gap-2 font-semibold">
         <mat-icon fontIcon="error" />
-        <span
-          >{{ data.unmappedBoxFileAliases.length }} file(s) in the upload box are not
-          mapped.</span
-        >
+        @if (data.unmappedBoxFileAliases.length === 1) {
+          <span>The following file in the upload box cannot be mapped:</span>
+        } @else {
+          <span
+            >{{ data.unmappedBoxFileAliases.length }} files in the upload box cannot be
+            mapped.</span
+          >
+        }
       </div>
       <p class="mt-1 text-sm">
-        First unmapped: <strong>{{ data.unmappedBoxFileAliases[0] }}</strong>
+        @if (data.unmappedBoxFileAliases.length === 1) {
+          <strong>{{ data.unmappedBoxFileAliases[0] }}</strong>
+        } @else {
+          First unmapped: <strong>{{ data.unmappedBoxFileAliases[0] }}</strong>
+        }
       </p>
-      <p class="mt-1 text-sm"
-        >These files must be mapped or deleted before archiving can proceed.</p
-      >
+      <p class="mt-1 text-sm">
+        @if (data.unmappedBoxFileAliases.length === 1) {
+          This file must be mapped or deleted before archival.
+        } @else {
+          These files must be mapped or deleted before archival.
+        }
+      </p>
     </div>
   }
 
   @if (data.unmappedMetaFileNames.length > 0) {
-    <div class="border-warning bg-warning/10 text-warning rounded border p-3">
+    <div class="border-warning bg-warning/10 text-warning mt-4 rounded border px-3 pt-3 pb-2">
       <div class="flex items-center gap-2 font-semibold">
         <mat-icon fontIcon="warning" />
-        <span
-          >{{ data.unmappedMetaFileNames.length }} metadata file(s) are not
-          mapped.</span
-        >
+        @if (data.unmappedMetaFileNames.length === 1) {
+          <span>The following metadata file is not mapped:</span>
+        } @else {
+          <span
+            >{{ data.unmappedMetaFileNames.length }} metadata files are not
+            mapped.</span
+          >
+        }
       </div>
       <p class="mt-1 text-sm">
-        First unmapped: <strong>{{ data.unmappedMetaFileNames[0] }}</strong>
+        @if (data.unmappedMetaFileNames.length === 1) {
+          <strong>{{ data.unmappedMetaFileNames[0] }}</strong>
+        } @else {
+          First unmapped: <strong>{{ data.unmappedMetaFileNames[0] }}</strong>
+        }
       </p>
-      <p class="mt-1 text-sm">You may proceed without mapping these files.</p>
+      <p class="mt-1 text-sm">
+        @if (data.unmappedMetaFileNames.length === 1) {
+          You may proceed without mapping this file.
+        } @else {
+          You may proceed without mapping these files.
+        }
+      </p>
     </div>
   }
 
-  <p>
-    This action is <strong>irreversible</strong>. The upload box will be archived and
-    cannot be modified afterwards.
+  <p class="mt-4">
+    This action is <strong>irreversible</strong>. The upload box will be archived with
+    the specified mapping and cannot be modified afterwards.
   </p>
 
-  <mat-checkbox [checked]="confirmed()" (change)="confirmed.set($event.checked)">
-    I understand this action cannot be undone
-  </mat-checkbox>
+  @if (data.unmappedBoxFileAliases.length === 0) {
+    <mat-checkbox class="mt-4" [checked]="confirmed()" (change)="confirmed.set($event.checked)">
+      I understand this action cannot be undone
+    </mat-checkbox>
+  }
 </div>
 <div mat-dialog-actions align="end">
   <button mat-button (click)="onCancel()">Cancel</button>
-  <button
-    mat-raised-button
-    color="primary"
-    [disabled]="!canConfirm"
-    (click)="onConfirm()"
-  >
-    <mat-icon fontIcon="archive" />
-    Confirm and Archive
-  </button>
+  @if (canConfirm) {
+    <button mat-raised-button color="primary" (click)="onConfirm()">
+      <mat-icon fontIcon="archive" />
+      Confirm and Archive
+    </button>
+  }
 </div>

--- a/src/app/upload/features/upload-box-mapping/upload-box-mapping-confirm-dialog.html
+++ b/src/app/upload/features/upload-box-mapping/upload-box-mapping-confirm-dialog.html
@@ -86,7 +86,7 @@
     <button
       mat-raised-button
       color="primary"
-      [disabled]="!canConfirm"
+      [disabled]="!canConfirm()"
       (click)="onConfirm()"
     >
       <mat-icon fontIcon="archive" />

--- a/src/app/upload/features/upload-box-mapping/upload-box-mapping-confirm-dialog.html
+++ b/src/app/upload/features/upload-box-mapping/upload-box-mapping-confirm-dialog.html
@@ -5,11 +5,11 @@
       <div class="flex items-center gap-2 font-semibold">
         <mat-icon fontIcon="error" />
         @if (data.unmappedBoxFileAliases.length === 1) {
-          <span>The following file in the upload box cannot be mapped:</span>
+          <span>The following file in the upload box has not been mapped:</span>
         } @else {
           <span
-            >{{ data.unmappedBoxFileAliases.length }} files in the upload box cannot be
-            mapped.</span
+            >{{ data.unmappedBoxFileAliases.length }} files in the upload box have not
+            been mapped.</span
           >
         }
       </div>
@@ -31,14 +31,16 @@
   }
 
   @if (data.unmappedMetaFileNames.length > 0) {
-    <div class="border-warning bg-warning/10 text-warning mt-4 rounded border px-3 pt-3 pb-2">
+    <div
+      class="border-warning bg-warning/10 text-warning mt-4 rounded border px-3 pt-3 pb-2"
+    >
       <div class="flex items-center gap-2 font-semibold">
         <mat-icon fontIcon="warning" />
         @if (data.unmappedMetaFileNames.length === 1) {
-          <span>The following metadata file is not mapped:</span>
+          <span>The following metadata file has not been mapped:</span>
         } @else {
           <span
-            >{{ data.unmappedMetaFileNames.length }} metadata files are not
+            >{{ data.unmappedMetaFileNames.length }} metadata files have not been
             mapped.</span
           >
         }
@@ -60,13 +62,19 @@
     </div>
   }
 
-  <p class="mt-4">
-    This action is <strong>irreversible</strong>. The upload box will be archived with
-    the specified mapping and cannot be modified afterwards.
-  </p>
+  @if (data.unmappedBoxFileAliases.length === 0) {
+    <p class="mt-4">
+      This action is <strong>irreversible</strong>. The upload box will be archived with
+      the specified mapping and cannot be modified afterwards.
+    </p>
+  }
 
   @if (data.unmappedBoxFileAliases.length === 0) {
-    <mat-checkbox class="mt-4" [checked]="confirmed()" (change)="confirmed.set($event.checked)">
+    <mat-checkbox
+      class="mt-4"
+      [checked]="confirmed()"
+      (change)="confirmed.set($event.checked)"
+    >
       I understand this action cannot be undone
     </mat-checkbox>
   }

--- a/src/app/upload/features/upload-box-mapping/upload-box-mapping-confirm-dialog.html
+++ b/src/app/upload/features/upload-box-mapping/upload-box-mapping-confirm-dialog.html
@@ -1,0 +1,57 @@
+<h2 mat-dialog-title>Confirm Mapping and Archive</h2>
+<div mat-dialog-content class="flex flex-col gap-4">
+  @if (data.unmappedBoxFileAliases.length > 0) {
+    <div class="border-error bg-error/10 text-error rounded border p-3">
+      <div class="flex items-center gap-2 font-semibold">
+        <mat-icon fontIcon="error" />
+        <span
+          >{{ data.unmappedBoxFileAliases.length }} file(s) in the upload box are not
+          mapped.</span
+        >
+      </div>
+      <p class="mt-1 text-sm">
+        First unmapped: <strong>{{ data.unmappedBoxFileAliases[0] }}</strong>
+      </p>
+      <p class="mt-1 text-sm"
+        >These files must be mapped or deleted before archiving can proceed.</p
+      >
+    </div>
+  }
+
+  @if (data.unmappedMetaFileNames.length > 0) {
+    <div class="border-warning bg-warning/10 text-warning rounded border p-3">
+      <div class="flex items-center gap-2 font-semibold">
+        <mat-icon fontIcon="warning" />
+        <span
+          >{{ data.unmappedMetaFileNames.length }} metadata file(s) are not
+          mapped.</span
+        >
+      </div>
+      <p class="mt-1 text-sm">
+        First unmapped: <strong>{{ data.unmappedMetaFileNames[0] }}</strong>
+      </p>
+      <p class="mt-1 text-sm">You may proceed without mapping these files.</p>
+    </div>
+  }
+
+  <p>
+    This action is <strong>irreversible</strong>. The upload box will be archived and
+    cannot be modified afterwards.
+  </p>
+
+  <mat-checkbox [checked]="confirmed()" (change)="confirmed.set($event.checked)">
+    I understand this action cannot be undone
+  </mat-checkbox>
+</div>
+<div mat-dialog-actions align="end">
+  <button mat-button (click)="onCancel()">Cancel</button>
+  <button
+    mat-raised-button
+    color="primary"
+    [disabled]="!canConfirm"
+    (click)="onConfirm()"
+  >
+    <mat-icon fontIcon="archive" />
+    Confirm and Archive
+  </button>
+</div>

--- a/src/app/upload/features/upload-box-mapping/upload-box-mapping-confirm-dialog.html
+++ b/src/app/upload/features/upload-box-mapping/upload-box-mapping-confirm-dialog.html
@@ -1,5 +1,5 @@
 <h2 mat-dialog-title>Confirm Mapping and Archive</h2>
-<div mat-dialog-content>
+<div mat-dialog-content class="!pb-2">
   @if (data.unmappedBoxFileAliases.length > 0) {
     <div class="border-error bg-error/10 text-error rounded border px-3 pt-3 pb-2">
       <div class="flex items-center gap-2 font-semibold">
@@ -32,7 +32,8 @@
 
   @if (data.unmappedMetaFileNames.length > 0) {
     <div
-      class="border-warning bg-warning/10 text-warning mt-4 rounded border px-3 pt-3 pb-2"
+      class="border-warning bg-warning/10 text-warning rounded border px-3 pt-3 pb-2"
+      [class.mt-4]="data.unmappedBoxFileAliases.length > 0"
     >
       <div class="flex items-center gap-2 font-semibold">
         <mat-icon fontIcon="warning" />
@@ -63,7 +64,7 @@
   }
 
   @if (data.unmappedBoxFileAliases.length === 0) {
-    <p class="mt-4">
+    <p [class.mt-4]="data.unmappedMetaFileNames.length > 0">
       This action is <strong>irreversible</strong>. The upload box will be archived with
       the specified mapping and cannot be modified afterwards.
     </p>
@@ -71,7 +72,7 @@
 
   @if (data.unmappedBoxFileAliases.length === 0) {
     <mat-checkbox
-      class="mt-4"
+      class="mt-2"
       [checked]="confirmed()"
       (change)="confirmed.set($event.checked)"
     >
@@ -81,8 +82,13 @@
 </div>
 <div mat-dialog-actions align="end">
   <button mat-button (click)="onCancel()">Cancel</button>
-  @if (canConfirm) {
-    <button mat-raised-button color="primary" (click)="onConfirm()">
+  @if (data.unmappedBoxFileAliases.length === 0) {
+    <button
+      mat-raised-button
+      color="primary"
+      [disabled]="!canConfirm"
+      (click)="onConfirm()"
+    >
       <mat-icon fontIcon="archive" />
       Confirm and Archive
     </button>

--- a/src/app/upload/features/upload-box-mapping/upload-box-mapping-confirm-dialog.html
+++ b/src/app/upload/features/upload-box-mapping/upload-box-mapping-confirm-dialog.html
@@ -68,9 +68,6 @@
       This action is <strong>irreversible</strong>. The upload box will be archived with
       the specified mapping and cannot be modified afterwards.
     </p>
-  }
-
-  @if (data.unmappedBoxFileAliases.length === 0) {
     <mat-checkbox
       class="mt-2"
       [checked]="confirmed()"

--- a/src/app/upload/features/upload-box-mapping/upload-box-mapping-confirm-dialog.ts
+++ b/src/app/upload/features/upload-box-mapping/upload-box-mapping-confirm-dialog.ts
@@ -1,0 +1,70 @@
+/**
+ * Confirmation dialog for the file mapping and archive action.
+ * @copyright The GHGA Authors
+ * @license Apache-2.0
+ */
+
+import { Component, inject, signal } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogActions,
+  MatDialogContent,
+  MatDialogModule,
+  MatDialogRef,
+  MatDialogTitle,
+} from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
+
+/** Data passed into the mapping confirmation dialog */
+export interface MappingConfirmDialogData {
+  /** Aliases of upload-box files that are not yet mapped (must be fixed) */
+  unmappedBoxFileAliases: string[];
+  /** Names/aliases of metadata files that are not mapped (warning only) */
+  unmappedMetaFileNames: string[];
+}
+
+/**
+ * Dialog to confirm the file mapping submission and box archival.
+ * Blocks submission when any upload-box files remain unmapped.
+ * Shows a warning (but allows submission) when metadata files remain unmapped.
+ */
+@Component({
+  selector: 'app-upload-box-mapping-confirm-dialog',
+  imports: [
+    MatButtonModule,
+    MatCheckboxModule,
+    MatDialogModule,
+    MatDialogTitle,
+    MatDialogContent,
+    MatDialogActions,
+    MatIconModule,
+  ],
+  templateUrl: './upload-box-mapping-confirm-dialog.html',
+})
+export class UploadBoxMappingConfirmDialogComponent {
+  #dialogRef = inject(MatDialogRef<UploadBoxMappingConfirmDialogComponent, boolean>);
+  protected data = inject<MappingConfirmDialogData>(MAT_DIALOG_DATA);
+
+  /** Whether the user has ticked the confirmation checkbox */
+  protected confirmed = signal<boolean>(false);
+
+  /**
+   * Whether the confirm button should be enabled.
+   * @returns true when all box files are mapped and the user confirmed the checkbox
+   */
+  protected get canConfirm(): boolean {
+    return this.confirmed() && this.data.unmappedBoxFileAliases.length === 0;
+  }
+
+  /** Close the dialog with a positive result */
+  protected onConfirm(): void {
+    this.#dialogRef.close(true);
+  }
+
+  /** Close the dialog with a negative result */
+  protected onCancel(): void {
+    this.#dialogRef.close(false);
+  }
+}

--- a/src/app/upload/features/upload-box-mapping/upload-box-mapping-confirm-dialog.ts
+++ b/src/app/upload/features/upload-box-mapping/upload-box-mapping-confirm-dialog.ts
@@ -4,7 +4,13 @@
  * @license Apache-2.0
  */
 
-import { Component, inject, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import {
@@ -42,6 +48,7 @@ export interface MappingConfirmDialogData {
     MatIconModule,
   ],
   templateUrl: './upload-box-mapping-confirm-dialog.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class UploadBoxMappingConfirmDialogComponent {
   #dialogRef = inject(MatDialogRef<UploadBoxMappingConfirmDialogComponent, boolean>);
@@ -50,13 +57,10 @@ export class UploadBoxMappingConfirmDialogComponent {
   /** Whether the user has ticked the confirmation checkbox */
   protected confirmed = signal<boolean>(false);
 
-  /**
-   * Whether the confirm button should be enabled.
-   * @returns true when all box files are mapped and the user confirmed the checkbox
-   */
-  protected get canConfirm(): boolean {
-    return this.confirmed() && this.data.unmappedBoxFileAliases.length === 0;
-  }
+  /** Whether the confirm button should be enabled */
+  protected canConfirm = computed<boolean>(
+    () => this.confirmed() && this.data.unmappedBoxFileAliases.length === 0,
+  );
 
   /** Close the dialog with a positive result */
   protected onConfirm(): void {

--- a/src/app/upload/features/upload-box-mapping/upload-box-mapping-confirm-dialog.ts
+++ b/src/app/upload/features/upload-box-mapping/upload-box-mapping-confirm-dialog.ts
@@ -58,9 +58,7 @@ export class UploadBoxMappingConfirmDialogComponent {
   protected confirmed = signal<boolean>(false);
 
   /** Whether the confirm button should be enabled */
-  protected canConfirm = computed<boolean>(
-    () => this.confirmed() && this.data.unmappedBoxFileAliases.length === 0,
-  );
+  protected canConfirm = computed<boolean>(() => this.confirmed());
 
   /** Close the dialog with a positive result */
   protected onConfirm(): void {

--- a/src/app/upload/features/upload-box-mapping/upload-box-mapping.html
+++ b/src/app/upload/features/upload-box-mapping/upload-box-mapping.html
@@ -73,7 +73,7 @@
             <mat-radio-group
               [value]="pendingMappedField() ?? null"
               (change)="pendingMappedField.set($event.value)"
-              class="flex gap-4"
+              class="flex gap-4 larger-mat-radio-label"
             >
               <mat-radio-button value="alias">File alias</mat-radio-button>
               <mat-radio-button value="name">File name</mat-radio-button>
@@ -198,7 +198,10 @@
                           (ngModelChange)="inlineInputValue.set($event)"
                           [matAutocomplete]="autocomplete"
                           [attr.aria-label]="
-                            'Map upload box file for ' + row.metadataFile.alias
+                            'Map upload box file for ' +
+                            (committedMappedField() === 'name'
+                              ? row.metadataFile.name
+                              : row.metadataFile.alias)
                           "
                           placeholder="Type or select file name in upload box…"
                           (keydown.enter)="commitInlineEdit(row)"
@@ -285,11 +288,7 @@
                   <mat-icon fontIcon="refresh" />
                   Reset
                 </button>
-                <button
-                  mat-stroked-button
-                  [disabled]="!canCancel()"
-                  (click)="onCancel()"
-                >
+                <button mat-stroked-button (click)="onCancel()">
                   <mat-icon fontIcon="cancel" />
                   Cancel
                 </button>
@@ -297,7 +296,7 @@
             </div>
           } @else if (pendingMappedField()) {
             <div class="flex flex-wrap items-center gap-3">
-              <button mat-stroked-button [disabled]="!canCancel()" (click)="onCancel()">
+              <button mat-stroked-button (click)="onCancel()">
                 <mat-icon fontIcon="cancel" />
                 Cancel
               </button>

--- a/src/app/upload/features/upload-box-mapping/upload-box-mapping.html
+++ b/src/app/upload/features/upload-box-mapping/upload-box-mapping.html
@@ -285,15 +285,18 @@
                   mat-stroked-button
                   [disabled]="!canCancel()"
                   (click)="onCancel()"
-                  >Cancel</button
                 >
+                  <mat-icon fontIcon="cancel" />
+                  Cancel
+                </button>
               </div>
             </div>
           } @else if (pendingMappedField()) {
             <div class="flex flex-wrap items-center gap-3">
-              <button mat-stroked-button [disabled]="!canCancel()" (click)="onCancel()"
-                >Cancel</button
-              >
+              <button mat-stroked-button [disabled]="!canCancel()" (click)="onCancel()">
+                <mat-icon fontIcon="cancel" />
+                Cancel
+              </button>
             </div>
           }
         </div>

--- a/src/app/upload/features/upload-box-mapping/upload-box-mapping.html
+++ b/src/app/upload/features/upload-box-mapping/upload-box-mapping.html
@@ -74,14 +74,13 @@
               [value]="pendingMappedField() ?? null"
               (change)="pendingMappedField.set($event.value)"
               class="flex gap-4"
-              style="--mat-radio-label-text-size: 1rem"
             >
               <mat-radio-button value="alias">File alias</mat-radio-button>
               <mat-radio-button value="name">File name</mat-radio-button>
             </mat-radio-group>
           </div>
 
-          <!-- File counts summary and filter/table/buttons (only when field is committed) -->
+          <!-- File counts summary, filter, table, and buttons (only when field is committed) -->
           @if (committedMappedField()) {
             <div class="flex text-base">
               <span class="w-1/2 pl-4"
@@ -111,10 +110,8 @@
                 </button>
               }
             </mat-form-field>
-          }
 
-          <!-- Mapping table -->
-          @if (committedMappedField()) {
+            <!-- Mapping table -->
             <div class="overflow-x-auto">
               <table
                 mat-table
@@ -200,6 +197,9 @@
                           [ngModel]="inlineInputValue()"
                           (ngModelChange)="inlineInputValue.set($event)"
                           [matAutocomplete]="autocomplete"
+                          [attr.aria-label]="
+                            'Map upload box file for ' + row.metadataFile.alias
+                          "
                           placeholder="Type or select file name in upload box…"
                           (keydown.enter)="commitInlineEdit(row)"
                           (keydown.escape)="editingMetaAccession.set(null)"
@@ -233,6 +233,12 @@
                         [title]="
                           'Click to ' + (row.boxFile ? 'change' : 'set') + ' mapping'
                         "
+                        [attr.aria-label]="
+                          'Click to ' +
+                          (row.boxFile ? 'change' : 'set') +
+                          ' mapping for ' +
+                          row.metadataFile.alias
+                        "
                       >
                         @if (row.boxFile) {
                           <span
@@ -262,10 +268,8 @@
                 aria-label="Select page of file mappings"
               ></mat-paginator>
             </div>
-          }
 
-          <!-- Action buttons -->
-          @if (committedMappedField()) {
+            <!-- Action buttons -->
             <div class="mt-4 flex w-full flex-wrap items-center justify-between gap-3">
               <button
                 mat-raised-button

--- a/src/app/upload/features/upload-box-mapping/upload-box-mapping.html
+++ b/src/app/upload/features/upload-box-mapping/upload-box-mapping.html
@@ -98,7 +98,7 @@
                 matInput
                 [ngModel]="filterText()"
                 (ngModelChange)="filterText.set($event)"
-                placeholder="Type to filter…"
+                placeholder="Type part of filename or extension to filter…"
               />
               @if (filterText()) {
                 <button
@@ -200,7 +200,7 @@
                           [ngModel]="inlineInputValue()"
                           (ngModelChange)="inlineInputValue.set($event)"
                           [matAutocomplete]="autocomplete"
-                          placeholder="Type file name…"
+                          placeholder="Type or select file name in upload box…"
                           (keydown.enter)="commitInlineEdit(row)"
                           (keydown.escape)="editingMetaAccession.set(null)"
                         />
@@ -241,7 +241,7 @@
                             >{{ row.boxFile.alias }}</span
                           >
                         } @else {
-                          <span class="text-warning italic">not mapped</span>
+                          <span class="text-warning italic">unmapped</span>
                         }
                         <mat-icon
                           fontIcon="change_circle"

--- a/src/app/upload/features/upload-box-mapping/upload-box-mapping.html
+++ b/src/app/upload/features/upload-box-mapping/upload-box-mapping.html
@@ -136,7 +136,7 @@
                       <span class="pr-2">Name in Experimental Metadata</span>
                       <span class="mt-1 flex gap-4 pr-2 text-sm font-normal">
                         @if (mappedMetaCount() > 0) {
-                          <span class="text-success"
+                          <span class="text-gray-700"
                             >Mapped: {{ mappedMetaCount() }}</span
                           >
                         }
@@ -170,16 +170,16 @@
                       <span class="mt-1 flex gap-4 pr-2 text-sm font-normal">
                         @if (exactMatchCount() > 0) {
                           <span class="text-success"
-                            >Exact: {{ exactMatchCount() }}</span
+                            >Matches: {{ exactMatchCount() }}</span
                           >
                         }
                         @if (manualMappingCount() > 0) {
-                          <span class="text-primary"
+                          <span class="text-blue-700"
                             >Manual: {{ manualMappingCount() }}</span
                           >
                         }
                         @if (unmappedBoxCount() > 0) {
-                          <span class="text-warning"
+                          <span class="text-error"
                             >Unmapped: {{ unmappedBoxCount() }}</span
                           >
                         }
@@ -237,7 +237,7 @@
                         @if (row.boxFile) {
                           <span
                             [class.text-success]="row.mappingType === 'exact'"
-                            [class.text-primary]="row.mappingType === 'manual'"
+                            [class.text-blue-700]="row.mappingType === 'manual'"
                             >{{ row.boxFile.alias }}</span
                           >
                         } @else {

--- a/src/app/upload/features/upload-box-mapping/upload-box-mapping.html
+++ b/src/app/upload/features/upload-box-mapping/upload-box-mapping.html
@@ -277,16 +277,23 @@
                 Confirm mapping and archive
               </button>
               <div class="flex gap-3">
-                <button mat-stroked-button (click)="onReset()">
+                <button mat-stroked-button [disabled]="!canReset()" (click)="onReset()">
                   <mat-icon fontIcon="refresh" />
                   Reset
                 </button>
-                <button mat-stroked-button (click)="onCancel()">Cancel</button>
+                <button
+                  mat-stroked-button
+                  [disabled]="!canCancel()"
+                  (click)="onCancel()"
+                  >Cancel</button
+                >
               </div>
             </div>
           } @else if (pendingMappedField()) {
             <div class="flex flex-wrap items-center gap-3">
-              <button mat-stroked-button (click)="onCancel()">Cancel</button>
+              <button mat-stroked-button [disabled]="!canCancel()" (click)="onCancel()"
+                >Cancel</button
+              >
             </div>
           }
         </div>

--- a/src/app/upload/features/upload-box-mapping/upload-box-mapping.html
+++ b/src/app/upload/features/upload-box-mapping/upload-box-mapping.html
@@ -1,0 +1,296 @@
+<div class="flex flex-col gap-4">
+  <!-- Study card -->
+  <mat-card>
+    <mat-card-header>
+      <mat-card-title><h2>Study</h2></mat-card-title>
+    </mat-card-header>
+
+    <mat-card-content>
+      @if (selectedStudy(); as study) {
+        <!-- Study details with change button -->
+        <p class="flex items-center">
+          <strong class="inline-block w-40">Accession:</strong>
+          <a [routerLink]="['/study', study.accession]" class="text-primary">{{
+            study.accession
+          }}</a>
+          <button
+            mat-icon-button
+            class="ml-2"
+            title="Select a different study"
+            aria-label="Select a different study"
+            (click)="onChangeStudy()"
+          >
+            <mat-icon fontIcon="change_circle" />
+          </button>
+        </p>
+        <p>
+          <strong class="inline-block w-40">Title:</strong>
+          <span>{{ study.title }}</span>
+        </p>
+        <p class="flex">
+          <strong class="inline-block min-w-40">Description:</strong>
+          <span>{{ study.description }}</span>
+        </p>
+        <p>
+          <strong class="inline-block w-40">Datasets:</strong>
+          <span>{{ study.datasets.length }}</span>
+        </p>
+      } @else {
+        <!-- Intro text + study selector -->
+        <p
+          >In order to establish a mapping from the uploaded files to the Experimental
+          Metadata, you need to select the corresponding study.</p
+        >
+        <mat-form-field appearance="outline" class="w-full">
+          <mat-select
+            [value]="selectedStudyAccession()"
+            (valueChange)="selectedStudyAccession.set($event)"
+            placeholder="Please select the study corresponding to this upload box"
+          >
+            @for (study of studiesArray(); track study.accession) {
+              <mat-option [value]="study.accession">
+                {{ study.accession }}: {{ study.title }}
+              </mat-option>
+            }
+          </mat-select>
+        </mat-form-field>
+      }
+    </mat-card-content>
+  </mat-card>
+
+  <!-- File Mapping card (only shown when a study is selected) -->
+  @if (selectedStudyAccession()) {
+    <mat-card>
+      <mat-card-header>
+        <mat-card-title><h2>File Mapping</h2></mat-card-title>
+      </mat-card-header>
+
+      <mat-card-content>
+        <div class="flex flex-col gap-4">
+          <!-- Mapped field selector -->
+          <div class="flex items-center gap-4">
+            <span class="font-medium">Mapped field in Experimental Metadata:</span>
+            <mat-radio-group
+              [value]="pendingMappedField() ?? null"
+              (change)="pendingMappedField.set($event.value)"
+              class="flex gap-4"
+              style="--mat-radio-label-text-size: 1rem"
+            >
+              <mat-radio-button value="alias">File alias</mat-radio-button>
+              <mat-radio-button value="name">File name</mat-radio-button>
+            </mat-radio-group>
+          </div>
+
+          <!-- File counts summary and filter/table/buttons (only when field is committed) -->
+          @if (committedMappedField()) {
+            <div class="flex text-base">
+              <span class="w-1/2 pl-4"
+                ><strong>Files in Experimental Metadata:</strong>
+                {{ metadataFiles().length }}</span
+              >
+              <span class="w-1/2 pl-4"
+                ><strong>Files in Upload Box:</strong> {{ boxFiles().length }}</span
+              >
+            </div>
+            <mat-form-field appearance="outline" class="mt-2 w-full">
+              <mat-label>Filter by part of filename or extension</mat-label>
+              <input
+                matInput
+                [ngModel]="filterText()"
+                (ngModelChange)="filterText.set($event)"
+                placeholder="Type to filter…"
+              />
+              @if (filterText()) {
+                <button
+                  matSuffix
+                  mat-icon-button
+                  aria-label="Clear filter"
+                  (click)="filterText.set('')"
+                >
+                  <mat-icon fontIcon="close" />
+                </button>
+              }
+            </mat-form-field>
+          }
+
+          <!-- Mapping table -->
+          @if (committedMappedField()) {
+            <div class="overflow-x-auto">
+              <table
+                mat-table
+                matSort
+                matSortActive="metadataName"
+                matSortDirection="asc"
+                [dataSource]="tableDataSource"
+                class="w-full"
+              >
+                <!-- Metadata file name column -->
+                <ng-container matColumnDef="metadataName">
+                  <th
+                    mat-header-cell
+                    *matHeaderCellDef
+                    mat-sort-header
+                    class="w-1/2 !py-3"
+                  >
+                    <div class="flex w-full flex-col">
+                      <span class="pr-2">Name in Experimental Metadata</span>
+                      <span class="mt-1 flex gap-4 pr-2 text-sm font-normal">
+                        @if (mappedMetaCount() > 0) {
+                          <span class="text-success"
+                            >Mapped: {{ mappedMetaCount() }}</span
+                          >
+                        }
+                        @if (unmappedMetaCount() > 0) {
+                          <span class="text-warning"
+                            >Unmapped: {{ unmappedMetaCount() }}</span
+                          >
+                        }
+                      </span>
+                    </div>
+                  </th>
+                  <td mat-cell *matCellDef="let row" class="py-1">
+                    {{
+                      committedMappedField() === 'alias'
+                        ? row.metadataFile.alias
+                        : row.metadataFile.name
+                    }}
+                  </td>
+                </ng-container>
+
+                <!-- Upload box file name column -->
+                <ng-container matColumnDef="boxFileName">
+                  <th
+                    mat-header-cell
+                    *matHeaderCellDef
+                    mat-sort-header
+                    class="w-1/2 !py-3"
+                  >
+                    <div class="flex w-full flex-col">
+                      <span class="pr-2">Name in Upload Box</span>
+                      <span class="mt-1 flex gap-4 pr-2 text-sm font-normal">
+                        @if (exactMatchCount() > 0) {
+                          <span class="text-success"
+                            >Exact: {{ exactMatchCount() }}</span
+                          >
+                        }
+                        @if (manualMappingCount() > 0) {
+                          <span class="text-primary"
+                            >Manual: {{ manualMappingCount() }}</span
+                          >
+                        }
+                        @if (unmappedBoxCount() > 0) {
+                          <span class="text-warning"
+                            >Unmapped: {{ unmappedBoxCount() }}</span
+                          >
+                        }
+                      </span>
+                    </div>
+                  </th>
+                  <td mat-cell *matCellDef="let row" class="py-1">
+                    @if (editingMetaAccession() === row.metadataFile.accession) {
+                      <!-- Inline autocomplete editor -->
+                      <mat-form-field
+                        appearance="outline"
+                        class="w-full"
+                        subscriptSizing="dynamic"
+                      >
+                        <input
+                          #inlineInput
+                          matInput
+                          [ngModel]="inlineInputValue()"
+                          (ngModelChange)="inlineInputValue.set($event)"
+                          [matAutocomplete]="autocomplete"
+                          placeholder="Type file name…"
+                          (keydown.enter)="commitInlineEdit(row)"
+                          (keydown.escape)="editingMetaAccession.set(null)"
+                        />
+                        <mat-autocomplete
+                          #autocomplete="matAutocomplete"
+                          [displayWith]="displayBoxFileAlias"
+                          (optionSelected)="
+                            inlineInputValue.set($event.option.value.alias);
+                            commitInlineEdit(row)
+                          "
+                        >
+                          @for (opt of autocompleteOptions(); track opt.id) {
+                            <mat-option [value]="opt">{{ opt.alias }}</mat-option>
+                          }
+                        </mat-autocomplete>
+                        <button
+                          matSuffix
+                          mat-icon-button
+                          aria-label="Confirm"
+                          (click)="commitInlineEdit(row)"
+                        >
+                          <mat-icon fontIcon="check" />
+                        </button>
+                      </mat-form-field>
+                    } @else {
+                      <!-- Display mode with click-to-edit -->
+                      <button
+                        class="flex items-center gap-1 text-left"
+                        (click)="startEditing(row)"
+                        [title]="
+                          'Click to ' + (row.boxFile ? 'change' : 'set') + ' mapping'
+                        "
+                      >
+                        @if (row.boxFile) {
+                          <span
+                            [class.text-success]="row.mappingType === 'exact'"
+                            [class.text-primary]="row.mappingType === 'manual'"
+                            >{{ row.boxFile.alias }}</span
+                          >
+                        } @else {
+                          <span class="text-warning italic">not mapped</span>
+                        }
+                        <mat-icon
+                          fontIcon="change_circle"
+                          class="ml-2 !text-base opacity-50"
+                        />
+                      </button>
+                    }
+                  </td>
+                </ng-container>
+
+                <tr mat-header-row *matHeaderRowDef="columns"></tr>
+                <tr mat-row *matRowDef="let row; columns: columns"></tr>
+              </table>
+
+              <mat-paginator
+                [pageSizeOptions]="[10, 25, 50]"
+                showFirstLastButtons
+                aria-label="Select page of file mappings"
+              ></mat-paginator>
+            </div>
+          }
+
+          <!-- Action buttons -->
+          @if (committedMappedField()) {
+            <div class="mt-4 flex w-full flex-wrap items-center justify-between gap-3">
+              <button
+                mat-raised-button
+                color="primary"
+                [disabled]="!canConfirmAndArchive()"
+                (click)="onConfirmAndArchive()"
+              >
+                <mat-icon fontIcon="archive" />
+                Confirm mapping and archive
+              </button>
+              <div class="flex gap-3">
+                <button mat-stroked-button (click)="onReset()">
+                  <mat-icon fontIcon="refresh" />
+                  Reset
+                </button>
+                <button mat-stroked-button (click)="onCancel()">Cancel</button>
+              </div>
+            </div>
+          } @else if (pendingMappedField()) {
+            <div class="flex flex-wrap items-center gap-3">
+              <button mat-stroked-button (click)="onCancel()">Cancel</button>
+            </div>
+          }
+        </div>
+      </mat-card-content>
+    </mat-card>
+  }
+</div>

--- a/src/app/upload/features/upload-box-mapping/upload-box-mapping.ts
+++ b/src/app/upload/features/upload-box-mapping/upload-box-mapping.ts
@@ -31,7 +31,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatSort, MatSortModule } from '@angular/material/sort';
 import { MatTableDataSource, MatTableModule } from '@angular/material/table';
 import { RouterLink } from '@angular/router';
-import { concatMap, of, switchMap } from 'rxjs';
+import { catchError, concatMap, of, switchMap, throwError } from 'rxjs';
 
 import { EmFile } from '@app/metadata/models/dataset-information';
 import { Study } from '@app/metadata/models/study';
@@ -192,6 +192,9 @@ export class UploadBoxMappingComponent implements OnInit {
 
   /** Whether a mapping submission is in progress */
   isSubmitting = signal<boolean>(false);
+
+  /** Guard to prevent opening a second field-change confirmation dialog */
+  #fieldChangeDialogOpen = signal<boolean>(false);
 
   // Async data
 
@@ -447,17 +450,21 @@ export class UploadBoxMappingComponent implements OnInit {
   /**
    * Watch pending field changes; if manual mappings exist, ask for confirmation
    * before committing, otherwise commit immediately.
+   * A re-entry lock prevents a second dialog from opening while one is already
+   * open (e.g. if manualMappings changes reactively during dialog lifetime).
    */
   #fieldChangeEffect = effect(() => {
     const pending = this.pendingMappedField();
     const committed = this.committedMappedField();
     if (pending === committed) return;
+    if (this.#fieldChangeDialogOpen()) return;
 
     if (this.manualMappings().size === 0) {
       this.committedMappedField.set(pending);
       return;
     }
 
+    this.#fieldChangeDialogOpen.set(true);
     const ref = this.#dialog.open<ConfirmDialogComponent, ConfirmDialogData, boolean>(
       ConfirmDialogComponent,
       {
@@ -472,6 +479,7 @@ export class UploadBoxMappingComponent implements OnInit {
       },
     );
     ref.afterClosed().subscribe((confirmed) => {
+      this.#fieldChangeDialogOpen.set(false);
       if (confirmed) {
         this.manualMappings.set(new Map());
         this.committedMappedField.set(pending);
@@ -486,14 +494,6 @@ export class UploadBoxMappingComponent implements OnInit {
 
   /** @inheritdoc */
   ngOnInit(): void {
-    this.tableDataSource.sortingDataAccessor = (row, column) => {
-      if (column === 'metadataName') {
-        const field = this.committedMappedField();
-        return fileSortKey(field ? (row.metadataFile[field] ?? undefined) : undefined);
-      }
-      return fileSortKey(row.boxFile?.alias);
-    };
-
     const snapshot = this.#mappingStateService.snapshotFor(this.box().id);
     if (snapshot) {
       this.selectedStudyAccession.set(snapshot.studyAccession);
@@ -628,8 +628,9 @@ export class UploadBoxMappingComponent implements OnInit {
     const metaFiles = this.metadataFiles();
     const field = this.committedMappedField();
 
+    const unmappedBoxFileIds = this.unusedBoxFileIds();
     const unmappedBoxFileAliases = boxFiles
-      .filter((bf) => !Array.from(effective.values()).includes(bf.id))
+      .filter((bf) => unmappedBoxFileIds.has(bf.id))
       .map((bf) => bf.alias);
 
     const unmappedMetaFileNames = metaFiles
@@ -673,8 +674,11 @@ export class UploadBoxMappingComponent implements OnInit {
         mapping,
       })
       .pipe(
+        catchError(() => throwError(() => 'mapping' as const)),
         concatMap(() =>
-          this.#uploadBoxService.archiveUploadBox(box.id, box.version + 1),
+          this.#uploadBoxService
+            .archiveUploadBox(box.id, box.version + 1)
+            .pipe(catchError(() => throwError(() => 'archival' as const))),
         ),
       )
       .subscribe({
@@ -686,10 +690,12 @@ export class UploadBoxMappingComponent implements OnInit {
           );
           this.archived.emit();
         },
-        error: () => {
+        error: (phase: 'mapping' | 'archival') => {
           this.isSubmitting.set(false);
           this.#notificationService.showError(
-            'Failed to submit the file mapping. Please try again.',
+            phase === 'archival'
+              ? 'Mapping was submitted but archival failed.'
+              : 'Failed to submit the file mapping.',
           );
         },
       });

--- a/src/app/upload/features/upload-box-mapping/upload-box-mapping.ts
+++ b/src/app/upload/features/upload-box-mapping/upload-box-mapping.ts
@@ -45,15 +45,13 @@ import {
 } from '@app/shared/ui/confirm-dialog/confirm-dialog';
 import { ResearchDataUploadBox } from '@app/upload/models/box';
 import { FileUploadWithAccession } from '@app/upload/models/file-upload';
+import { MappedField } from '@app/upload/models/mapping';
 import { UploadBoxService } from '@app/upload/services/upload-box';
 import { UploadBoxMappingStateService } from '@app/upload/services/upload-box-mapping-state';
 import {
   MappingConfirmDialogData,
   UploadBoxMappingConfirmDialogComponent,
 } from './upload-box-mapping-confirm-dialog';
-
-/** The metadata field to use for matching */
-export type MappedField = 'alias' | 'name';
 
 /** A single row in the mapping table */
 export interface MappingRow {

--- a/src/app/upload/features/upload-box-mapping/upload-box-mapping.ts
+++ b/src/app/upload/features/upload-box-mapping/upload-box-mapping.ts
@@ -359,7 +359,16 @@ export class UploadBoxMappingComponent implements OnInit {
     const currentBoxId = editingAcc
       ? this.effectiveMappings().get(editingAcc)
       : undefined;
-    const query = this.inlineInputValue().toLowerCase();
+    const query = this.inlineInputValue().toLowerCase().trim();
+
+    // Derive the metadata field value for this row so we can float
+    // name-matching candidates to the top even when no text is typed.
+    const field = this.committedMappedField();
+    const editingMetaFile = editingAcc
+      ? this.metadataFiles().find((f) => f.accession === editingAcc)
+      : undefined;
+    const metaValue =
+      editingMetaFile && field ? (editingMetaFile[field] ?? '').toLowerCase() : '';
 
     const candidates = this.boxFiles().filter(
       (bf) => unused.has(bf.id) || bf.id === currentBoxId,
@@ -368,8 +377,21 @@ export class UploadBoxMappingComponent implements OnInit {
     return candidates.sort((a, b) => {
       const aAlias = a.alias.toLowerCase();
       const bAlias = b.alias.toLowerCase();
-      const aStarts = aAlias.startsWith(query);
-      const bStarts = bAlias.startsWith(query);
+      // Tier 1: name-field exact match (or typed exact match) — absolute top
+      const aNameMatch =
+        (metaValue !== '' && aAlias === metaValue) ||
+        (query !== '' && aAlias === query);
+      const bNameMatch =
+        (metaValue !== '' && bAlias === metaValue) ||
+        (query !== '' && bAlias === query);
+      if (aNameMatch !== bNameMatch) return aNameMatch ? -1 : 1;
+      // Tier 2: currently-mapped file
+      const aMapped = a.id === currentBoxId;
+      const bMapped = b.id === currentBoxId;
+      if (aMapped !== bMapped) return aMapped ? -1 : 1;
+      // Tier 3: prefix matches when the user has typed something
+      const aStarts = query !== '' && aAlias.startsWith(query);
+      const bStarts = query !== '' && bAlias.startsWith(query);
       if (aStarts !== bStarts) return aStarts ? -1 : 1;
       return fileSortKey(a.alias).localeCompare(fileSortKey(b.alias));
     });

--- a/src/app/upload/features/upload-box-mapping/upload-box-mapping.ts
+++ b/src/app/upload/features/upload-box-mapping/upload-box-mapping.ts
@@ -1,0 +1,694 @@
+/**
+ * File mapping card component for the upload box manager detail page.
+ * @copyright The GHGA Authors
+ * @license Apache-2.0
+ */
+
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  input,
+  OnInit,
+  output,
+  signal,
+  viewChild,
+} from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { FormsModule } from '@angular/forms';
+import { MatAutocompleteModule } from '@angular/material/autocomplete';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatDialog } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
+import { MatRadioModule } from '@angular/material/radio';
+import { MatSelectModule } from '@angular/material/select';
+import { MatSort, MatSortModule } from '@angular/material/sort';
+import { MatTableDataSource, MatTableModule } from '@angular/material/table';
+import { RouterLink } from '@angular/router';
+import { of, switchMap } from 'rxjs';
+
+import { EmFile } from '@app/metadata/models/dataset-information';
+import { Study } from '@app/metadata/models/study';
+import { MetadataService } from '@app/metadata/services/metadata';
+import { MetadataSearchService } from '@app/metadata/services/metadata-search';
+import { NotificationService } from '@app/shared/services/notification';
+import {
+  ConfirmDialogComponent,
+  ConfirmDialogData,
+} from '@app/shared/ui/confirm-dialog/confirm-dialog';
+import { ResearchDataUploadBox } from '@app/upload/models/box';
+import { FileUploadWithAccession } from '@app/upload/models/file-upload';
+import { UploadBoxService } from '@app/upload/services/upload-box';
+import {
+  MappingConfirmDialogData,
+  UploadBoxMappingConfirmDialogComponent,
+} from './upload-box-mapping-confirm-dialog';
+
+/** The metadata field to use for matching */
+export type MappedField = 'alias' | 'name';
+
+/** A single row in the mapping table */
+export interface MappingRow {
+  /** The metadata file entry */
+  metadataFile: EmFile;
+  /** The matched upload-box file, if any */
+  boxFile: FileUploadWithAccession | undefined;
+  /** How the mapping was established */
+  mappingType: 'exact' | 'manual' | 'none';
+}
+
+/**
+ * Sort key for a filename: "{extension}:{basename}" for grouping by extension
+ * @param filename - the filename to generate a sort key for
+ * @returns a string key that groups files by extension then sorts alphabetically
+ */
+function fileSortKey(filename: string | undefined): string {
+  if (!filename) return '\xff'; // sort absent names last
+  const lower = filename.toLowerCase();
+  const dot = lower.lastIndexOf('.');
+  if (dot < 0) return `\xfe:${lower}`; // files without extension sort just above absent
+  return `${lower.slice(dot + 1)}:${lower}`;
+}
+
+/**
+ * Compute automatic mappings between metadata files and upload-box files.
+ * Case-sensitive exact match takes priority; falls back to the single
+ * case-insensitive match if exactly one exists. Box files are not reused.
+ * @param metaFiles - metadata files to match
+ * @param boxFiles - upload-box files to match against
+ * @param field - which metadata field to compare against the box file alias
+ * @returns Map from metadata file accession to matched box file ID
+ */
+function computeAutoMappings(
+  metaFiles: EmFile[],
+  boxFiles: FileUploadWithAccession[],
+  field: MappedField | undefined,
+): Map<string, string> {
+  const result = new Map<string, string>();
+  if (!field || !metaFiles.length || !boxFiles.length) return result;
+
+  const usedBoxIds = new Set<string>();
+
+  for (const meta of metaFiles) {
+    const metaValue = meta[field];
+    if (!metaValue) continue;
+
+    // Case-sensitive exact match
+    const exact = boxFiles.find(
+      (bf) => bf.alias === metaValue && !usedBoxIds.has(bf.id),
+    );
+    if (exact) {
+      result.set(meta.accession, exact.id);
+      usedBoxIds.add(exact.id);
+      continue;
+    }
+
+    // Case-insensitive single match
+    const lower = metaValue.toLowerCase();
+    const caseMatches = boxFiles.filter(
+      (bf) => bf.alias.toLowerCase() === lower && !usedBoxIds.has(bf.id),
+    );
+    if (caseMatches.length === 1) {
+      result.set(meta.accession, caseMatches[0].id);
+      usedBoxIds.add(caseMatches[0].id);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Embedded card for establishing a mapping between metadata file accessions
+ * and upload box file IDs. Appears automatically when the box state is "locked".
+ */
+@Component({
+  selector: 'app-upload-box-mapping',
+  imports: [
+    FormsModule,
+    MatAutocompleteModule,
+    MatButtonModule,
+    MatCardModule,
+    MatFormFieldModule,
+    MatIconModule,
+    MatInputModule,
+    MatPaginatorModule,
+    MatRadioModule,
+    MatSelectModule,
+    MatSortModule,
+    MatTableModule,
+    RouterLink,
+  ],
+  providers: [MetadataService],
+  templateUrl: './upload-box-mapping.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class UploadBoxMappingComponent implements OnInit {
+  #uploadBoxService = inject(UploadBoxService);
+  #metadataSearchService = inject(MetadataSearchService);
+  #metadataService = inject(MetadataService);
+  #dialog = inject(MatDialog);
+  #notificationService = inject(NotificationService);
+
+  /** The locked upload box */
+  box = input.required<ResearchDataUploadBox>();
+
+  /** Emitted after a successful mapping submission */
+  archived = output<void>();
+
+  /** Currently selected study accession */
+  selectedStudyAccession = signal<string | undefined>(undefined);
+
+  /** The metadata field currently committed for auto-matching */
+  committedMappedField = signal<MappedField | undefined>(undefined);
+
+  /**
+   * The metadata field value bound to the dropdown.
+   * Changes are staged here and committed (with confirmation) via an effect.
+   */
+  pendingMappedField = signal<MappedField | undefined>(undefined);
+
+  /** Text used to filter table rows */
+  filterText = signal<string>('');
+
+  /**
+   * Manual mappings: meta accession → box file ID.
+   * A `null` value means the mapping was explicitly cleared.
+   */
+  manualMappings = signal<Map<string, string | null>>(new Map());
+
+  /** The metadata file accession currently open for inline editing */
+  editingMetaAccession = signal<string | null>(null);
+
+  /** The current text value in the inline editor */
+  inlineInputValue = signal<string>('');
+
+  /** Whether a mapping submission is in progress */
+  isSubmitting = signal<boolean>(false);
+
+  // Async data
+
+  private readonly studiesMap$ = this.#metadataSearchService.loadStudiesMap();
+
+  /** All available studies, keyed by accession */
+  studiesMap = toSignal(this.studiesMap$, { initialValue: new Map<string, Study>() });
+
+  /** Studies as a sorted array for the dropdown */
+  studiesArray = computed(() =>
+    Array.from(this.studiesMap().values()).sort((a, b) =>
+      a.accession.localeCompare(b.accession),
+    ),
+  );
+
+  /** The currently selected Study object */
+  selectedStudy = computed<Study | undefined>(() =>
+    this.studiesMap().get(this.selectedStudyAccession() ?? ''),
+  );
+
+  /** Files from the selected study in metadata */
+  metadataFiles = toSignal(
+    toObservable(this.selectedStudy).pipe(
+      switchMap((study) =>
+        study ? this.#metadataService.filesOfStudy(study) : of([]),
+      ),
+    ),
+    { initialValue: [] as EmFile[] },
+  );
+
+  /** Files in the upload box */
+  boxFiles = computed<FileUploadWithAccession[]>(() =>
+    this.#uploadBoxService.boxFileUploads.value(),
+  );
+
+  // Derived mappings
+
+  /** Auto-matched mappings from metadata accession to box file ID */
+  autoMappings = computed<Map<string, string>>(() =>
+    computeAutoMappings(
+      this.metadataFiles(),
+      this.boxFiles(),
+      this.committedMappedField(),
+    ),
+  );
+
+  /**
+   * Effective mapping: manual entries override auto entries.
+   * `null` values in manualMappings explicitly clear an auto-match.
+   */
+  effectiveMappings = computed<Map<string, string>>(() => {
+    const auto = this.autoMappings();
+    const manual = this.manualMappings();
+    const result = new Map(auto);
+    for (const [acc, boxId] of manual) {
+      if (boxId === null) {
+        result.delete(acc);
+      } else {
+        result.set(acc, boxId);
+      }
+    }
+    return result;
+  });
+
+  /** Box file IDs that are not yet claimed by any mapping */
+  unusedBoxFileIds = computed<Set<string>>(() => {
+    const usedIds = new Set(this.effectiveMappings().values());
+    return new Set(
+      this.boxFiles()
+        .filter((bf) => !usedIds.has(bf.id))
+        .map((bf) => bf.id),
+    );
+  });
+
+  // Stats
+
+  /** Number of metadata files that have an effective mapping */
+  mappedMetaCount = computed(
+    () =>
+      this.metadataFiles().filter((f) => this.effectiveMappings().has(f.accession))
+        .length,
+  );
+
+  /** Number of metadata files without an effective mapping */
+  unmappedMetaCount = computed(
+    () => this.metadataFiles().length - this.mappedMetaCount(),
+  );
+
+  /** Number of mappings that came from auto-matching (exact) */
+  exactMatchCount = computed(() => {
+    let count = 0;
+    const auto = this.autoMappings();
+    const manual = this.manualMappings();
+    for (const [acc, boxId] of auto) {
+      // still effectively mapped by auto (not overridden by manual)
+      if (!manual.has(acc) || manual.get(acc) === boxId) count++;
+    }
+    return count;
+  });
+
+  /** Number of manually established mappings (different from auto) */
+  manualMappingCount = computed(() => {
+    let count = 0;
+    const auto = this.autoMappings();
+    const manual = this.manualMappings();
+    for (const [acc, boxId] of manual) {
+      if (boxId !== null && auto.get(acc) !== boxId) count++;
+    }
+    return count;
+  });
+
+  /** Number of box files not referenced by any mapping */
+  unmappedBoxCount = computed(() => this.unusedBoxFileIds().size);
+
+  // Table rows
+
+  private readonly boxFileById = computed<Map<string, FileUploadWithAccession>>(() => {
+    return new Map(this.boxFiles().map((bf) => [bf.id, bf]));
+  });
+
+  /** All rows (unfiltered) */
+  mappingRows = computed<MappingRow[]>(() => {
+    const effective = this.effectiveMappings();
+    const auto = this.autoMappings();
+    const manual = this.manualMappings();
+    const byId = this.boxFileById();
+
+    return this.metadataFiles().map((meta) => {
+      const boxFileId = effective.get(meta.accession);
+      const boxFile = boxFileId ? byId.get(boxFileId) : undefined;
+
+      let mappingType: MappingRow['mappingType'] = 'none';
+      if (boxFileId) {
+        const manualEntry = manual.get(meta.accession);
+        const isManuallySet = manualEntry !== undefined && manualEntry !== null;
+        const isAutoMatch =
+          auto.has(meta.accession) && auto.get(meta.accession) === boxFileId;
+        mappingType = !isManuallySet && isAutoMatch ? 'exact' : 'manual';
+      }
+
+      return { metadataFile: meta, boxFile, mappingType };
+    });
+  });
+
+  /** Rows filtered by the current filterText */
+  filteredRows = computed<MappingRow[]>(() => {
+    const filter = this.filterText().trim().toLowerCase();
+    if (!filter) return this.mappingRows();
+    return this.mappingRows().filter((row) => {
+      const field = this.committedMappedField();
+      const metaName = field ? (row.metadataFile[field] ?? '') : '';
+      return (
+        metaName.toLowerCase().includes(filter) ||
+        (row.boxFile?.alias ?? '').toLowerCase().includes(filter)
+      );
+    });
+  });
+
+  // Autocomplete options for inline editor
+
+  /** Options for the inline autocomplete, sorted with prefix matches first */
+  autocompleteOptions = computed<FileUploadWithAccession[]>(() => {
+    const unused = this.unusedBoxFileIds();
+    const editingAcc = this.editingMetaAccession();
+    const currentBoxId = editingAcc
+      ? this.effectiveMappings().get(editingAcc)
+      : undefined;
+    const query = this.inlineInputValue().toLowerCase();
+
+    const candidates = this.boxFiles().filter(
+      (bf) => unused.has(bf.id) || bf.id === currentBoxId,
+    );
+
+    return candidates.sort((a, b) => {
+      const aAlias = a.alias.toLowerCase();
+      const bAlias = b.alias.toLowerCase();
+      const aStarts = aAlias.startsWith(query);
+      const bStarts = bAlias.startsWith(query);
+      if (aStarts !== bStarts) return aStarts ? -1 : 1;
+      return fileSortKey(a.alias).localeCompare(fileSortKey(b.alias));
+    });
+  });
+
+  // Table datasource, sort, and paginator
+
+  readonly tableDataSource = new MatTableDataSource<MappingRow>([]);
+  readonly columns = ['metadataName', 'boxFileName'] as const;
+
+  private readonly tableSort = viewChild(MatSort);
+  private readonly tablePaginator = viewChild(MatPaginator);
+
+  // Effects
+
+  /** Keep table data in sync with filtered rows */
+  #syncTableEffect = effect(() => {
+    this.tableDataSource.data = this.filteredRows();
+  });
+
+  /** Assign paginator once it's available */
+  #assignPaginatorEffect = effect(() => {
+    const paginator = this.tablePaginator();
+    if (paginator) this.tableDataSource.paginator = paginator;
+  });
+
+  /** Assign sort once it's available */
+  #assignSortEffect = effect(() => {
+    const sort = this.tableSort();
+    if (sort) {
+      this.tableDataSource.sort = sort;
+      this.tableDataSource.sortingDataAccessor = (row, column) => {
+        if (column === 'metadataName') {
+          const field = this.committedMappedField();
+          return fileSortKey(
+            field ? (row.metadataFile[field] ?? undefined) : undefined,
+          );
+        }
+        return fileSortKey(row.boxFile?.alias);
+      };
+    }
+  });
+
+  /**
+   * Watch pending field changes; if manual mappings exist, ask for confirmation
+   * before committing, otherwise commit immediately.
+   */
+  #fieldChangeEffect = effect(() => {
+    const pending = this.pendingMappedField();
+    const committed = this.committedMappedField();
+    if (pending === committed) return;
+
+    if (this.manualMappings().size === 0) {
+      this.committedMappedField.set(pending);
+      return;
+    }
+
+    const ref = this.#dialog.open<ConfirmDialogComponent, ConfirmDialogData, boolean>(
+      ConfirmDialogComponent,
+      {
+        data: {
+          title: 'Change mapped field',
+          message:
+            'Changing the mapped field will discard all manual mappings. Do you want to proceed?',
+          confirmText: 'Change field',
+          cancelText: 'Keep editing',
+          confirmClass: 'button-error',
+        },
+      },
+    );
+    ref.afterClosed().subscribe((confirmed) => {
+      if (confirmed) {
+        this.manualMappings.set(new Map());
+        this.committedMappedField.set(pending);
+      } else {
+        // revert dropdown to committed value
+        this.pendingMappedField.set(committed);
+      }
+    });
+  });
+
+  // Lifecycle
+
+  /** @inheritdoc */
+  ngOnInit(): void {
+    this.tableDataSource.sortingDataAccessor = (row, column) => {
+      if (column === 'metadataName') {
+        const field = this.committedMappedField();
+        return fileSortKey(field ? (row.metadataFile[field] ?? undefined) : undefined);
+      }
+      return fileSortKey(row.boxFile?.alias);
+    };
+  }
+
+  // Row editing
+
+  /**
+   * Open the inline editor for a given row.
+   * @param row - the mapping row to edit
+   */
+  startEditing(row: MappingRow): void {
+    this.editingMetaAccession.set(row.metadataFile.accession);
+    this.inlineInputValue.set(row.boxFile?.alias ?? '');
+  }
+
+  /**
+   * Commit the inline editor value for a given row.
+   * Accepts the entered alias if it matches an unused box file (or the current
+   * mapping). An empty string explicitly clears the mapping.
+   * Invalid input silently reverts.
+   * @param row - the mapping row being edited
+   */
+  commitInlineEdit(row: MappingRow): void {
+    const alias = this.inlineInputValue().trim();
+    const acc = row.metadataFile.accession;
+
+    if (alias === '') {
+      // Explicitly clear the mapping
+      const updated = new Map(this.manualMappings());
+      updated.set(acc, null);
+      this.manualMappings.set(updated);
+    } else {
+      // Find a matching box file
+      const lower = alias.toLowerCase();
+      const exact = this.boxFiles().find((bf) => bf.alias === alias);
+      const caseMatch = exact
+        ? exact
+        : this.boxFiles().filter((bf) => bf.alias.toLowerCase() === lower);
+      const match =
+        exact ??
+        (Array.isArray(caseMatch) && caseMatch.length === 1 ? caseMatch[0] : undefined);
+
+      if (match) {
+        const isUnused = this.unusedBoxFileIds().has(match.id);
+        const isCurrent = this.effectiveMappings().get(acc) === match.id;
+
+        if (isUnused || isCurrent) {
+          const updated = new Map(this.manualMappings());
+          updated.set(acc, match.id);
+          this.manualMappings.set(updated);
+        }
+        // else: box file is already mapped elsewhere — silently revert
+      }
+      // else: alias not found in box — silently revert
+    }
+
+    this.editingMetaAccession.set(null);
+  }
+
+  // Actions
+
+  /**
+   * Reset manual mappings, optionally after user confirmation.
+   * Auto-mappings are recomputed automatically.
+   */
+  onReset(): void {
+    if (this.manualMappings().size === 0) {
+      return; // nothing to reset
+    }
+    const ref = this.#dialog.open<ConfirmDialogComponent, ConfirmDialogData, boolean>(
+      ConfirmDialogComponent,
+      {
+        data: {
+          title: 'Reset mappings',
+          message:
+            'This will discard all manually established mappings and restore the automatic matches. Do you want to proceed?',
+          confirmText: 'Reset',
+          cancelText: 'Keep editing',
+          confirmClass: 'button-error',
+        },
+      },
+    );
+    ref.afterClosed().subscribe((confirmed) => {
+      if (confirmed) this.manualMappings.set(new Map());
+    });
+  }
+
+  /**
+   * Cancel and reset the entire mapping form.
+   * Asks for confirmation if manual mappings exist.
+   */
+  onCancel(): void {
+    if (this.manualMappings().size > 0) {
+      const ref = this.#dialog.open<ConfirmDialogComponent, ConfirmDialogData, boolean>(
+        ConfirmDialogComponent,
+        {
+          data: {
+            title: 'Discard mappings',
+            message:
+              'You have established manual mappings that will be lost. Do you want to discard all mapping progress?',
+            confirmText: 'Discard',
+            cancelText: 'Keep editing',
+            confirmClass: 'button-error',
+          },
+        },
+      );
+      ref.afterClosed().subscribe((confirmed) => {
+        if (confirmed) this.#resetForm();
+      });
+    } else {
+      this.#resetForm();
+    }
+  }
+
+  /** Reset all form state back to initial values */
+  #resetForm(): void {
+    this.selectedStudyAccession.set(undefined);
+    this.committedMappedField.set(undefined);
+    this.pendingMappedField.set(undefined);
+    this.filterText.set('');
+    this.manualMappings.set(new Map());
+    this.editingMetaAccession.set(null);
+    this.inlineInputValue.set('');
+  }
+
+  /** Clear the selected study and all dependent mapping state */
+  onChangeStudy(): void {
+    if (this.manualMappings().size > 0) {
+      const ref = this.#dialog.open<ConfirmDialogComponent, ConfirmDialogData, boolean>(
+        ConfirmDialogComponent,
+        {
+          data: {
+            title: 'Change study',
+            message:
+              'You have established manual mappings that will be lost if you select a different study. Do you want to proceed?',
+            confirmText: 'Change study',
+            cancelText: 'Keep editing',
+            confirmClass: 'button-error',
+          },
+        },
+      );
+      ref.afterClosed().subscribe((confirmed) => {
+        if (confirmed) this.#resetForm();
+      });
+    } else {
+      this.#resetForm();
+    }
+  }
+
+  /**
+   * Open the confirmation dialog and, if confirmed, submit the mapping.
+   */
+  onConfirmAndArchive(): void {
+    const effective = this.effectiveMappings();
+    const boxFiles = this.boxFiles();
+    const metaFiles = this.metadataFiles();
+    const field = this.committedMappedField();
+
+    const unmappedBoxFileAliases = boxFiles
+      .filter((bf) => !Array.from(effective.values()).includes(bf.id))
+      .map((bf) => bf.alias);
+
+    const unmappedMetaFileNames = metaFiles
+      .filter((mf) => !effective.has(mf.accession))
+      .map((mf) => (field ? (mf[field] ?? mf.accession) : mf.accession));
+
+    const ref = this.#dialog.open<
+      UploadBoxMappingConfirmDialogComponent,
+      MappingConfirmDialogData,
+      boolean
+    >(UploadBoxMappingConfirmDialogComponent, {
+      data: { unmappedBoxFileAliases, unmappedMetaFileNames },
+      width: 'clamp(24rem, 90vw, 42rem)',
+    });
+
+    ref.afterClosed().subscribe((confirmed) => {
+      if (!confirmed) return;
+      this.#submitMapping(effective);
+    });
+  }
+
+  /**
+   * Build the request and POST it to the backend.
+   * @param effective - the final mapping to submit
+   */
+  #submitMapping(effective: Map<string, string>): void {
+    const studyId = this.selectedStudyAccession();
+    if (!studyId) return;
+
+    const mapping: Record<string, string> = {};
+    for (const [accession, boxFileId] of effective) {
+      mapping[accession] = boxFileId;
+    }
+
+    this.isSubmitting.set(true);
+    this.#uploadBoxService
+      .submitFileMapping(this.box().id, {
+        box_version: this.box().version,
+        study_id: studyId,
+        mapping,
+      })
+      .subscribe({
+        next: () => {
+          this.isSubmitting.set(false);
+          this.archived.emit();
+        },
+        error: () => {
+          this.isSubmitting.set(false);
+          this.#notificationService.showError(
+            'Failed to submit the file mapping. Please try again.',
+          );
+        },
+      });
+  }
+
+  /**
+   * Display function for the MatAutocomplete on the box file field.
+   * @param file - the selected file upload object, or a plain string from typing
+   * @returns the alias string to display
+   */
+  displayBoxFileAlias(file: FileUploadWithAccession | string | undefined): string {
+    if (!file) return '';
+    if (typeof file === 'string') return file;
+    return file.alias;
+  }
+
+  /** Whether the "Confirm and archive" button should be enabled */
+  canConfirmAndArchive = computed<boolean>(
+    () =>
+      !!this.selectedStudyAccession() &&
+      !!this.committedMappedField() &&
+      !this.isSubmitting(),
+  );
+}

--- a/src/app/upload/features/upload-box-mapping/upload-box-mapping.ts
+++ b/src/app/upload/features/upload-box-mapping/upload-box-mapping.ts
@@ -31,7 +31,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatSort, MatSortModule } from '@angular/material/sort';
 import { MatTableDataSource, MatTableModule } from '@angular/material/table';
 import { RouterLink } from '@angular/router';
-import { of, switchMap } from 'rxjs';
+import { concatMap, of, switchMap } from 'rxjs';
 
 import { EmFile } from '@app/metadata/models/dataset-information';
 import { Study } from '@app/metadata/models/study';
@@ -665,16 +665,25 @@ export class UploadBoxMappingComponent implements OnInit {
     }
 
     this.isSubmitting.set(true);
+    const box = this.box();
     this.#uploadBoxService
-      .submitFileMapping(this.box().id, {
-        box_version: this.box().version,
+      .submitFileMapping(box.id, {
+        box_version: box.version,
         study_id: studyId,
         mapping,
       })
+      .pipe(
+        concatMap(() =>
+          this.#uploadBoxService.archiveUploadBox(box.id, box.version + 1),
+        ),
+      )
       .subscribe({
         next: () => {
           this.isSubmitting.set(false);
-          this.#mappingStateService.clearSnapshot(this.box().id);
+          this.#mappingStateService.clearSnapshot(box.id);
+          this.#notificationService.showSuccess(
+            'File mapping submitted and upload box archived successfully.',
+          );
           this.archived.emit();
         },
         error: () => {

--- a/src/app/upload/features/upload-box-mapping/upload-box-mapping.ts
+++ b/src/app/upload/features/upload-box-mapping/upload-box-mapping.ts
@@ -283,7 +283,7 @@ export class UploadBoxMappingComponent implements OnInit {
     () => this.metadataFiles().length - this.mappedMetaCount(),
   );
 
-  /** Number of mappings that came from auto-matching (exact) */
+  /** Number of auto-matched mappings not overridden by a manual entry */
   exactMatchCount = computed(() => {
     let count = 0;
     const auto = this.autoMappings();
@@ -329,7 +329,10 @@ export class UploadBoxMappingComponent implements OnInit {
       let mappingType: MappingRow['mappingType'] = 'none';
       if (boxFileId) {
         const manualEntry = manual.get(meta.accession);
-        const isManuallySet = manualEntry !== undefined && manualEntry !== null;
+        const isManuallySet =
+          manualEntry !== undefined &&
+          manualEntry !== null &&
+          manualEntry !== auto.get(meta.accession);
         const isAutoMatch =
           auto.has(meta.accession) && auto.get(meta.accession) === boxFileId;
         mappingType = !isManuallySet && isAutoMatch ? 'exact' : 'manual';
@@ -534,12 +537,10 @@ export class UploadBoxMappingComponent implements OnInit {
       // Find a matching box file
       const lower = alias.toLowerCase();
       const exact = this.boxFiles().find((bf) => bf.alias === alias);
-      const caseMatch = exact
-        ? exact
-        : this.boxFiles().filter((bf) => bf.alias.toLowerCase() === lower);
-      const match =
-        exact ??
-        (Array.isArray(caseMatch) && caseMatch.length === 1 ? caseMatch[0] : undefined);
+      const caseMatches = !exact
+        ? this.boxFiles().filter((bf) => bf.alias.toLowerCase() === lower)
+        : [];
+      const match = exact ?? (caseMatches.length === 1 ? caseMatches[0] : undefined);
 
       if (match) {
         const isUnused = this.unusedBoxFileIds().has(match.id);
@@ -722,7 +723,4 @@ export class UploadBoxMappingComponent implements OnInit {
 
   /** Whether the Reset button should be enabled */
   canReset = computed<boolean>(() => this.manualMappings().size > 0);
-
-  /** Whether the Cancel button should be enabled */
-  canCancel = computed<boolean>(() => !!this.selectedStudyAccession());
 }

--- a/src/app/upload/features/upload-box-mapping/upload-box-mapping.ts
+++ b/src/app/upload/features/upload-box-mapping/upload-box-mapping.ts
@@ -37,6 +37,7 @@ import { EmFile } from '@app/metadata/models/dataset-information';
 import { Study } from '@app/metadata/models/study';
 import { MetadataService } from '@app/metadata/services/metadata';
 import { MetadataSearchService } from '@app/metadata/services/metadata-search';
+import { NavigationTrackingService } from '@app/shared/services/navigation';
 import { NotificationService } from '@app/shared/services/notification';
 import {
   ConfirmDialogComponent,
@@ -45,6 +46,7 @@ import {
 import { ResearchDataUploadBox } from '@app/upload/models/box';
 import { FileUploadWithAccession } from '@app/upload/models/file-upload';
 import { UploadBoxService } from '@app/upload/services/upload-box';
+import { UploadBoxMappingStateService } from '@app/upload/services/upload-box-mapping-state';
 import {
   MappingConfirmDialogData,
   UploadBoxMappingConfirmDialogComponent,
@@ -154,6 +156,8 @@ export class UploadBoxMappingComponent implements OnInit {
   #metadataService = inject(MetadataService);
   #dialog = inject(MatDialog);
   #notificationService = inject(NotificationService);
+  #mappingStateService = inject(UploadBoxMappingStateService);
+  #navigationService = inject(NavigationTrackingService);
 
   /** The locked upload box */
   box = input.required<ResearchDataUploadBox>();
@@ -411,6 +415,15 @@ export class UploadBoxMappingComponent implements OnInit {
     }
   });
 
+  /** Persist mapping state whenever the three persistent signals change */
+  #saveStateEffect = effect(() => {
+    this.#mappingStateService.saveSnapshot(this.box().id, {
+      studyAccession: this.selectedStudyAccession(),
+      mappedField: this.committedMappedField(),
+      manualMappings: Array.from(this.manualMappings()),
+    });
+  });
+
   /**
    * Watch pending field changes; if manual mappings exist, ask for confirmation
    * before committing, otherwise commit immediately.
@@ -460,6 +473,14 @@ export class UploadBoxMappingComponent implements OnInit {
       }
       return fileSortKey(row.boxFile?.alias);
     };
+
+    const snapshot = this.#mappingStateService.snapshotFor(this.box().id);
+    if (snapshot) {
+      this.selectedStudyAccession.set(snapshot.studyAccession);
+      this.committedMappedField.set(snapshot.mappedField);
+      this.pendingMappedField.set(snapshot.mappedField);
+      this.manualMappings.set(new Map(snapshot.manualMappings));
+    }
   }
 
   // Row editing
@@ -520,60 +541,31 @@ export class UploadBoxMappingComponent implements OnInit {
   // Actions
 
   /**
-   * Reset manual mappings, optionally after user confirmation.
+   * Reset manual mappings without confirmation.
    * Auto-mappings are recomputed automatically.
    */
   onReset(): void {
-    if (this.manualMappings().size === 0) {
-      return; // nothing to reset
-    }
-    const ref = this.#dialog.open<ConfirmDialogComponent, ConfirmDialogData, boolean>(
-      ConfirmDialogComponent,
-      {
-        data: {
-          title: 'Reset mappings',
-          message:
-            'This will discard all manually established mappings and restore the automatic matches. Do you want to proceed?',
-          confirmText: 'Reset',
-          cancelText: 'Keep editing',
-          confirmClass: 'button-error',
-        },
-      },
-    );
-    ref.afterClosed().subscribe((confirmed) => {
-      if (confirmed) this.manualMappings.set(new Map());
-    });
+    this.manualMappings.set(new Map());
+    this.#notificationService.showInfo('Manual mappings have been reset.');
   }
 
   /**
-   * Cancel and reset the entire mapping form.
-   * Asks for confirmation if manual mappings exist.
+   * Cancel the mapping form: clear the field selection and manual mappings,
+   * keep the study selection, and navigate back.
    */
   onCancel(): void {
-    if (this.manualMappings().size > 0) {
-      const ref = this.#dialog.open<ConfirmDialogComponent, ConfirmDialogData, boolean>(
-        ConfirmDialogComponent,
-        {
-          data: {
-            title: 'Discard mappings',
-            message:
-              'You have established manual mappings that will be lost. Do you want to discard all mapping progress?',
-            confirmText: 'Discard',
-            cancelText: 'Keep editing',
-            confirmClass: 'button-error',
-          },
-        },
-      );
-      ref.afterClosed().subscribe((confirmed) => {
-        if (confirmed) this.#resetForm();
-      });
-    } else {
-      this.#resetForm();
-    }
+    this.committedMappedField.set(undefined);
+    this.pendingMappedField.set(undefined);
+    this.filterText.set('');
+    this.manualMappings.set(new Map());
+    this.editingMetaAccession.set(null);
+    this.inlineInputValue.set('');
+    this.#navigationService.back(['/upload-box-manager']);
   }
 
-  /** Reset all form state back to initial values */
+  /** Reset all form state back to initial values and clear the saved snapshot */
   #resetForm(): void {
+    this.#mappingStateService.clearSnapshot(this.box().id);
     this.selectedStudyAccession.set(undefined);
     this.committedMappedField.set(undefined);
     this.pendingMappedField.set(undefined);
@@ -662,6 +654,7 @@ export class UploadBoxMappingComponent implements OnInit {
       .subscribe({
         next: () => {
           this.isSubmitting.set(false);
+          this.#mappingStateService.clearSnapshot(this.box().id);
           this.archived.emit();
         },
         error: () => {
@@ -691,4 +684,10 @@ export class UploadBoxMappingComponent implements OnInit {
       !!this.committedMappedField() &&
       !this.isSubmitting(),
   );
+
+  /** Whether the Reset button should be enabled */
+  canReset = computed<boolean>(() => this.manualMappings().size > 0);
+
+  /** Whether the Cancel button should be enabled */
+  canCancel = computed<boolean>(() => !!this.selectedStudyAccession());
 }

--- a/src/app/upload/models/accession-map.ts
+++ b/src/app/upload/models/accession-map.ts
@@ -1,0 +1,18 @@
+/**
+ * Models for submitting a file accession mapping to the UOS backend.
+ * @copyright The GHGA Authors
+ * @license Apache-2.0
+ */
+
+/**
+ * Request body for submitting a file accession mapping.
+ * Maps metadata file accessions to upload box file IDs.
+ */
+export interface AccessionMapRequest {
+  /** The current version of the upload box */
+  box_version: number;
+  /** The accession of the study this mapping belongs to */
+  study_id: string;
+  /** Mapping from metadata file accession to upload box file ID */
+  mapping: Record<string, string>;
+}

--- a/src/app/upload/models/mapping.ts
+++ b/src/app/upload/models/mapping.ts
@@ -1,0 +1,8 @@
+/**
+ * Models for the upload box file mapping tool.
+ * @copyright The GHGA Authors
+ * @license Apache-2.0
+ */
+
+/** The metadata field to use for matching upload box files against metadata files */
+export type MappedField = 'alias' | 'name';

--- a/src/app/upload/services/upload-box-mapping-state.ts
+++ b/src/app/upload/services/upload-box-mapping-state.ts
@@ -13,7 +13,7 @@ export interface MappingSnapshot {
   studyAccession: string | undefined;
   /** The committed mapped field */
   mappedField: MappedField | undefined;
-  /** Manual mappings serialised as an entries array */
+  /** Manual mappings serialised as Map entries (JSON-serialisable) */
   manualMappings: [string, string | null][];
 }
 

--- a/src/app/upload/services/upload-box-mapping-state.ts
+++ b/src/app/upload/services/upload-box-mapping-state.ts
@@ -5,7 +5,7 @@
  */
 
 import { Injectable, signal } from '@angular/core';
-import { MappedField } from '../features/upload-box-mapping/upload-box-mapping';
+import { MappedField } from '../models/mapping';
 
 /** Persisted state for a single upload box mapping session */
 export interface MappingSnapshot {

--- a/src/app/upload/services/upload-box-mapping-state.ts
+++ b/src/app/upload/services/upload-box-mapping-state.ts
@@ -1,0 +1,58 @@
+/**
+ * In-memory state service for the upload box file mapping tool.
+ * @copyright The GHGA Authors
+ * @license Apache-2.0
+ */
+
+import { Injectable, signal } from '@angular/core';
+import { MappedField } from '../features/upload-box-mapping/upload-box-mapping';
+
+/** Persisted state for a single upload box mapping session */
+export interface MappingSnapshot {
+  /** The selected study accession */
+  studyAccession: string | undefined;
+  /** The committed mapped field */
+  mappedField: MappedField | undefined;
+  /** Manual mappings serialised as an entries array */
+  manualMappings: [string, string | null][];
+}
+
+/**
+ * Root-level in-memory store for upload box mapping state.
+ * Keyed by box ID so multiple boxes can have independent snapshots.
+ * Instantiated lazily — only created when a data steward opens the mapping tool.
+ */
+@Injectable({ providedIn: 'root' })
+export class UploadBoxMappingStateService {
+  readonly #snapshots = signal<Map<string, MappingSnapshot>>(new Map());
+
+  /**
+   * Retrieve the saved snapshot for a box, or undefined if none exists.
+   * @param boxId - the upload box ID
+   * @returns the stored snapshot, or undefined
+   */
+  snapshotFor(boxId: string): MappingSnapshot | undefined {
+    return this.#snapshots().get(boxId);
+  }
+
+  /**
+   * Persist the current mapping state for a box.
+   * @param boxId - the upload box ID
+   * @param snapshot - the state to store
+   */
+  saveSnapshot(boxId: string, snapshot: MappingSnapshot): void {
+    this.#snapshots.update((map) => new Map(map).set(boxId, snapshot));
+  }
+
+  /**
+   * Remove the stored snapshot for a box (e.g. after submit or explicit cancel).
+   * @param boxId - the upload box ID
+   */
+  clearSnapshot(boxId: string): void {
+    this.#snapshots.update((map) => {
+      const next = new Map(map);
+      next.delete(boxId);
+      return next;
+    });
+  }
+}

--- a/src/app/upload/services/upload-box.ts
+++ b/src/app/upload/services/upload-box.ts
@@ -460,10 +460,51 @@ export class UploadBoxService {
    * @returns An observable that completes when the mapping is accepted
    */
   submitFileMapping(boxId: string, request: AccessionMapRequest): Observable<void> {
-    return this.#http.post<void>(
-      `${this.#boxesUrl}/${encodeURIComponent(boxId)}/file-ids`,
-      request,
+    return this.#http
+      .post<void>(`${this.#boxesUrl}/${encodeURIComponent(boxId)}/file-ids`, request)
+      .pipe(tap(() => this.#applyFileMappingLocally(boxId, request)));
+  }
+
+  /**
+   * Apply a submitted file mapping locally: stamp accessions onto boxFileUploads
+   * and increment the box version in all local caches.
+   * @param boxId - the ID of the upload box
+   * @param request - the submitted accession map request
+   */
+  #applyFileMappingLocally(boxId: string, request: AccessionMapRequest): void {
+    // Invert the mapping: boxFileId -> accession
+    const accessionByBoxFileId = new Map<string, string>(
+      Object.entries(request.mapping).map(([accession, boxFileId]) => [
+        boxFileId,
+        accession,
+      ]),
     );
+
+    if (!this.boxFileUploads.error()) {
+      const updated = this.boxFileUploads.value().map((f) => {
+        const accession = accessionByBoxFileId.get(f.id);
+        return accession !== undefined ? { ...f, accession } : f;
+      });
+      this.boxFileUploads.value.set(updated);
+    }
+
+    this.#updateUploadBoxLocally(boxId, { version: request.box_version });
+  }
+
+  /**
+   * Send a PATCH request to set the upload box state to archived.
+   * @param boxId - the ID of the upload box
+   * @param currentVersion - the current (post-mapping) box version
+   * @returns An observable that completes when the archive is accepted
+   */
+  archiveUploadBox(boxId: string, currentVersion: number): Observable<void> {
+    const changes: ResearchDataUploadBoxUpdate = {
+      version: currentVersion,
+      state: UploadBoxState.archived,
+    };
+    return this.#http
+      .patch<void>(`${this.#boxesUrl}/${encodeURIComponent(boxId)}`, changes)
+      .pipe(tap(() => this.#updateUploadBoxLocally(boxId, changes)));
   }
 
   /**

--- a/src/app/upload/services/upload-box.ts
+++ b/src/app/upload/services/upload-box.ts
@@ -9,6 +9,7 @@ import { computed, inject, Injectable, signal } from '@angular/core';
 import { AuthService } from '@app/auth/services/auth';
 import { ConfigService } from '@app/shared/services/config';
 import { map, Observable, tap } from 'rxjs';
+import { AccessionMapRequest } from '../models/accession-map';
 import {
   BoxRetrievalResults,
   ResearchDataUploadBox,
@@ -449,6 +450,19 @@ export class UploadBoxService {
 
         return grantId;
       }),
+    );
+  }
+
+  /**
+   * Submit a file accession mapping for an upload box, causing it to be archived.
+   * @param boxId - the ID of the upload box
+   * @param request - the accession map request payload
+   * @returns An observable that completes when the mapping is accepted
+   */
+  submitFileMapping(boxId: string, request: AccessionMapRequest): Observable<void> {
+    return this.#http.post<void>(
+      `${this.#boxesUrl}/${encodeURIComponent(boxId)}/file-ids`,
+      request,
     );
   }
 

--- a/src/app/upload/services/upload-box.ts
+++ b/src/app/upload/services/upload-box.ts
@@ -466,7 +466,7 @@ export class UploadBoxService {
   }
 
   /**
-   * Apply a submitted file mapping locally: stamp accessions onto boxFileUploads
+   * Apply a submitted file mapping locally: add accessions to boxFileUploads
    * and increment the box version in all local caches.
    * @param boxId - the ID of the upload box
    * @param request - the submitted accession map request

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -1582,7 +1582,7 @@ export const uploadBoxTestDatasetSummary: DatasetSummary = {
     count: 16,
     stats: {
       format: [
-        { value: 'FASTQ', count: 6 },
+        { value: 'FASTQ', count: 5 },
         { value: 'BAM', count: 2 },
         { value: 'CRAM', count: 1 },
         { value: 'VCF', count: 1 },

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -738,6 +738,13 @@ export const searchResults: SearchResults = {
           'Test dataset for details and this is also testing whether two lines of text actually appear correctly on the expansion panel headers or not at least at a resolution of one thousand nine hundred and twenty pixels wide',
       },
     },
+    {
+      id_: 'GHGAD99999999999001',
+      content: {
+        ega_accession: 'EGAD99999999001',
+        title: 'Upload Box Test Dataset',
+      },
+    },
   ],
 };
 
@@ -1529,4 +1536,170 @@ export const studyData: Study = {
   description:
     'Test study description. Pharetra convallis posuere morbi leo urna molestie. Ut faucibus pulvinar elementum integer. Nec nam aliquam sem et tortor. Pretium viverra suspendisse potenti nullam ac. Commodo sed egestas egestas fringilla. Tincidunt dui ut ornare lectus sit. Amet massa vitae tortor condimentum lacinia quis vel eros donec. Feugiat pretium nibh ipsum consequat. Pulvinar etiam non quam lacus suspendisse faucibus interdum. Aliquam sem et tortor consequat id.',
   publications: ['GHGA123456789', 'GHGA123456709'],
+};
+
+/**
+ * Mock study for testing the upload box file mapping feature (box 2).
+ * Files in `uploadBoxTestDatasetDetails.research_data_files` deliberately
+ * cover exact alias matches, case-insensitive alias matches, exact name
+ * matches, and un-matched files so all mapping branches can be exercised.
+ */
+export const uploadBoxTestStudyData: Study = {
+  accession: 'GHGAS99999999999001',
+  ega_accession: 'EGAS99999999901',
+  alias: 'UPLOAD_BOX_TEST_STUDY',
+  types: ['test_genomics'],
+  title: 'Upload Box File Mapping Test Study',
+  affiliations: ['Test affiliation'],
+  datasets: ['GHGAD99999999999001'],
+  description: 'Dedicated study for testing the file mapping UI with upload box 2.',
+  publications: [],
+};
+
+/**
+ * Minimal DatasetSummary for the upload-box-mapping test dataset.
+ * The `studies_summary.stats.accession` must point to `uploadBoxTestStudyData`.
+ */
+export const uploadBoxTestDatasetSummary: DatasetSummary = {
+  accession: 'GHGAD99999999999001',
+  description: 'Upload box test dataset',
+  types: ['test_genomics'],
+  title: 'Upload Box Test Dataset',
+  dac_email: 'test@some.dac.org',
+  samples_summary: {
+    count: 1,
+    stats: { sex: [], tissues: [], phenotypic_features: [] },
+  },
+  studies_summary: {
+    count: 1,
+    stats: {
+      accession: ['GHGAS99999999999001'],
+      title: ['Upload Box File Mapping Test Study'],
+    },
+  },
+  experiments_summary: { count: 1, stats: { experiment_methods: [] } },
+  files_summary: {
+    count: 12,
+    stats: {
+      format: [
+        { value: 'FASTQ', count: 5 },
+        { value: 'BAM', count: 2 },
+        { value: 'CRAM', count: 1 },
+        { value: 'VCF', count: 2 },
+        { value: 'BED', count: 2 },
+      ],
+    },
+  },
+};
+
+/**
+ * DatasetDetailsRaw for the upload-box-mapping test dataset.
+ * `research_data_files` aliases/names are chosen to test all mapping scenarios:
+ * - exact alias match (files 1–3, 5, 7–9)
+ * - case-insensitive alias match (files 4, 6)
+ * - exact name match only (file 10)
+ * - no match at all (files 11–12)
+ */
+export const uploadBoxTestDatasetDetails: DatasetDetailsRaw = {
+  ...datasetDetails,
+  accession: 'GHGAD99999999999001',
+  ega_accession: 'EGAD99999999001',
+  title: 'Upload Box Test Dataset',
+  description: 'Dedicated dataset for testing the file mapping UI.',
+  process_data_files: [],
+  experiment_method_supporting_files: [],
+  analysis_method_supporting_files: [],
+  individual_supporting_files: [],
+  experiments: [],
+  samples: [],
+  research_data_files: [
+    // Exact alias matches:
+    {
+      accession: 'GHGAF99999999999001',
+      ega_accession: 'EGAF99999901',
+      alias: 'sample_001_R1.fastq',
+      name: 'Sample 001 Read 1',
+      format: 'FASTQ',
+    },
+    {
+      accession: 'GHGAF99999999999002',
+      ega_accession: 'EGAF99999902',
+      alias: 'sample_001_R2.fastq',
+      name: 'Sample 001 Read 2',
+      format: 'FASTQ',
+    },
+    {
+      accession: 'GHGAF99999999999003',
+      ega_accession: 'EGAF99999903',
+      alias: 'sample_002_R1.fastq.gz',
+      name: 'Sample 002 Read 1',
+      format: 'FASTQ',
+    },
+    {
+      accession: 'GHGAF99999999999005',
+      ega_accession: 'EGAF99999905',
+      alias: 'reference_genome.fasta',
+      name: 'Reference Genome',
+      format: 'FASTA',
+    },
+    {
+      accession: 'GHGAF99999999999007',
+      ega_accession: 'EGAF99999907',
+      alias: 'aligned_reads_002.cram',
+      name: 'Aligned Reads 002',
+      format: 'CRAM',
+    },
+    {
+      accession: 'GHGAF99999999999008',
+      ega_accession: 'EGAF99999908',
+      alias: 'variants_cohort.vcf',
+      name: 'Variants Cohort',
+      format: 'VCF',
+    },
+    {
+      accession: 'GHGAF99999999999009',
+      ega_accession: 'EGAF99999909',
+      alias: 'chip_peaks_001.bed',
+      name: 'ChIP Peaks 001',
+      format: 'BED',
+    },
+    // Case-insensitive alias matches (alias case differs, name = exact box alias):
+    {
+      accession: 'GHGAF99999999999004',
+      ega_accession: 'EGAF99999904',
+      alias: 'Sample_002_R2.fastq.gz',
+      name: 'sample_002_R2.fastq.gz',
+      format: 'FASTQ',
+    },
+    {
+      accession: 'GHGAF99999999999006',
+      ega_accession: 'EGAF99999906',
+      alias: 'ALIGNED_READS_001.BAM',
+      name: 'aligned_reads_001.bam',
+      format: 'BAM',
+    },
+    // Exact name match only (alias does not match any box file):
+    {
+      accession: 'GHGAF99999999999010',
+      ega_accession: 'EGAF99999910',
+      alias: 'methylation_data.meth',
+      name: 'methylation_sample_001.meth',
+      format: 'METH',
+    },
+    // No match at all:
+    {
+      accession: 'GHGAF99999999999011',
+      ega_accession: 'EGAF99999911',
+      alias: 'unmatched_metadata_file.vcf',
+      name: 'Unmatched Metadata File',
+      format: 'VCF',
+    },
+    {
+      accession: 'GHGAF99999999999012',
+      ega_accession: 'EGAF99999912',
+      alias: 'extra_metadata_file.fastq',
+      name: 'Extra Metadata File',
+      format: 'FASTQ',
+    },
+  ],
 };

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -1690,7 +1690,7 @@ export const uploadBoxTestDatasetDetails: DatasetDetailsRaw = {
       name: 'methylation_sample_001.meth',
       format: 'METH',
     },
-    // No match at all:
+    // Further exact alias matches:
     {
       accession: 'GHGAF99999999999011',
       ega_accession: 'EGAF99999911',
@@ -1726,6 +1726,7 @@ export const uploadBoxTestDatasetDetails: DatasetDetailsRaw = {
       name: 'ChIP Peaks 002',
       format: 'BED',
     },
+    // No match in upload box (metadata-only):
     {
       accession: 'GHGAF99999999999016',
       ega_accession: 'EGAF99999916',

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -1579,14 +1579,19 @@ export const uploadBoxTestDatasetSummary: DatasetSummary = {
   },
   experiments_summary: { count: 1, stats: { experiment_methods: [] } },
   files_summary: {
-    count: 12,
+    count: 16,
     stats: {
       format: [
-        { value: 'FASTQ', count: 5 },
+        { value: 'FASTQ', count: 6 },
         { value: 'BAM', count: 2 },
         { value: 'CRAM', count: 1 },
-        { value: 'VCF', count: 2 },
+        { value: 'VCF', count: 1 },
         { value: 'BED', count: 2 },
+        { value: 'FASTA', count: 1 },
+        { value: 'METH', count: 1 },
+        { value: 'RAW', count: 1 },
+        { value: 'PDF', count: 1 },
+        { value: 'CSV', count: 1 },
       ],
     },
   },
@@ -1595,10 +1600,9 @@ export const uploadBoxTestDatasetSummary: DatasetSummary = {
 /**
  * DatasetDetailsRaw for the upload-box-mapping test dataset.
  * `research_data_files` aliases/names are chosen to test all mapping scenarios:
- * - exact alias match (files 1–3, 5, 7–9)
+ * - exact alias match (files 1–3, 5, 7–9, 11–15)
  * - case-insensitive alias match (files 4, 6)
  * - exact name match only (file 10)
- * - no match at all (files 11–12)
  */
 export const uploadBoxTestDatasetDetails: DatasetDetailsRaw = {
   ...datasetDetails,
@@ -1690,16 +1694,44 @@ export const uploadBoxTestDatasetDetails: DatasetDetailsRaw = {
     {
       accession: 'GHGAF99999999999011',
       ega_accession: 'EGAF99999911',
-      alias: 'unmatched_metadata_file.vcf',
-      name: 'Unmatched Metadata File',
-      format: 'VCF',
+      alias: 'ms_proteomics_run1.raw',
+      name: 'MS Proteomics Run 1',
+      format: 'RAW',
     },
     {
       accession: 'GHGAF99999999999012',
       ega_accession: 'EGAF99999912',
-      alias: 'extra_metadata_file.fastq',
-      name: 'Extra Metadata File',
+      alias: 'study_data_manifest.pdf',
+      name: 'Study Data Manifest',
+      format: 'PDF',
+    },
+    {
+      accession: 'GHGAF99999999999013',
+      ega_accession: 'EGAF99999913',
+      alias: 'sample_003_R1.fastq.gz',
+      name: 'Sample 003 Read 1',
       format: 'FASTQ',
+    },
+    {
+      accession: 'GHGAF99999999999014',
+      ega_accession: 'EGAF99999914',
+      alias: 'aligned_reads_003.bam',
+      name: 'Aligned Reads 003',
+      format: 'BAM',
+    },
+    {
+      accession: 'GHGAF99999999999015',
+      ega_accession: 'EGAF99999915',
+      alias: 'chip_peaks_002.bed',
+      name: 'ChIP Peaks 002',
+      format: 'BED',
+    },
+    {
+      accession: 'GHGAF99999999999016',
+      ega_accession: 'EGAF99999916',
+      alias: 'some_unessential_data.csv',
+      name: 'Some Unessential Data',
+      format: 'CSV',
     },
   ],
 };

--- a/src/mocks/responses.ts
+++ b/src/mocks/responses.ts
@@ -25,6 +25,9 @@ import {
   uploadBox2FileUploads,
   uploadBox3FileUploads,
   uploadBoxes,
+  uploadBoxTestDatasetDetails,
+  uploadBoxTestDatasetSummary,
+  uploadBoxTestStudyData,
   uploadGrants,
   users,
   workPackageResponse,
@@ -124,6 +127,9 @@ export const responses: { [endpoint: string]: ResponseValue } = {
   // Get summary data from a single dataset
   'GET /api/metldata/artifacts/stats_public/classes/DatasetStats/resources/GHGAD12345678901238':
     getDatasetSummary('GHGAD12345678901238'),
+  // Upload box mapping test dataset summary (points to the new test study)
+  'GET /api/metldata/artifacts/stats_public/classes/DatasetStats/resources/GHGAD99999999999001':
+    uploadBoxTestDatasetSummary,
 
   // Get dataset details (embedded)
   'GET /api/metldata/artifacts/embedded_public/classes/EmbeddedDataset/resources/GHGAD12345678901234':
@@ -136,7 +142,13 @@ export const responses: { [endpoint: string]: ResponseValue } = {
     getDatasetDetails('GHGAD12345678901237'),
   'GET /api/metldata/artifacts/embedded_public/classes/EmbeddedDataset/resources/GHGAD12345678901238':
     getDatasetDetails('GHGAD12345678901238'),
+  // Upload box mapping test dataset details (files match box 2 aliases for testing)
+  'GET /api/metldata/artifacts/embedded_public/classes/EmbeddedDataset/resources/GHGAD99999999999001':
+    uploadBoxTestDatasetDetails,
 
+  // Get study details (embedded) — specific entries before the wildcard catch-all
+  'GET /api/metldata/artifacts/embedded_public/classes/Study/resources/GHGAS99999999999001':
+    uploadBoxTestStudyData,
   // Get study details (embedded)
   'GET /api/metldata/artifacts/embedded_public/classes/Study/resources/*': studyData,
 
@@ -250,6 +262,9 @@ export const responses: { [endpoint: string]: ResponseValue } = {
 
   // Revoke an upload grant
   'DELETE /api/uos/access-grants/*': 204,
+
+  // Submit file mapping for box 2 (locked box used for mapping UI testing)
+  'POST /api/uos/boxes/0a36607a-b53f-49ed-bf3e-a5f2dbc68002/file-ids': 204,
 
   // Update (submit) an upload box
   'PATCH /api/uos/boxes/*': 204,

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -466,6 +466,10 @@ mat-expansion-panel {
   );
 }
 
+.mat-mdc-radio-group {
+  --mat-radio-label-text-size: 1rem;
+}
+
 table[mat-table].bold-table-headers {
   @include mat.table-overrides(
     (

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -183,6 +183,10 @@
     border-color: var(--mat-sys-outline-variant);
   }
 
+  .mat-mdc-select-placeholder {
+    color: var(--mat-sys-on-surface-variant);
+  }
+
   .smaller-mat-card-title,
   :is(.\*\:smaller-mat-card-title > *) {
     @include mat.card-overrides(

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -466,7 +466,7 @@ mat-expansion-panel {
   );
 }
 
-.mat-mdc-radio-group {
+.larger-mat-radio-label {
   --mat-radio-label-text-size: 1rem;
 }
 


### PR DESCRIPTION
This PR implements the research data mapping tool for locked upload boxes.

It follows the written spec and wireframes in the Archaeopteryx epic with minor deviations.