### PR TITLE
Add size limit to upload box creation dialog

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-portal",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3749,6 +3749,10 @@ packages:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
     engines: {node: '>= 0.4'}
 
+  is-core-module@2.16.2:
+    resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
+    engines: {node: '>= 0.4'}
+
   is-docker@2.2.1:
     resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
     engines: {node: '>=8'}
@@ -8796,7 +8800,7 @@ snapshots:
   eslint-import-resolver-node@0.3.9:
     dependencies:
       debug: 3.2.7
-      is-core-module: 2.16.1
+      is-core-module: 2.16.2
       resolve: 1.22.12
     transitivePeerDependencies:
       - supports-color
@@ -9362,6 +9366,10 @@ snapshots:
       semver: 7.7.4
 
   is-core-module@2.16.1:
+    dependencies:
+      hasown: 2.0.3
+
+  is-core-module@2.16.2:
     dependencies:
       hasown: 2.0.3
 
@@ -10587,7 +10595,7 @@ snapshots:
   resolve@1.22.12:
     dependencies:
       es-errors: 1.3.0
-      is-core-module: 2.16.1
+      is-core-module: 2.16.2
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 

--- a/src/app/shared/pipes/parse-bytes-pipe.spec.ts
+++ b/src/app/shared/pipes/parse-bytes-pipe.spec.ts
@@ -24,15 +24,15 @@ describe('ParseBytesPipe', () => {
     expect(result).toBe('750\u00A0B');
   });
 
-  it('should return 25 KB for 25 * 2^10 Bytes', () => {
+  it('should return 25 KiB for 25 * 2^10 Bytes', () => {
     const pipe = new ParseBytes();
     const result = pipe.transform(25 * 2 ** 10);
-    expect(result).toBe('25\u00A0kB');
+    expect(result).toBe('25\u00A0KiB');
   });
 
-  it('should return 2.5 MB for 2.5 * 2^20 Bytes', () => {
+  it('should return 2.5 MiB for 2.5 * 2^20 Bytes', () => {
     const pipe = new ParseBytes();
     const result = pipe.transform(2.5 * 2 ** 20);
-    expect(result).toBe('2.5\u00A0MB');
+    expect(result).toBe('2.5\u00A0MiB');
   });
 });

--- a/src/app/shared/pipes/parse-bytes-pipe.ts
+++ b/src/app/shared/pipes/parse-bytes-pipe.ts
@@ -7,11 +7,11 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
 /**
- * Note: Using 2^10 as multiplier we should strictly speaking also use
- * the new binary prefixes. But many uses are not familiar with these.
+ * Binary prefixes for bytes (base 1024).
+ * Using 2^10 as multiplier with official binary prefixes (KiB, MiB, GiB, etc.)
  */
 const MULTIPLIER = 1024;
-const PREFIXES = ['', 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y'];
+const PREFIXES = ['', 'K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y'];
 
 /**
  * Pipe to convert number of bytes to a human-readable format
@@ -23,14 +23,17 @@ export class ParseBytes implements PipeTransform {
   /**
    * This function converts a number of bytes to a human-readable string
    * @param bytes Bytes as number
-   * @returns Human readable size string, e.g. 5 kB
+   * @returns Human readable size string, e.g. 5 KiB
    */
   transform(bytes: number | null | undefined): string {
     if (bytes === null || bytes === undefined) return '';
     let parsedBytes = PREFIXES.flatMap((prefix, index) => {
       let calculatedVal = bytes / Math.pow(MULTIPLIER, index);
       if (calculatedVal < 1000 && calculatedVal >= 0.1) {
-        return String(Math.round(calculatedVal * 100) / 100) + `\u00A0${prefix}B`;
+        return (
+          String(Math.round(calculatedVal * 100) / 100) +
+          `\u00A0${prefix}${prefix ? 'i' : ''}B`
+        );
       } else return null;
     });
     return parsedBytes.find((parsing) => parsing !== null) || String(bytes) + '\u00A0B';

--- a/src/app/upload/features/upload-box-creation-dialog/upload-box-creation-dialog.html
+++ b/src/app/upload/features/upload-box-creation-dialog/upload-box-creation-dialog.html
@@ -22,7 +22,7 @@
     </mat-form-field>
 
     <mat-form-field>
-      <mat-label>Size limit (in SI Terabytes)</mat-label>
+      <mat-label>Size limit (in TiB)</mat-label>
       <input matInput type="number" step="1" [formField]="boxForm.max_size_tb" />
     </mat-form-field>
 

--- a/src/app/upload/features/upload-box-creation-dialog/upload-box-creation-dialog.html
+++ b/src/app/upload/features/upload-box-creation-dialog/upload-box-creation-dialog.html
@@ -21,6 +21,11 @@
       </mat-select>
     </mat-form-field>
 
+    <mat-form-field>
+      <mat-label>Size limit (in SI Terabytes)</mat-label>
+      <input matInput type="number" step="1" [formField]="boxForm.max_size_tb" />
+    </mat-form-field>
+
     @if (creationError()) {
       <p class="text-error">There was an error creating the Upload Box.</p>
     }

--- a/src/app/upload/features/upload-box-creation-dialog/upload-box-creation-dialog.spec.ts
+++ b/src/app/upload/features/upload-box-creation-dialog/upload-box-creation-dialog.spec.ts
@@ -70,7 +70,37 @@ describe('UploadBoxCreationDialogComponent', () => {
     expect(screen.getByRole('button', { name: /^ok$/i })).toBeDisabled();
   });
 
+  it('should configure size limit step to 1 TB', () => {
+    const sizeInput = screen.getByRole('spinbutton', {
+      name: 'Size limit (in SI Terabytes)',
+    });
+
+    expect(sizeInput).toHaveAttribute('step', '1');
+  });
+
   it('should enable OK with multiline description when all fields are set', async () => {
+    const titleInput = screen.getByRole('textbox', { name: 'Title' });
+    const descriptionInput = screen.getByRole('textbox', {
+      name: 'Description',
+    });
+    const locationSelect = screen.getByRole('combobox', {
+      name: 'Storage location',
+    });
+    const sizeInput = screen.getByRole('spinbutton', {
+      name: 'Size limit (in SI Terabytes)',
+    });
+
+    await userEvent.type(titleInput, 'New Box');
+    await userEvent.type(descriptionInput, 'First line{enter}Second line');
+    await userEvent.click(locationSelect);
+    await userEvent.click(await screen.findByRole('option', { name: 'Tuebingen 1' }));
+    await userEvent.type(sizeInput, '2.5');
+    fixture.detectChanges();
+
+    expect(screen.getByRole('button', { name: /^ok$/i })).toBeEnabled();
+  });
+
+  it('should keep OK disabled when size limit is missing', async () => {
     const titleInput = screen.getByRole('textbox', { name: 'Title' });
     const descriptionInput = screen.getByRole('textbox', {
       name: 'Description',
@@ -80,12 +110,56 @@ describe('UploadBoxCreationDialogComponent', () => {
     });
 
     await userEvent.type(titleInput, 'New Box');
-    await userEvent.type(descriptionInput, 'First line{enter}Second line');
+    await userEvent.type(descriptionInput, 'Description');
     await userEvent.click(locationSelect);
     await userEvent.click(await screen.findByRole('option', { name: 'Tuebingen 1' }));
     fixture.detectChanges();
 
-    expect(screen.getByRole('button', { name: /^ok$/i })).toBeEnabled();
+    expect(screen.getByRole('button', { name: /^ok$/i })).toBeDisabled();
+  });
+
+  it('should keep OK disabled when size limit is below 1 GB', async () => {
+    const titleInput = screen.getByRole('textbox', { name: 'Title' });
+    const descriptionInput = screen.getByRole('textbox', {
+      name: 'Description',
+    });
+    const locationSelect = screen.getByRole('combobox', {
+      name: 'Storage location',
+    });
+    const sizeInput = screen.getByRole('spinbutton', {
+      name: 'Size limit (in SI Terabytes)',
+    });
+
+    await userEvent.type(titleInput, 'New Box');
+    await userEvent.type(descriptionInput, 'Description');
+    await userEvent.click(locationSelect);
+    await userEvent.click(await screen.findByRole('option', { name: 'Tuebingen 1' }));
+    await userEvent.type(sizeInput, '0.0009');
+    fixture.detectChanges();
+
+    expect(screen.getByRole('button', { name: /^ok$/i })).toBeDisabled();
+  });
+
+  it('should keep OK disabled when size limit exceeds 1,000,000 TB', async () => {
+    const titleInput = screen.getByRole('textbox', { name: 'Title' });
+    const descriptionInput = screen.getByRole('textbox', {
+      name: 'Description',
+    });
+    const locationSelect = screen.getByRole('combobox', {
+      name: 'Storage location',
+    });
+    const sizeInput = screen.getByRole('spinbutton', {
+      name: 'Size limit (in SI Terabytes)',
+    });
+
+    await userEvent.type(titleInput, 'New Box');
+    await userEvent.type(descriptionInput, 'Description');
+    await userEvent.click(locationSelect);
+    await userEvent.click(await screen.findByRole('option', { name: 'Tuebingen 1' }));
+    await userEvent.type(sizeInput, '1000000.0001');
+    fixture.detectChanges();
+
+    expect(screen.getByRole('button', { name: /^ok$/i })).toBeDisabled();
   });
 
   it('should close without result on cancel', () => {
@@ -103,17 +177,22 @@ describe('UploadBoxCreationDialogComponent', () => {
     const locationSelect = screen.getByRole('combobox', {
       name: 'Storage location',
     });
+    const sizeInput = screen.getByRole('spinbutton', {
+      name: 'Size limit (in SI Terabytes)',
+    });
 
     await userEvent.type(titleInput, '  New Box  ');
     await userEvent.type(descriptionInput, '  Description  ');
     await userEvent.click(locationSelect);
     await userEvent.click(await screen.findByRole('option', { name: 'Tuebingen 1' }));
+    await userEvent.type(sizeInput, '1.25');
     await userEvent.click(screen.getByRole('button', { name: /^ok$/i }));
 
     expect(uploadBoxService.createUploadBox).toHaveBeenCalledWith({
       title: 'New Box',
       description: 'Description',
       storage_alias: 'TUE01',
+      max_size: 1250000000000,
     });
     expect(mockDialogRef.close).toHaveBeenCalledWith('new-box-id');
     expect(mockNotificationService.showError).not.toHaveBeenCalled();
@@ -131,11 +210,15 @@ describe('UploadBoxCreationDialogComponent', () => {
     const locationSelect = screen.getByRole('combobox', {
       name: 'Storage location',
     });
+    const sizeInput = screen.getByRole('spinbutton', {
+      name: 'Size limit (in SI Terabytes)',
+    });
 
     await userEvent.type(titleInput, 'New Box');
     await userEvent.type(descriptionInput, 'Description');
     await userEvent.click(locationSelect);
     await userEvent.click(await screen.findByRole('option', { name: 'Heidelberg 2' }));
+    await userEvent.type(sizeInput, '0.5');
     await userEvent.click(screen.getByRole('button', { name: /^ok$/i }));
     fixture.detectChanges();
 

--- a/src/app/upload/features/upload-box-creation-dialog/upload-box-creation-dialog.spec.ts
+++ b/src/app/upload/features/upload-box-creation-dialog/upload-box-creation-dialog.spec.ts
@@ -70,9 +70,9 @@ describe('UploadBoxCreationDialogComponent', () => {
     expect(screen.getByRole('button', { name: /^ok$/i })).toBeDisabled();
   });
 
-  it('should configure size limit step to 1 TB', () => {
+  it('should configure size limit step to 1 TiB', () => {
     const sizeInput = screen.getByRole('spinbutton', {
-      name: 'Size limit (in SI Terabytes)',
+      name: 'Size limit (in TiB)',
     });
 
     expect(sizeInput).toHaveAttribute('step', '1');
@@ -87,7 +87,7 @@ describe('UploadBoxCreationDialogComponent', () => {
       name: 'Storage location',
     });
     const sizeInput = screen.getByRole('spinbutton', {
-      name: 'Size limit (in SI Terabytes)',
+      name: 'Size limit (in TiB)',
     });
 
     await userEvent.type(titleInput, 'New Box');
@@ -118,7 +118,7 @@ describe('UploadBoxCreationDialogComponent', () => {
     expect(screen.getByRole('button', { name: /^ok$/i })).toBeDisabled();
   });
 
-  it('should keep OK disabled when size limit is below 1 GB', async () => {
+  it('should keep OK disabled when size limit is below 1 GiB', async () => {
     const titleInput = screen.getByRole('textbox', { name: 'Title' });
     const descriptionInput = screen.getByRole('textbox', {
       name: 'Description',
@@ -127,7 +127,7 @@ describe('UploadBoxCreationDialogComponent', () => {
       name: 'Storage location',
     });
     const sizeInput = screen.getByRole('spinbutton', {
-      name: 'Size limit (in SI Terabytes)',
+      name: 'Size limit (in TiB)',
     });
 
     await userEvent.type(titleInput, 'New Box');
@@ -140,7 +140,7 @@ describe('UploadBoxCreationDialogComponent', () => {
     expect(screen.getByRole('button', { name: /^ok$/i })).toBeDisabled();
   });
 
-  it('should keep OK disabled when size limit exceeds 1,000,000 TB', async () => {
+  it('should keep OK disabled when size limit exceeds 1,000,000 TiB', async () => {
     const titleInput = screen.getByRole('textbox', { name: 'Title' });
     const descriptionInput = screen.getByRole('textbox', {
       name: 'Description',
@@ -149,7 +149,7 @@ describe('UploadBoxCreationDialogComponent', () => {
       name: 'Storage location',
     });
     const sizeInput = screen.getByRole('spinbutton', {
-      name: 'Size limit (in SI Terabytes)',
+      name: 'Size limit (in TiB)',
     });
 
     await userEvent.type(titleInput, 'New Box');
@@ -178,7 +178,7 @@ describe('UploadBoxCreationDialogComponent', () => {
       name: 'Storage location',
     });
     const sizeInput = screen.getByRole('spinbutton', {
-      name: 'Size limit (in SI Terabytes)',
+      name: 'Size limit (in TiB)',
     });
 
     await userEvent.type(titleInput, '  New Box  ');
@@ -192,7 +192,7 @@ describe('UploadBoxCreationDialogComponent', () => {
       title: 'New Box',
       description: 'Description',
       storage_alias: 'TUE01',
-      max_size: 1250000000000,
+      max_size: 1374389534720,
     });
     expect(mockDialogRef.close).toHaveBeenCalledWith('new-box-id');
     expect(mockNotificationService.showError).not.toHaveBeenCalled();
@@ -211,7 +211,7 @@ describe('UploadBoxCreationDialogComponent', () => {
       name: 'Storage location',
     });
     const sizeInput = screen.getByRole('spinbutton', {
-      name: 'Size limit (in SI Terabytes)',
+      name: 'Size limit (in TiB)',
     });
 
     await userEvent.type(titleInput, 'New Box');

--- a/src/app/upload/features/upload-box-creation-dialog/upload-box-creation-dialog.ts
+++ b/src/app/upload/features/upload-box-creation-dialog/upload-box-creation-dialog.ts
@@ -11,7 +11,15 @@ import {
   inject,
   signal,
 } from '@angular/core';
-import { form, FormField, pattern, required } from '@angular/forms/signals';
+import {
+  form,
+  FormField,
+  max,
+  min,
+  pattern,
+  required,
+  validate,
+} from '@angular/forms/signals';
 import { MatButtonModule } from '@angular/material/button';
 import {
   MatDialogActions,
@@ -25,6 +33,15 @@ import { MatSelectModule } from '@angular/material/select';
 import { NotificationService } from '@app/shared/services/notification';
 import { ResearchDataUploadBoxBase } from '@app/upload/models/box';
 import { UploadBoxService } from '@app/upload/services/upload-box';
+
+/** Minimum upload box limit in TB (1 GB in decimal units). */
+const MIN_UPLOAD_BOX_SIZE_TB = 0.001;
+
+/** Maximum upload box limit in TB (1 million TB in decimal units). */
+const MAX_UPLOAD_BOX_SIZE_TB = 1_000_000;
+
+/** Number of bytes in one decimal TB. */
+const BYTES_PER_TB_DECIMAL = 1_000_000_000_000;
 
 /**
  * Dialog for creating a new upload box.
@@ -54,7 +71,12 @@ export class UploadBoxCreationDialogComponent {
   isSubmitting = signal(false);
   creationError = signal(false);
 
-  protected boxModel = signal({ title: '', description: '', storage_alias: '' });
+  protected boxModel = signal({
+    title: '',
+    description: '',
+    storage_alias: '',
+    max_size_tb: null as number | null,
+  });
 
   protected boxForm = form(this.boxModel, (p) => {
     required(p.title);
@@ -62,6 +84,19 @@ export class UploadBoxCreationDialogComponent {
     required(p.description);
     pattern(p.description, /\S/);
     required(p.storage_alias);
+    required(p.max_size_tb);
+    min(p.max_size_tb, 0); // do not use actual minimum since it is also the step size
+    max(p.max_size_tb, MAX_UPLOAD_BOX_SIZE_TB);
+    validate(p.max_size_tb, ({ value }) => {
+      const sizeTb = value();
+      if (sizeTb === null || Number.isNaN(sizeTb)) {
+        return { kind: 'required' };
+      }
+      if (sizeTb < MIN_UPLOAD_BOX_SIZE_TB) {
+        return { kind: 'min' };
+      }
+      return null;
+    });
   });
 
   isSubmitDisabled = computed(() => !this.boxForm().valid() || this.isSubmitting());
@@ -81,11 +116,17 @@ export class UploadBoxCreationDialogComponent {
 
     this.isSubmitting.set(true);
     this.creationError.set(false);
+    const box = this.boxModel();
+    const maxSizeTb = box.max_size_tb;
+    if (maxSizeTb === null) {
+      return;
+    }
 
     const payload: ResearchDataUploadBoxBase = {
-      title: this.boxModel().title.trim(),
-      description: this.boxModel().description.trim(),
-      storage_alias: this.boxModel().storage_alias,
+      title: box.title.trim(),
+      description: box.description.trim(),
+      storage_alias: box.storage_alias,
+      max_size: Math.round(maxSizeTb * BYTES_PER_TB_DECIMAL),
     };
 
     this.#uploadBoxService.createUploadBox(payload).subscribe({

--- a/src/app/upload/features/upload-box-creation-dialog/upload-box-creation-dialog.ts
+++ b/src/app/upload/features/upload-box-creation-dialog/upload-box-creation-dialog.ts
@@ -34,14 +34,14 @@ import { NotificationService } from '@app/shared/services/notification';
 import { ResearchDataUploadBoxBase } from '@app/upload/models/box';
 import { UploadBoxService } from '@app/upload/services/upload-box';
 
-/** Minimum upload box limit in TB (1 GB in decimal units). */
-const MIN_UPLOAD_BOX_SIZE_TB = 0.001;
+/** Minimum upload box limit in TiB (1 GiB in binary units). */
+const MIN_UPLOAD_BOX_SIZE_TIB = 1 / 1024;
 
-/** Maximum upload box limit in TB (1 million TB in decimal units). */
-const MAX_UPLOAD_BOX_SIZE_TB = 1_000_000;
+/** Maximum upload box limit in TiB (1 million TiB in binary units). */
+const MAX_UPLOAD_BOX_SIZE_TIB = 1_000_000;
 
-/** Number of bytes in one decimal TB. */
-const BYTES_PER_TB_DECIMAL = 1_000_000_000_000;
+/** Number of bytes in one binary TiB (1024^4). */
+const BYTES_PER_TIB = 1_099_511_627_776;
 
 /**
  * Dialog for creating a new upload box.
@@ -86,13 +86,13 @@ export class UploadBoxCreationDialogComponent {
     required(p.storage_alias);
     required(p.max_size_tb);
     min(p.max_size_tb, 0); // do not use actual minimum since it is also the step size
-    max(p.max_size_tb, MAX_UPLOAD_BOX_SIZE_TB);
+    max(p.max_size_tb, MAX_UPLOAD_BOX_SIZE_TIB);
     validate(p.max_size_tb, ({ value }) => {
       const sizeTb = value();
       if (sizeTb === null || Number.isNaN(sizeTb)) {
         return { kind: 'required' };
       }
-      if (sizeTb < MIN_UPLOAD_BOX_SIZE_TB) {
+      if (sizeTb < MIN_UPLOAD_BOX_SIZE_TIB) {
         return { kind: 'min' };
       }
       return null;
@@ -126,7 +126,7 @@ export class UploadBoxCreationDialogComponent {
       title: box.title.trim(),
       description: box.description.trim(),
       storage_alias: box.storage_alias,
-      max_size: Math.round(maxSizeTb * BYTES_PER_TB_DECIMAL),
+      max_size: Math.round(maxSizeTb * BYTES_PER_TIB),
     };
 
     this.#uploadBoxService.createUploadBox(payload).subscribe({

--- a/src/app/upload/features/upload-box-manager-detail/upload-box-manager-detail.html
+++ b/src/app/upload/features/upload-box-manager-detail/upload-box-manager-detail.html
@@ -67,7 +67,10 @@
             </p>
             <p>
               <strong class="inline-block w-40">Files / Size:</strong>
-              <span>{{ box.file_count }} files, {{ box.size | parseBytes }}</span>
+              <span
+                >{{ box.file_count }} files using {{ box.size | parseBytes }} of
+                {{ box.max_size | parseBytes }}</span
+              >
             </p>
           </mat-card-content>
         </mat-card>

--- a/src/app/upload/features/upload-box-manager-filter/upload-box-manager-filter.spec.ts
+++ b/src/app/upload/features/upload-box-manager-filter/upload-box-manager-filter.spec.ts
@@ -23,6 +23,7 @@ const TEST_UPLOAD_BOX: ResearchDataUploadBox = {
   file_count: 3,
   size: 123456,
   storage_alias: 'TUE01',
+  max_size: 10_000_000_000_000,
 };
 
 const uploadBoxesSignal = signal<ResearchDataUploadBox[]>([TEST_UPLOAD_BOX]);

--- a/src/app/upload/features/upload-box-manager-list/upload-box-manager-list.html
+++ b/src/app/upload/features/upload-box-manager-list/upload-box-manager-list.html
@@ -6,7 +6,7 @@
   <p class="text-base">Loading upload boxes...</p>
 } @else {
   @let columns =
-    ['title', 'state', 'files', 'size', 'location', 'last_change', 'details'];
+    ['title', 'state', 'files', 'size', 'limit', 'location', 'last_change', 'details'];
   <div class="overflow-auto">
     <table
       mat-table
@@ -47,6 +47,13 @@
       <ng-container matColumnDef="size">
         <th mat-header-cell *matHeaderCellDef mat-sort-header class="min-w-32">Size</th>
         <td mat-cell *matCellDef="let box">{{ box.size | parseBytes }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="limit">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header class="min-w-32"
+          >Limit</th
+        >
+        <td mat-cell *matCellDef="let box">{{ box.max_size | parseBytes }}</td>
       </ng-container>
 
       <ng-container matColumnDef="location">

--- a/src/app/upload/features/upload-box-manager-list/upload-box-manager-list.ts
+++ b/src/app/upload/features/upload-box-manager-list/upload-box-manager-list.ts
@@ -90,6 +90,8 @@ export class UploadBoxManagerListComponent {
         return uploadBox.file_count;
       case 'size':
         return uploadBox.size;
+      case 'limit':
+        return uploadBox.max_size;
       case 'location':
         return this.getStorageLocationLabel(uploadBox.storage_alias);
       case 'last_change':

--- a/src/app/upload/features/upload-box-manager/upload-box-manager.spec.ts
+++ b/src/app/upload/features/upload-box-manager/upload-box-manager.spec.ts
@@ -25,6 +25,7 @@ const TEST_UPLOAD_BOX: ResearchDataUploadBox = {
   file_count: 3,
   size: 123456,
   storage_alias: 'TUE01',
+  max_size: 10_000_000_000_000,
 };
 
 /**

--- a/src/app/upload/models/box.ts
+++ b/src/app/upload/models/box.ts
@@ -23,6 +23,7 @@ export interface ResearchDataUploadBoxBase {
   title: string;
   description: string;
   storage_alias: string;
+  max_size: number; // in bytes
 }
 
 /** All data describing a Research Data Upload Box */

--- a/src/app/upload/services/upload-box.spec.ts
+++ b/src/app/upload/services/upload-box.spec.ts
@@ -36,6 +36,7 @@ const TEST_BOX_RETRIEVAL_RESULTS: BoxRetrievalResults = {
       file_count: 3,
       size: 123456789,
       storage_alias: 'TUE01',
+      max_size: 10_000_000_000_000,
     },
     {
       id: '0a36607a-b53f-49ed-bf3e-a5f2dbc68002',
@@ -48,6 +49,7 @@ const TEST_BOX_RETRIEVAL_RESULTS: BoxRetrievalResults = {
       file_count: 12,
       size: 987654321,
       storage_alias: 'HD02',
+      max_size: 15_000_000_000_000,
     },
     {
       id: '0a36607a-b53f-49ed-bf3e-a5f2dbc68003',
@@ -60,6 +62,7 @@ const TEST_BOX_RETRIEVAL_RESULTS: BoxRetrievalResults = {
       file_count: 0,
       size: 0,
       storage_alias: 'TUE01',
+      max_size: 7_500_000_000_000,
     },
   ],
 };
@@ -290,6 +293,7 @@ describe('UploadBoxService', () => {
       title: 'New Test Box',
       description: 'A box created in a test',
       storage_alias: 'TUE01',
+      max_size: 2_000_000_000_000,
     };
     const createdId = '0a36607a-b53f-49ed-bf3e-a5f2dbc68099';
 
@@ -319,6 +323,7 @@ describe('UploadBoxService', () => {
       title: 'Bad Box',
       description: 'A box that will fail',
       storage_alias: 'INVALID',
+      max_size: 2_000_000_000_000,
     };
 
     let caughtError: HttpErrorResponse | undefined;

--- a/src/app/upload/services/upload-box.ts
+++ b/src/app/upload/services/upload-box.ts
@@ -277,6 +277,7 @@ export class UploadBoxService {
       title: data.title,
       description: data.description,
       storage_alias: data.storage_alias,
+      max_size: data.max_size,
       last_changed: new Date().toISOString(),
       changed_by: this.#auth.user()?.id ?? '',
       file_count: 0,

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -1069,7 +1069,7 @@ export const uploadBoxes: BoxRetrievalResults = {
       file_count: 3,
       size: 123456789,
       storage_alias: 'TUE01',
-      max_size: 10_000_000_000_000, // 10 TB
+      max_size: 10_995_116_277_760, // 10 TiB
     },
     {
       id: '0a36607a-b53f-49ed-bf3e-a5f2dbc68002',
@@ -1082,7 +1082,7 @@ export const uploadBoxes: BoxRetrievalResults = {
       file_count: 15,
       size: 120259084288, // ~112 GB total
       storage_alias: 'HD02',
-      max_size: 15_000_000_000_000, // 15 TB
+      max_size: 16_492_674_416_640, // 15 TiB
     },
     {
       id: '0a36607a-b53f-49ed-bf3e-a5f2dbc68003',
@@ -1095,7 +1095,7 @@ export const uploadBoxes: BoxRetrievalResults = {
       file_count: 28,
       size: 1567890123,
       storage_alias: 'TUE03',
-      max_size: 7_500_000_000_000, // 7.5 TB
+      max_size: 8_246_337_208_320, // 7.5 TiB
     },
   ],
 };

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -1069,6 +1069,7 @@ export const uploadBoxes: BoxRetrievalResults = {
       file_count: 3,
       size: 123456789,
       storage_alias: 'TUE01',
+      max_size: 10_000_000_000_000, // 10 TB
     },
     {
       id: '0a36607a-b53f-49ed-bf3e-a5f2dbc68002',
@@ -1081,6 +1082,7 @@ export const uploadBoxes: BoxRetrievalResults = {
       file_count: 15,
       size: 120259084288, // ~112 GB total
       storage_alias: 'HD02',
+      max_size: 15_000_000_000_000, // 15 TB
     },
     {
       id: '0a36607a-b53f-49ed-bf3e-a5f2dbc68003',
@@ -1093,6 +1095,7 @@ export const uploadBoxes: BoxRetrievalResults = {
       file_count: 28,
       size: 1567890123,
       storage_alias: 'TUE03',
+      max_size: 7_500_000_000_000, // 7.5 TB
     },
   ],
 };

--- a/tests/admin-pages/upload-box-manager.spec.ts
+++ b/tests/admin-pages/upload-box-manager.spec.ts
@@ -145,6 +145,9 @@ test('validates required fields in the create upload box dialog', async ({
   await dialog.getByRole('combobox', { name: 'Storage location' }).click();
   await page.getByRole('option', { name: 'Tübingen 1' }).click();
 
+  await expect(okButton).toBeDisabled();
+  await dialog.getByLabel('Size limit (in TiB)').fill('1');
+
   await expect(okButton).toBeEnabled();
 
   await dialog.getByRole('button', { name: 'Cancel' }).click();
@@ -164,6 +167,7 @@ test('can create an upload box from the manager page', async ({ adminPage: page 
   await dialog.getByLabel('Description').fill('Created via E2E coverage test');
   await dialog.getByRole('combobox', { name: 'Storage location' }).click();
   await page.getByRole('option', { name: 'Heidelberg 2' }).click();
+  await dialog.getByLabel('Size limit (in TiB)').fill('1');
   await dialog.getByRole('button', { name: 'OK' }).click();
 
   const notification = page.locator('app-custom-snack-bar');

--- a/tests/admin-pages/upload-box-mapping-tool.spec.ts
+++ b/tests/admin-pages/upload-box-mapping-tool.spec.ts
@@ -70,7 +70,7 @@ test('can map files and archive locked upload box using mapping tool', async ({
     .first();
   await expect(methStorageRow).toBeVisible();
   await expect(methStorageRow).toContainText('interrogated');
-  await expect(methStorageRow).toContainText('2 GB');
+  await expect(methStorageRow).toContainText('2 GiB');
 
   const studyCard = page.locator('mat-card').filter({
     has: page.getByRole('heading', { level: 2, name: 'Study' }),

--- a/tests/public-pages/browse.spec.ts
+++ b/tests/public-pages/browse.spec.ts
@@ -87,7 +87,7 @@ test('can navigate to dataset details', async ({ page }) => {
   await expect(main).toContainText('Test dataset with some details for testing.');
 
   await expect(main).toContainText('Test study description.');
-  await expect(main).toContainText('List of files (12 total, 6.16 GB)');
+  await expect(main).toContainText('List of files (12 total, 6.16 GiB)');
 
   // files table should not yet be visible
   await expect(main).not.toContainText('File ID');


### PR DESCRIPTION
The backend now has a mandatory upload box size limit field, so we need to support this in the frontend as well.

As discussed with Paul, we specify the size in TiB. In the context of box sizes, SI TB could also make sense, but I think it's better to consistently use the binary scale throughout the application for individual file sizes, accumulated box sizes and quotas. To make this more explicit, and in the spirit of scientific accuracy, I changed the byte size rendering pipe to output the official GiB unit instead of GB etc. (we showed the commonly used but wrong units before). 