### PR TITLE
Shortening umami event name, adding hint to readme and updating TOC.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,14 @@ This repository contains the front-end application for the GHGA data portal.
 - [Code scaffolding](#code-scaffolding)
 - [Building](#building)
 - [Package Manager](#package-manager)
+  - [Dependency overrides](#dependency-overrides)
 - [Linter, Commits, and Documentation](#linter-commits-and-documentation)
   - [Ease of use](#ease-of-use)
 - [Automated tests](#automated-tests)
   - [Unit-tests](#unit-tests)
   - [End-to-End tests](#end-to-end-tests)
     - [Issues relating to headed execution](#issues-relating-to-headed-execution)
+- [Analytics](#analytics)
 - [The Architecture Matrix](#the-architecture-matrix)
 - [AI assisted coding](#ai-assisted-coding)
 - [References](#references)
@@ -233,6 +235,10 @@ On macOs, you can use [XQuartz](https://www.xquartz.org/). On Windows with WSL 2
 The directory `/tmp/.X11-unix` should exist and should be mounted on the corresponding host directory, which is `/mnt/wslg/.X11-unix` for WSLg. If you run `ls /tmp/.X11-unix`, it should show `X0`. If that is not the case, you may need to add or modify volume mounts manually in the `docker-compose.local.yml` file, of which a suitable version is created for you on startup.
 
 You may also need to add `/tmp/.X11-unix` to the virtual file shares in Docker Desktop under Linux, and run `xhost +local:docker` on the host system.
+
+## Analytics
+
+This SPA uses Umami for event tracking. Every clickable item has a property `data-umami-event` that is globally unique and which should clearly identify both the action and the environment it is occurring in. Furthermore, there's a limit of 50 characters for these event names - otherwise they will be ignored by the backend.
 
 ## The Architecture Matrix
 

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "eslint-plugin-prettier": "^5.5.5",
     "husky": "^9.1.7",
     "jsdom": "^29.1.1",
+    "markdown-toc-gen": "^1.2.0",
     "msw": "^2.14.6",
     "postcss": "^8.5.15",
     "prettier": "^3.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,9 @@ importers:
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
+      markdown-toc-gen:
+        specifier: ^1.2.0
+        version: 1.2.0
       msw:
         specifier: ^2.14.6
         version: 2.14.6(@types/node@25.9.1)(typescript@5.9.3)
@@ -1519,6 +1522,10 @@ packages:
     resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
     engines: {node: '>=8'}
 
+  '@jest/schemas@29.6.3':
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -2167,6 +2174,9 @@ packages:
   '@sigstore/verify@3.1.0':
     resolution: {integrity: sha512-mNe0Iigql08YupSOGv197YdHpPPr+EzDZmfCgMc7RPNaZTw5aLN01nBl6CHJOh3BGtnMIj83EeN4butBchc8Ag==}
     engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@sinclair/typebox@0.27.10':
+    resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
 
   '@sindresorhus/base62@1.0.0':
     resolution: {integrity: sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==}
@@ -3117,6 +3127,10 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
+  diff-sequences@29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   diff@4.0.4:
     resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
     engines: {node: '>=0.3.1'}
@@ -3832,6 +3846,14 @@ packages:
     resolution: {integrity: sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==}
     engines: {node: '>=10'}
 
+  jest-diff@29.7.0:
+    resolution: {integrity: sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-get-type@29.6.3:
+    resolution: {integrity: sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
@@ -4075,6 +4097,10 @@ packages:
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  markdown-toc-gen@1.2.0:
+    resolution: {integrity: sha512-+8eDFxBDC08XpBa8NdHaU0kDUGrc2XLn/3xCdzZZ0MWQ3ZvUhkdCAINeUwcGjhJ3zkBbfiVVWscORvI1UzO9sQ==}
+    hasBin: true
 
   marked@7.0.3:
     resolution: {integrity: sha512-ev2uM40p0zQ/GbvqotfKcSWEa59fJwluGZj5dcaUOwDRrB1F3dncdXy8NWUApk4fi8atU3kTBOwjyjZ0ud0dxw==}
@@ -4744,6 +4770,10 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  pretty-format@29.7.0:
+    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   prismjs@1.30.0:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
@@ -4793,6 +4823,9 @@ packages:
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
@@ -7226,6 +7259,10 @@ snapshots:
 
   '@istanbuljs/schema@0.1.6': {}
 
+  '@jest/schemas@29.6.3':
+    dependencies:
+      '@sinclair/typebox': 0.27.10
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -7726,6 +7763,8 @@ snapshots:
       '@sigstore/bundle': 4.0.0
       '@sigstore/core': 3.2.0
       '@sigstore/protobuf-specs': 0.5.1
+
+  '@sinclair/typebox@0.27.10': {}
 
   '@sindresorhus/base62@1.0.0': {}
 
@@ -8690,6 +8729,8 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  diff-sequences@29.6.3: {}
+
   diff@4.0.4: {}
 
   dijkstrajs@1.0.3: {}
@@ -9452,6 +9493,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  jest-diff@29.7.0:
+    dependencies:
+      chalk: 4.1.2
+      diff-sequences: 29.6.3
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+
+  jest-get-type@29.6.3: {}
+
   jiti@2.7.0: {}
 
   jose@6.2.3: {}
@@ -9686,6 +9736,11 @@ snapshots:
   map-stream@0.0.7: {}
 
   markdown-table@3.0.4: {}
+
+  markdown-toc-gen@1.2.0:
+    dependencies:
+      jest-diff: 29.7.0
+      yargs: 17.7.2
 
   marked@7.0.3: {}
 
@@ -10529,6 +10584,12 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
+  pretty-format@29.7.0:
+    dependencies:
+      '@jest/schemas': 29.6.3
+      ansi-styles: 5.2.0
+      react-is: 18.3.1
+
   prismjs@1.30.0: {}
 
   proc-log@6.1.0: {}
@@ -10574,6 +10635,8 @@ snapshots:
       unpipe: 1.0.0
 
   react-is@17.0.2: {}
+
+  react-is@18.3.1: {}
 
   readdirp@3.6.0:
     dependencies:

--- a/src/app/access-requests/features/active-access-grants-list/active-access-grants-list.html
+++ b/src/app/access-requests/features/active-access-grants-list/active-access-grants-list.html
@@ -43,7 +43,7 @@
                   [attr.aria-label]="
                     'Create a download token for dataset ' + grant.dataset_id
                   "
-                  data-umami-event="Granted Access Requests List Download Token Clicked"
+                  data-umami-event="Granted AR List Download Token Clicked"
                   class="w-full whitespace-nowrap"
                 >
                   <mat-icon fontIcon="download"></mat-icon>


### PR DESCRIPTION
The event name Granted Access Requests List Download Token Clicked was too long and therefore blocked by the backend. This fixes that, adds a hint about the issue to the readme and updates the TOC in the readme.