### PR TITLE
Handle archival error due to incomplete uploads (GSI-2420)

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "markdown-toc-gen": "^1.2.0",
     "msw": "^2.14.6",
     "postcss": "^8.5.15",
-    "prettier": "^3.8.3",
+    "prettier": "^3.8.4",
     "prettier-plugin-tailwindcss": "^0.8.0",
     "tailwindcss": "^4.3.0",
     "ts-node": "^10.9.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,7 +145,7 @@ importers:
         version: 62.9.0(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-prettier:
         specifier: ^5.5.6
-        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.3)
+        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.4)
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -162,11 +162,11 @@ importers:
         specifier: ^8.5.15
         version: 8.5.15
       prettier:
-        specifier: ^3.8.3
-        version: 3.8.3
+        specifier: ^3.8.4
+        version: 3.8.4
       prettier-plugin-tailwindcss:
         specifier: ^0.8.0
-        version: 0.8.0(prettier@3.8.3)
+        version: 0.8.0(prettier@3.8.4)
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.0
@@ -3171,8 +3171,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  electron-to-chromium@1.5.369:
-    resolution: {integrity: sha512-XM22K9FNaaCOvMMrBn1caIc8v0g6+pKt660ZbfQqUZvfil0hEzr8ZoiY7VcSLGM3L/x3rz5PqZrk+bKOOmVM9w==}
+  electron-to-chromium@1.5.370:
+    resolution: {integrity: sha512-D5tSHJReAb/Kf3Hu9F/GO4lJuSWzEWHwvQ/kKSUP7pimNgvxkSKj+gUQhHpKKACwrin7rS3byU7IxreF56rl5g==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -4763,8 +4763,8 @@ packages:
       prettier-plugin-svelte:
         optional: true
 
-  prettier@3.8.3:
-    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
+  prettier@3.8.4:
+    resolution: {integrity: sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -8447,7 +8447,7 @@ snapshots:
     dependencies:
       baseline-browser-mapping: 2.10.34
       caniuse-lite: 1.0.30001797
-      electron-to-chromium: 1.5.369
+      electron-to-chromium: 1.5.370
       node-releases: 2.0.47
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
@@ -8768,7 +8768,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  electron-to-chromium@1.5.369: {}
+  electron-to-chromium@1.5.370: {}
 
   emoji-regex@10.6.0: {}
 
@@ -8941,10 +8941,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-prettier@5.5.6(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.3):
+  eslint-plugin-prettier@5.5.6(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.4):
     dependencies:
       eslint: 9.39.4(jiti@2.7.0)
-      prettier: 3.8.3
+      prettier: 3.8.4
       prettier-linter-helpers: 1.0.1
       synckit: 0.11.13
     optionalDependencies:
@@ -10571,11 +10571,11 @@ snapshots:
     dependencies:
       fast-diff: 1.3.0
 
-  prettier-plugin-tailwindcss@0.8.0(prettier@3.8.3):
+  prettier-plugin-tailwindcss@0.8.0(prettier@3.8.4):
     dependencies:
-      prettier: 3.8.3
+      prettier: 3.8.4
 
-  prettier@3.8.3: {}
+  prettier@3.8.4: {}
 
   pretty-format@27.5.1:
     dependencies:

--- a/src/app/upload/features/upload-box-mapping/upload-box-mapping.spec.ts
+++ b/src/app/upload/features/upload-box-mapping/upload-box-mapping.spec.ts
@@ -4,6 +4,7 @@
  * @license Apache-2.0
  */
 
+import { HttpErrorResponse } from '@angular/common/http';
 import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialog } from '@angular/material/dialog';
@@ -15,6 +16,7 @@ import { MetadataService } from '@app/metadata/services/metadata';
 import { MetadataSearchService } from '@app/metadata/services/metadata-search';
 import { NavigationTrackingService } from '@app/shared/services/navigation';
 import { NotificationService } from '@app/shared/services/notification';
+import { ConfirmDialogComponent } from '@app/shared/ui/confirm-dialog/confirm-dialog';
 import { UploadBoxState } from '@app/upload/models/box';
 import { FileUploadWithAccession } from '@app/upload/models/file-upload';
 import { UploadBoxService } from '@app/upload/services/upload-box';
@@ -346,7 +348,7 @@ describe('UploadBoxMappingComponent', () => {
         'meta-3': 'file-3',
       },
     });
-    expect(uploadBoxService.archiveUploadBox).toHaveBeenCalledWith('box-1', 5);
+    expect(uploadBoxService.archiveUploadBox).toHaveBeenCalledWith('box-1', 5, false);
     expect(mockMappingStateService.clearSnapshot).toHaveBeenCalledWith('box-1');
     expect(mockNotificationService.showSuccess).toHaveBeenCalledWith(
       'File mapping submitted and upload box archived successfully.',
@@ -389,6 +391,146 @@ describe('UploadBoxMappingComponent', () => {
 
     component.onConfirmAndArchive();
 
+    expect(mockNotificationService.showError).toHaveBeenCalledWith(
+      'Mapping was submitted but archival failed.',
+    );
+  });
+
+  it('should force archival after confirmation when incomplete uploads block a 409 archival', async () => {
+    await createComponent({
+      studyAccession: TEST_STUDY.accession,
+      mappedField: 'alias',
+      manualMappings: [['meta-1', 'file-1']],
+    });
+    const archivedSpy = vitest.fn();
+    component.archived.subscribe(archivedSpy);
+    uploadBoxService.submitFileMapping.mockReturnValue(of(undefined));
+    uploadBoxService.archiveUploadBox
+      .mockReturnValueOnce(
+        throwError(
+          () =>
+            new HttpErrorResponse({
+              status: 409,
+              error: { data: { incomplete_uploads: ['file-2', 'file-3'] } },
+            }),
+        ),
+      )
+      .mockReturnValueOnce(of(undefined));
+    // First dialog: the mapping confirmation. Second: the force-archival prompt.
+    mockDialog.open
+      .mockReturnValueOnce({ afterClosed: () => of(true) })
+      .mockReturnValueOnce({ afterClosed: () => of(true) });
+    mockDialog.open.mockClear();
+
+    component.onConfirmAndArchive();
+
+    expect(mockDialog.open).toHaveBeenCalledWith(
+      ConfirmDialogComponent,
+      expect.objectContaining({
+        data: expect.objectContaining({
+          message:
+            'Archival failed because there are still 2 incomplete file uploads. Shall we archive anyway?',
+        }),
+      }),
+    );
+    expect(uploadBoxService.archiveUploadBox).toHaveBeenNthCalledWith(
+      1,
+      'box-1',
+      5,
+      false,
+    );
+    expect(uploadBoxService.archiveUploadBox).toHaveBeenNthCalledWith(
+      2,
+      'box-1',
+      5,
+      true,
+    );
+    expect(mockMappingStateService.clearSnapshot).toHaveBeenCalledWith('box-1');
+    expect(mockNotificationService.showSuccess).toHaveBeenCalledWith(
+      'File mapping submitted and upload box archived successfully.',
+    );
+    expect(archivedSpy).toHaveBeenCalled();
+  });
+
+  it('should leave the box non-archived when force archival is declined', async () => {
+    await createComponent({
+      studyAccession: TEST_STUDY.accession,
+      mappedField: 'alias',
+      manualMappings: [['meta-1', 'file-1']],
+    });
+    const archivedSpy = vitest.fn();
+    component.archived.subscribe(archivedSpy);
+    uploadBoxService.submitFileMapping.mockReturnValue(of(undefined));
+    uploadBoxService.archiveUploadBox.mockReturnValue(
+      throwError(
+        () =>
+          new HttpErrorResponse({
+            status: 409,
+            error: { data: { incomplete_uploads: ['file-2'] } },
+          }),
+      ),
+    );
+    mockDialog.open
+      .mockReturnValueOnce({ afterClosed: () => of(true) })
+      .mockReturnValueOnce({ afterClosed: () => of(false) });
+    mockDialog.open.mockClear();
+
+    component.onConfirmAndArchive();
+
+    expect(uploadBoxService.archiveUploadBox).toHaveBeenCalledTimes(1);
+    expect(uploadBoxService.archiveUploadBox).toHaveBeenCalledWith('box-1', 5, false);
+    expect(mockNotificationService.showError).not.toHaveBeenCalled();
+    expect(mockNotificationService.showSuccess).not.toHaveBeenCalled();
+    expect(archivedSpy).not.toHaveBeenCalled();
+    expect(component.isSubmitting()).toBe(false);
+  });
+
+  it('should show the generic error when a forced archival still fails', async () => {
+    await createComponent({
+      studyAccession: TEST_STUDY.accession,
+      mappedField: 'alias',
+      manualMappings: [['meta-1', 'file-1']],
+    });
+    uploadBoxService.submitFileMapping.mockReturnValue(of(undefined));
+    uploadBoxService.archiveUploadBox
+      .mockReturnValueOnce(
+        throwError(
+          () =>
+            new HttpErrorResponse({
+              status: 409,
+              error: { data: { incomplete_uploads: ['file-2'] } },
+            }),
+        ),
+      )
+      .mockReturnValueOnce(
+        throwError(
+          () =>
+            new HttpErrorResponse({
+              status: 409,
+              error: { data: { incomplete_uploads: ['file-2'] } },
+            }),
+        ),
+      );
+    mockDialog.open
+      .mockReturnValueOnce({ afterClosed: () => of(true) })
+      .mockReturnValueOnce({ afterClosed: () => of(true) });
+    mockDialog.open.mockClear();
+
+    component.onConfirmAndArchive();
+
+    // Two dialogs total: the mapping confirmation and a single force prompt.
+    // The failed forced retry must not reopen the force prompt.
+    expect(mockDialog.open).toHaveBeenCalledTimes(2);
+    expect(
+      mockDialog.open.mock.calls.filter(([cmp]) => cmp === ConfirmDialogComponent),
+    ).toHaveLength(1);
+    expect(uploadBoxService.archiveUploadBox).toHaveBeenCalledTimes(2);
+    expect(uploadBoxService.archiveUploadBox).toHaveBeenNthCalledWith(
+      2,
+      'box-1',
+      5,
+      true,
+    );
     expect(mockNotificationService.showError).toHaveBeenCalledWith(
       'Mapping was submitted but archival failed.',
     );

--- a/src/app/upload/features/upload-box-mapping/upload-box-mapping.ts
+++ b/src/app/upload/features/upload-box-mapping/upload-box-mapping.ts
@@ -4,6 +4,7 @@
  * @license Apache-2.0
  */
 
+import { HttpErrorResponse } from '@angular/common/http';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -32,7 +33,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatSort, MatSortModule } from '@angular/material/sort';
 import { MatTableDataSource, MatTableModule } from '@angular/material/table';
 import { RouterLink } from '@angular/router';
-import { catchError, concatMap, of, startWith, switchMap, throwError } from 'rxjs';
+import { of, startWith, switchMap } from 'rxjs';
 
 import { EmFile } from '@app/metadata/models/dataset-information';
 import { Study } from '@app/metadata/models/study';
@@ -698,32 +699,91 @@ export class UploadBoxMappingComponent implements OnInit {
         study_id: studyId,
         mapping,
       })
-      .pipe(
-        catchError(() => throwError(() => 'mapping' as const)),
-        concatMap(() =>
-          this.#uploadBoxService
-            .archiveUploadBox(box.id, box.version + 1)
-            .pipe(catchError(() => throwError(() => 'archival' as const))),
-        ),
-      )
       .subscribe({
-        next: () => {
+        next: () => this.#archiveAfterMapping(box, false),
+        error: () => {
           this.isSubmitting.set(false);
-          this.#mappingStateService.clearSnapshot(box.id);
-          this.#notificationService.showSuccess(
-            'File mapping submitted and upload box archived successfully.',
-          );
-          this.archived.emit();
-        },
-        error: (phase: 'mapping' | 'archival') => {
-          this.isSubmitting.set(false);
-          this.#notificationService.showError(
-            phase === 'archival'
-              ? 'Mapping was submitted but archival failed.'
-              : 'Failed to submit the file mapping.',
-          );
+          this.#notificationService.showError('Failed to submit the file mapping.');
         },
       });
+  }
+
+  /**
+   * Archive the box after the mapping was submitted. When the backend rejects
+   * the archival with a 409 because some uploads are still incomplete, ask the
+   * user whether to force it and retry once with force=true.
+   * @param box - the upload box being archived
+   * @param force - whether to force archival despite incomplete uploads
+   */
+  #archiveAfterMapping(box: ResearchDataUploadBox, force: boolean): void {
+    this.#uploadBoxService.archiveUploadBox(box.id, box.version + 1, force).subscribe({
+      next: () => {
+        this.isSubmitting.set(false);
+        this.#mappingStateService.clearSnapshot(box.id);
+        this.#notificationService.showSuccess(
+          'File mapping submitted and upload box archived successfully.',
+        );
+        this.archived.emit();
+      },
+      error: (err: unknown) => {
+        // Offer the force option only on the first attempt and only when the
+        // conflict is specifically caused by incomplete uploads. A forced
+        // retry that still fails falls through to the generic message.
+        const incompleteUploads = force ? null : this.#incompleteUploads(err);
+        if (incompleteUploads) {
+          this.#confirmForceArchival(box, incompleteUploads.length);
+        } else {
+          this.isSubmitting.set(false);
+          this.#notificationService.showError(
+            'Mapping was submitted but archival failed.',
+          );
+        }
+      },
+    });
+  }
+
+  /**
+   * Extract the incomplete uploads reported by a 409 archival conflict, which
+   * the user may override by forcing the archival.
+   * @param err - the error thrown by the archival request
+   * @returns the incomplete uploads, or null if this is not such a conflict
+   */
+  #incompleteUploads(err: unknown): unknown[] | null {
+    const response = err as HttpErrorResponse;
+    const data: unknown = response?.error?.data;
+    if (response?.status !== 409 || !data || typeof data !== 'object') return null;
+    const uploads = (data as { incomplete_uploads?: unknown }).incomplete_uploads;
+    return Array.isArray(uploads) ? uploads : null;
+  }
+
+  /**
+   * Ask the user whether to force archival despite incomplete uploads. On
+   * confirmation, retry the archival with force=true; otherwise leave the box
+   * in its non-archived state.
+   * @param box - the upload box being archived
+   * @param count - the number of still-incomplete file uploads
+   */
+  #confirmForceArchival(box: ResearchDataUploadBox, count: number): void {
+    const uploads = count === 1 ? 'upload' : 'uploads';
+    const ref = this.#dialog.open<ConfirmDialogComponent, ConfirmDialogData, boolean>(
+      ConfirmDialogComponent,
+      {
+        data: {
+          title: 'Archive upload box',
+          message: `Archival failed because there ${
+            count === 1 ? 'is' : 'are'
+          } still ${count} incomplete file ${uploads}. Shall we archive anyway?`,
+          confirmText: 'Archive anyway',
+        },
+      },
+    );
+    ref.afterClosed().subscribe((confirmed) => {
+      if (!confirmed) {
+        this.isSubmitting.set(false);
+        return;
+      }
+      this.#archiveAfterMapping(box, true);
+    });
   }
 
   /**

--- a/src/app/upload/services/upload-box.ts
+++ b/src/app/upload/services/upload-box.ts
@@ -485,15 +485,24 @@ export class UploadBoxService {
    * Send a PATCH request to set the upload box state to archived.
    * @param boxId - the ID of the upload box
    * @param currentVersion - the current (post-mapping) box version
+   * @param force - archive even if some file uploads are still incomplete
    * @returns An observable that completes when the archive is accepted
    */
-  archiveUploadBox(boxId: string, currentVersion: number): Observable<void> {
+  archiveUploadBox(
+    boxId: string,
+    currentVersion: number,
+    force = false,
+  ): Observable<void> {
     const changes: ResearchDataUploadBoxUpdate = {
       version: currentVersion,
       state: UploadBoxState.archived,
     };
+    // `force` makes the backend archive despite incomplete uploads; it is a
+    // request flag, not part of the persisted box state, so it is kept out of
+    // the local update below.
+    const body = force ? { ...changes, force: true } : changes;
     return this.#http
-      .patch<void>(`${this.#boxesUrl}/${encodeURIComponent(boxId)}`, changes)
+      .patch<void>(`${this.#boxesUrl}/${encodeURIComponent(boxId)}`, body)
       .pipe(tap(() => this.#updateUploadBoxLocally(boxId, changes)));
   }
 


### PR DESCRIPTION
When an upload box could not be archived because some file uploads were not completed, show the number of incomplete files and offer the option to archive anyway ("using the force").