### PR TITLE
Fix handling of incomplete files on upload

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-portal",
-  "version": "2.5.9",
+  "version": "2.5.10",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/app/upload/features/upload-box-mapping/upload-box-mapping.spec.ts
+++ b/src/app/upload/features/upload-box-mapping/upload-box-mapping.spec.ts
@@ -4,7 +4,6 @@
  * @license Apache-2.0
  */
 
-import { HttpErrorResponse } from '@angular/common/http';
 import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialog } from '@angular/material/dialog';
@@ -16,7 +15,6 @@ import { MetadataService } from '@app/metadata/services/metadata';
 import { MetadataSearchService } from '@app/metadata/services/metadata-search';
 import { NavigationTrackingService } from '@app/shared/services/navigation';
 import { NotificationService } from '@app/shared/services/notification';
-import { ConfirmDialogComponent } from '@app/shared/ui/confirm-dialog/confirm-dialog';
 import { UploadBoxState } from '@app/upload/models/box';
 import { FileUploadWithAccession } from '@app/upload/models/file-upload';
 import { UploadBoxService } from '@app/upload/services/upload-box';
@@ -348,7 +346,7 @@ describe('UploadBoxMappingComponent', () => {
         'meta-3': 'file-3',
       },
     });
-    expect(uploadBoxService.archiveUploadBox).toHaveBeenCalledWith('box-1', 5, false);
+    expect(uploadBoxService.archiveUploadBox).toHaveBeenCalledWith('box-1', 5);
     expect(mockMappingStateService.clearSnapshot).toHaveBeenCalledWith('box-1');
     expect(mockNotificationService.showSuccess).toHaveBeenCalledWith(
       'File mapping submitted and upload box archived successfully.',
@@ -391,146 +389,6 @@ describe('UploadBoxMappingComponent', () => {
 
     component.onConfirmAndArchive();
 
-    expect(mockNotificationService.showError).toHaveBeenCalledWith(
-      'Mapping was submitted but archival failed.',
-    );
-  });
-
-  it('should force archival after confirmation when incomplete uploads block a 409 archival', async () => {
-    await createComponent({
-      studyAccession: TEST_STUDY.accession,
-      mappedField: 'alias',
-      manualMappings: [['meta-1', 'file-1']],
-    });
-    const archivedSpy = vitest.fn();
-    component.archived.subscribe(archivedSpy);
-    uploadBoxService.submitFileMapping.mockReturnValue(of(undefined));
-    uploadBoxService.archiveUploadBox
-      .mockReturnValueOnce(
-        throwError(
-          () =>
-            new HttpErrorResponse({
-              status: 409,
-              error: { data: { incomplete_uploads: ['file-2', 'file-3'] } },
-            }),
-        ),
-      )
-      .mockReturnValueOnce(of(undefined));
-    // First dialog: the mapping confirmation. Second: the force-archival prompt.
-    mockDialog.open
-      .mockReturnValueOnce({ afterClosed: () => of(true) })
-      .mockReturnValueOnce({ afterClosed: () => of(true) });
-    mockDialog.open.mockClear();
-
-    component.onConfirmAndArchive();
-
-    expect(mockDialog.open).toHaveBeenCalledWith(
-      ConfirmDialogComponent,
-      expect.objectContaining({
-        data: expect.objectContaining({
-          message:
-            'Archival failed because there are still 2 incomplete file uploads. Shall we archive anyway?',
-        }),
-      }),
-    );
-    expect(uploadBoxService.archiveUploadBox).toHaveBeenNthCalledWith(
-      1,
-      'box-1',
-      5,
-      false,
-    );
-    expect(uploadBoxService.archiveUploadBox).toHaveBeenNthCalledWith(
-      2,
-      'box-1',
-      5,
-      true,
-    );
-    expect(mockMappingStateService.clearSnapshot).toHaveBeenCalledWith('box-1');
-    expect(mockNotificationService.showSuccess).toHaveBeenCalledWith(
-      'File mapping submitted and upload box archived successfully.',
-    );
-    expect(archivedSpy).toHaveBeenCalled();
-  });
-
-  it('should leave the box non-archived when force archival is declined', async () => {
-    await createComponent({
-      studyAccession: TEST_STUDY.accession,
-      mappedField: 'alias',
-      manualMappings: [['meta-1', 'file-1']],
-    });
-    const archivedSpy = vitest.fn();
-    component.archived.subscribe(archivedSpy);
-    uploadBoxService.submitFileMapping.mockReturnValue(of(undefined));
-    uploadBoxService.archiveUploadBox.mockReturnValue(
-      throwError(
-        () =>
-          new HttpErrorResponse({
-            status: 409,
-            error: { data: { incomplete_uploads: ['file-2'] } },
-          }),
-      ),
-    );
-    mockDialog.open
-      .mockReturnValueOnce({ afterClosed: () => of(true) })
-      .mockReturnValueOnce({ afterClosed: () => of(false) });
-    mockDialog.open.mockClear();
-
-    component.onConfirmAndArchive();
-
-    expect(uploadBoxService.archiveUploadBox).toHaveBeenCalledTimes(1);
-    expect(uploadBoxService.archiveUploadBox).toHaveBeenCalledWith('box-1', 5, false);
-    expect(mockNotificationService.showError).not.toHaveBeenCalled();
-    expect(mockNotificationService.showSuccess).not.toHaveBeenCalled();
-    expect(archivedSpy).not.toHaveBeenCalled();
-    expect(component.isSubmitting()).toBe(false);
-  });
-
-  it('should show the generic error when a forced archival still fails', async () => {
-    await createComponent({
-      studyAccession: TEST_STUDY.accession,
-      mappedField: 'alias',
-      manualMappings: [['meta-1', 'file-1']],
-    });
-    uploadBoxService.submitFileMapping.mockReturnValue(of(undefined));
-    uploadBoxService.archiveUploadBox
-      .mockReturnValueOnce(
-        throwError(
-          () =>
-            new HttpErrorResponse({
-              status: 409,
-              error: { data: { incomplete_uploads: ['file-2'] } },
-            }),
-        ),
-      )
-      .mockReturnValueOnce(
-        throwError(
-          () =>
-            new HttpErrorResponse({
-              status: 409,
-              error: { data: { incomplete_uploads: ['file-2'] } },
-            }),
-        ),
-      );
-    mockDialog.open
-      .mockReturnValueOnce({ afterClosed: () => of(true) })
-      .mockReturnValueOnce({ afterClosed: () => of(true) });
-    mockDialog.open.mockClear();
-
-    component.onConfirmAndArchive();
-
-    // Two dialogs total: the mapping confirmation and a single force prompt.
-    // The failed forced retry must not reopen the force prompt.
-    expect(mockDialog.open).toHaveBeenCalledTimes(2);
-    expect(
-      mockDialog.open.mock.calls.filter(([cmp]) => cmp === ConfirmDialogComponent),
-    ).toHaveLength(1);
-    expect(uploadBoxService.archiveUploadBox).toHaveBeenCalledTimes(2);
-    expect(uploadBoxService.archiveUploadBox).toHaveBeenNthCalledWith(
-      2,
-      'box-1',
-      5,
-      true,
-    );
     expect(mockNotificationService.showError).toHaveBeenCalledWith(
       'Mapping was submitted but archival failed.',
     );

--- a/src/app/upload/features/upload-box-mapping/upload-box-mapping.ts
+++ b/src/app/upload/features/upload-box-mapping/upload-box-mapping.ts
@@ -4,7 +4,6 @@
  * @license Apache-2.0
  */
 
-import { HttpErrorResponse } from '@angular/common/http';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -33,7 +32,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatSort, MatSortModule } from '@angular/material/sort';
 import { MatTableDataSource, MatTableModule } from '@angular/material/table';
 import { RouterLink } from '@angular/router';
-import { of, startWith, switchMap } from 'rxjs';
+import { catchError, concatMap, of, startWith, switchMap, throwError } from 'rxjs';
 
 import { EmFile } from '@app/metadata/models/dataset-information';
 import { Study } from '@app/metadata/models/study';
@@ -699,91 +698,32 @@ export class UploadBoxMappingComponent implements OnInit {
         study_id: studyId,
         mapping,
       })
+      .pipe(
+        catchError(() => throwError(() => 'mapping' as const)),
+        concatMap(() =>
+          this.#uploadBoxService
+            .archiveUploadBox(box.id, box.version + 1)
+            .pipe(catchError(() => throwError(() => 'archival' as const))),
+        ),
+      )
       .subscribe({
-        next: () => this.#archiveAfterMapping(box, false),
-        error: () => {
+        next: () => {
           this.isSubmitting.set(false);
-          this.#notificationService.showError('Failed to submit the file mapping.');
+          this.#mappingStateService.clearSnapshot(box.id);
+          this.#notificationService.showSuccess(
+            'File mapping submitted and upload box archived successfully.',
+          );
+          this.archived.emit();
         },
-      });
-  }
-
-  /**
-   * Archive the box after the mapping was submitted. When the backend rejects
-   * the archival with a 409 because some uploads are still incomplete, ask the
-   * user whether to force it and retry once with force=true.
-   * @param box - the upload box being archived
-   * @param force - whether to force archival despite incomplete uploads
-   */
-  #archiveAfterMapping(box: ResearchDataUploadBox, force: boolean): void {
-    this.#uploadBoxService.archiveUploadBox(box.id, box.version + 1, force).subscribe({
-      next: () => {
-        this.isSubmitting.set(false);
-        this.#mappingStateService.clearSnapshot(box.id);
-        this.#notificationService.showSuccess(
-          'File mapping submitted and upload box archived successfully.',
-        );
-        this.archived.emit();
-      },
-      error: (err: unknown) => {
-        // Offer the force option only on the first attempt and only when the
-        // conflict is specifically caused by incomplete uploads. A forced
-        // retry that still fails falls through to the generic message.
-        const incompleteUploads = force ? null : this.#incompleteUploads(err);
-        if (incompleteUploads) {
-          this.#confirmForceArchival(box, incompleteUploads.length);
-        } else {
+        error: (phase: 'mapping' | 'archival') => {
           this.isSubmitting.set(false);
           this.#notificationService.showError(
-            'Mapping was submitted but archival failed.',
+            phase === 'archival'
+              ? 'Mapping was submitted but archival failed.'
+              : 'Failed to submit the file mapping.',
           );
-        }
-      },
-    });
-  }
-
-  /**
-   * Extract the incomplete uploads reported by a 409 archival conflict, which
-   * the user may override by forcing the archival.
-   * @param err - the error thrown by the archival request
-   * @returns the incomplete uploads, or null if this is not such a conflict
-   */
-  #incompleteUploads(err: unknown): unknown[] | null {
-    const response = err as HttpErrorResponse;
-    const data: unknown = response?.error?.data;
-    if (response?.status !== 409 || !data || typeof data !== 'object') return null;
-    const uploads = (data as { incomplete_uploads?: unknown }).incomplete_uploads;
-    return Array.isArray(uploads) ? uploads : null;
-  }
-
-  /**
-   * Ask the user whether to force archival despite incomplete uploads. On
-   * confirmation, retry the archival with force=true; otherwise leave the box
-   * in its non-archived state.
-   * @param box - the upload box being archived
-   * @param count - the number of still-incomplete file uploads
-   */
-  #confirmForceArchival(box: ResearchDataUploadBox, count: number): void {
-    const uploads = count === 1 ? 'upload' : 'uploads';
-    const ref = this.#dialog.open<ConfirmDialogComponent, ConfirmDialogData, boolean>(
-      ConfirmDialogComponent,
-      {
-        data: {
-          title: 'Archive upload box',
-          message: `Archival failed because there ${
-            count === 1 ? 'is' : 'are'
-          } still ${count} incomplete file ${uploads}. Shall we archive anyway?`,
-          confirmText: 'Archive anyway',
         },
-      },
-    );
-    ref.afterClosed().subscribe((confirmed) => {
-      if (!confirmed) {
-        this.isSubmitting.set(false);
-        return;
-      }
-      this.#archiveAfterMapping(box, true);
-    });
+      });
   }
 
   /**

--- a/src/app/upload/features/user-upload-grants-list/user-upload-grants-list.spec.ts
+++ b/src/app/upload/features/user-upload-grants-list/user-upload-grants-list.spec.ts
@@ -4,6 +4,7 @@
  * @license Apache-2.0
  */
 
+import { HttpErrorResponse } from '@angular/common/http';
 import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialog } from '@angular/material/dialog';
@@ -53,7 +54,7 @@ class MockUploadBoxService {
     reload: vitest.fn(),
   };
 
-  updateUploadBox = vitest.fn();
+  lockUploadBox = vitest.fn();
 
   /**
    * Test helper: set the loaded grants.
@@ -201,18 +202,15 @@ describe('UserUploadGrantsListComponent', () => {
       mockConfirmationService.confirm.mockImplementation(({ callback }) =>
         callback(true),
       );
-      uploadBoxService.updateUploadBox.mockReturnValue(of(undefined));
+      uploadBoxService.lockUploadBox.mockReturnValue(of(undefined));
       uploadBoxService.setGrants([openGrant]);
       fixture.detectChanges();
       screen.getByRole('button', { name: /submit this upload box/i }).click();
       await fixture.whenStable();
     });
 
-    it('should call updateUploadBox with box id, version, and locked state', () => {
-      expect(uploadBoxService.updateUploadBox).toHaveBeenCalledWith('box-001', {
-        version: 1,
-        state: UploadBoxState.locked,
-      });
+    it('should call lockUploadBox with box id, version, and no force', () => {
+      expect(uploadBoxService.lockUploadBox).toHaveBeenCalledWith('box-001', 1, false);
     });
 
     it('should show a success notification', () => {
@@ -231,7 +229,7 @@ describe('UserUploadGrantsListComponent', () => {
       mockConfirmationService.confirm.mockImplementation(({ callback }) =>
         callback(true),
       );
-      uploadBoxService.updateUploadBox.mockReturnValue(
+      uploadBoxService.lockUploadBox.mockReturnValue(
         throwError(() => new Error('Server error')),
       );
       uploadBoxService.setGrants([openGrant]);
@@ -251,6 +249,136 @@ describe('UserUploadGrantsListComponent', () => {
     });
   });
 
+  describe('submitBox - incomplete uploads conflict', () => {
+    /**
+     * Build a 409 conflict reporting incomplete uploads, matching the backend
+     * response that blocks locking a box with unfinished uploads.
+     * @param incompleteUploads - the still-incomplete upload IDs
+     * @returns an HttpErrorResponse with the conflict payload
+     */
+    const conflict = (incompleteUploads: string[]): HttpErrorResponse =>
+      new HttpErrorResponse({
+        status: 409,
+        error: { data: { incomplete_uploads: incompleteUploads } },
+      });
+
+    beforeEach(() => {
+      uploadBoxService.setGrants([openGrant]);
+    });
+
+    it('should force submission after confirmation when a 409 blocks the submission', async () => {
+      uploadBoxService.lockUploadBox
+        .mockReturnValueOnce(throwError(() => conflict(['file-2', 'file-3'])))
+        .mockReturnValueOnce(of(undefined));
+      // First confirm: the submit prompt. Second: the force-submit prompt.
+      mockConfirmationService.confirm
+        .mockImplementationOnce(({ callback }) => callback(true))
+        .mockImplementationOnce(({ callback }) => callback(true));
+      fixture.detectChanges();
+
+      screen.getByRole('button', { name: /submit this upload box/i }).click();
+      await fixture.whenStable();
+
+      expect(mockConfirmationService.confirm).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          message:
+            'Submission failed because there are still 2 incomplete file uploads. ' +
+            'Do you want to submit anyway?',
+          confirmText: 'Submit anyway',
+        }),
+      );
+      expect(uploadBoxService.lockUploadBox).toHaveBeenNthCalledWith(
+        1,
+        'box-001',
+        1,
+        false,
+      );
+      expect(uploadBoxService.lockUploadBox).toHaveBeenNthCalledWith(
+        2,
+        'box-001',
+        1,
+        true,
+      );
+      expect(mockNotificationService.showSuccess).toHaveBeenCalledWith(
+        'The upload box has been submitted successfully.',
+      );
+    });
+
+    it('should leave the box open when force submission is declined', async () => {
+      uploadBoxService.lockUploadBox.mockReturnValue(
+        throwError(() => conflict(['file-2'])),
+      );
+      mockConfirmationService.confirm
+        .mockImplementationOnce(({ callback }) => callback(true))
+        .mockImplementationOnce(({ callback }) => callback(false));
+      fixture.detectChanges();
+
+      screen.getByRole('button', { name: /submit this upload box/i }).click();
+      await fixture.whenStable();
+
+      expect(mockConfirmationService.confirm).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          message:
+            'Submission failed because there is still 1 incomplete file upload. ' +
+            'Do you want to submit anyway?',
+          confirmText: 'Submit anyway',
+        }),
+      );
+      expect(uploadBoxService.lockUploadBox).toHaveBeenCalledTimes(1);
+      expect(uploadBoxService.lockUploadBox).toHaveBeenCalledWith('box-001', 1, false);
+      expect(mockNotificationService.showError).not.toHaveBeenCalled();
+      expect(mockNotificationService.showSuccess).not.toHaveBeenCalled();
+    });
+
+    it('should show the generic error when a forced submission still fails', async () => {
+      uploadBoxService.lockUploadBox
+        .mockReturnValueOnce(throwError(() => conflict(['file-2'])))
+        .mockReturnValueOnce(throwError(() => conflict(['file-2'])));
+      mockConfirmationService.confirm
+        .mockImplementationOnce(({ callback }) => callback(true))
+        .mockImplementationOnce(({ callback }) => callback(true));
+      fixture.detectChanges();
+
+      screen.getByRole('button', { name: /submit this upload box/i }).click();
+      await fixture.whenStable();
+
+      // Two confirmations total: the submit prompt and a single force prompt.
+      // The failed forced retry must not reopen the force prompt.
+      expect(mockConfirmationService.confirm).toHaveBeenCalledTimes(2);
+      expect(uploadBoxService.lockUploadBox).toHaveBeenCalledTimes(2);
+      expect(uploadBoxService.lockUploadBox).toHaveBeenNthCalledWith(
+        2,
+        'box-001',
+        1,
+        true,
+      );
+      expect(mockNotificationService.showError).toHaveBeenCalledWith(
+        'Failed to submit the upload box. Please try again.',
+      );
+    });
+
+    it('should show the generic error for a non-conflict failure without prompting to force', async () => {
+      uploadBoxService.lockUploadBox.mockReturnValue(
+        throwError(() => new Error('Server error')),
+      );
+      mockConfirmationService.confirm.mockImplementationOnce(({ callback }) =>
+        callback(true),
+      );
+      fixture.detectChanges();
+
+      screen.getByRole('button', { name: /submit this upload box/i }).click();
+      await fixture.whenStable();
+
+      expect(mockConfirmationService.confirm).toHaveBeenCalledTimes(1);
+      expect(uploadBoxService.lockUploadBox).toHaveBeenCalledTimes(1);
+      expect(mockNotificationService.showError).toHaveBeenCalledWith(
+        'Failed to submit the upload box. Please try again.',
+      );
+    });
+  });
+
   describe('submitBox - cancelled', () => {
     beforeEach(async () => {
       mockConfirmationService.confirm.mockImplementation(({ callback }) =>
@@ -262,8 +390,8 @@ describe('UserUploadGrantsListComponent', () => {
       await fixture.whenStable();
     });
 
-    it('should not call updateUploadBox', () => {
-      expect(uploadBoxService.updateUploadBox).not.toHaveBeenCalled();
+    it('should not call lockUploadBox', () => {
+      expect(uploadBoxService.lockUploadBox).not.toHaveBeenCalled();
     });
 
     it('should not show any notification', () => {

--- a/src/app/upload/features/user-upload-grants-list/user-upload-grants-list.ts
+++ b/src/app/upload/features/user-upload-grants-list/user-upload-grants-list.ts
@@ -4,6 +4,7 @@
  * @license Apache-2.0
  */
 
+import { HttpErrorResponse } from '@angular/common/http';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -87,26 +88,78 @@ export class UserUploadGrantsListComponent {
       confirmText: 'Submit',
       callback: (confirmed) => {
         if (!confirmed) return;
-        this.submittingBoxId.set(grant.box_id);
-        this.#uploadBoxService
-          .updateUploadBox(grant.box_id, {
-            version: grant.box_version,
-            state: UploadBoxState.locked,
-          })
-          .subscribe({
-            next: () => {
-              this.submittingBoxId.set(null);
-              this.#notification.showSuccess(
-                'The upload box has been submitted successfully.',
-              );
-            },
-            error: () => {
-              this.submittingBoxId.set(null);
-              this.#notification.showError(
-                'Failed to submit the upload box. Please try again.',
-              );
-            },
-          });
+        this.#submitBox(grant, false);
+      },
+    });
+  }
+
+  /**
+   * Submit the upload box (set state to locked). When the backend rejects the
+   * submission with a 409 because some uploads are still incomplete, ask the
+   * user whether to force it and retry once with force=true.
+   * @param grant - the grant whose upload box should be submitted
+   * @param force - whether to submit despite incomplete uploads
+   */
+  #submitBox(grant: GrantWithBoxInfo, force: boolean): void {
+    this.submittingBoxId.set(grant.box_id);
+    this.#uploadBoxService
+      .lockUploadBox(grant.box_id, grant.box_version, force)
+      .subscribe({
+        next: () => {
+          this.submittingBoxId.set(null);
+          this.#notification.showSuccess(
+            'The upload box has been submitted successfully.',
+          );
+        },
+        error: (err: unknown) => {
+          // Offer the force option only on the first attempt and only when the
+          // conflict is specifically caused by incomplete uploads. A forced
+          // retry that still fails falls through to the generic message.
+          const incompleteUploads = force ? null : this.#incompleteUploads(err);
+          if (incompleteUploads) {
+            this.#confirmForceSubmit(grant, incompleteUploads.length);
+          } else {
+            this.submittingBoxId.set(null);
+            this.#notification.showError(
+              'Failed to submit the upload box. Please try again.',
+            );
+          }
+        },
+      });
+  }
+
+  /**
+   * Extract the incomplete uploads reported by a 409 submission conflict, which
+   * the user may override by forcing the submission.
+   * @param err - the error thrown by the submission request
+   * @returns the incomplete uploads, or null if this is not such a conflict
+   */
+  #incompleteUploads(err: unknown): unknown[] | null {
+    const response = err as HttpErrorResponse;
+    const data: unknown = response?.error?.data;
+    if (response?.status !== 409 || !data || typeof data !== 'object') return null;
+    const uploads = (data as { incomplete_uploads?: unknown }).incomplete_uploads;
+    return Array.isArray(uploads) ? uploads : null;
+  }
+
+  /**
+   * Ask the user whether to submit despite incomplete uploads. On confirmation,
+   * retry the submission with force=true; otherwise leave the box open.
+   * @param grant - the grant whose upload box should be submitted
+   * @param count - the number of still-incomplete file uploads
+   */
+  #confirmForceSubmit(grant: GrantWithBoxInfo, count: number): void {
+    const [are, uploads] = count === 1 ? ['is', 'upload'] : ['are', 'uploads'];
+    this.#confirmation.confirm({
+      title: 'Incomplete uploads detected!',
+      message: `Submission failed because there ${are} still ${count} incomplete file ${uploads}. Do you want to submit anyway?`,
+      confirmText: 'Submit anyway',
+      callback: (confirmed) => {
+        if (!confirmed) {
+          this.submittingBoxId.set(null);
+          return;
+        }
+        this.#submitBox(grant, true);
       },
     });
   }

--- a/src/app/upload/services/upload-box.spec.ts
+++ b/src/app/upload/services/upload-box.spec.ts
@@ -417,6 +417,36 @@ describe('UploadBoxService', () => {
     expect(caughtError?.status).toBe(409);
   });
 
+  it('should lock an upload box without a force flag by default', () => {
+    const id = TEST_BOX_RETRIEVAL_RESULTS.boxes[0].id;
+
+    let completed = false;
+    service.lockUploadBox(id, 1).subscribe({ complete: () => (completed = true) });
+
+    const req = httpMock.expectOne(`http://mock.dev/rs/upload-boxes/${id}`);
+    expect(req.request.method).toBe('PATCH');
+    expect(req.request.body).toEqual({ version: 1, state: UploadBoxState.locked });
+    expect('force' in req.request.body).toBe(false);
+    req.flush(null, { status: 204, statusText: 'No Content' });
+
+    expect(completed).toBe(true);
+  });
+
+  it('should add the force flag when locking is forced', () => {
+    const id = TEST_BOX_RETRIEVAL_RESULTS.boxes[0].id;
+
+    service.lockUploadBox(id, 1, true).subscribe();
+
+    const req = httpMock.expectOne(`http://mock.dev/rs/upload-boxes/${id}`);
+    expect(req.request.method).toBe('PATCH');
+    expect(req.request.body).toEqual({
+      version: 1,
+      state: UploadBoxState.locked,
+      force: true,
+    });
+    req.flush(null, { status: 204, statusText: 'No Content' });
+  });
+
   describe('loadBoxGrants', () => {
     const BOX_ID = '0a36607a-b53f-49ed-bf3e-a5f2dbc68001';
     const GRANT: UploadGrant = {

--- a/src/app/upload/services/upload-box.ts
+++ b/src/app/upload/services/upload-box.ts
@@ -346,6 +346,32 @@ export class UploadBoxService {
   }
 
   /**
+   * Send a PATCH request to set the upload box state to locked (submitted).
+   * @param boxId - the ID of the upload box
+   * @param currentVersion - the current box version
+   * @param force - lock even if some file uploads are still incomplete
+   * @returns An observable that completes when the lock is accepted
+   */
+  lockUploadBox(
+    boxId: string,
+    currentVersion: number,
+    force = false,
+  ): Observable<void> {
+    const changes: ResearchDataUploadBoxUpdate = {
+      version: currentVersion,
+      state: UploadBoxState.locked,
+    };
+    // `force` makes the backend lock the box despite incomplete uploads; it is
+    // a request flag, not part of the persisted box state, so it is kept out of
+    // the local update below. The backend only accepts it on the open→locked
+    // transition, so it lives here rather than on the generic updateUploadBox.
+    const body = force ? { ...changes, force: true } : changes;
+    return this.#http
+      .patch<void>(`${this.#boxesUrl}/${encodeURIComponent(boxId)}`, body)
+      .pipe(tap(() => this.#updateUploadBoxLocally(boxId, changes)));
+  }
+
+  /**
    * Set the active filter for the upload box list.
    * @param filter - the filter to apply
    */
@@ -485,24 +511,15 @@ export class UploadBoxService {
    * Send a PATCH request to set the upload box state to archived.
    * @param boxId - the ID of the upload box
    * @param currentVersion - the current (post-mapping) box version
-   * @param force - archive even if some file uploads are still incomplete
    * @returns An observable that completes when the archive is accepted
    */
-  archiveUploadBox(
-    boxId: string,
-    currentVersion: number,
-    force = false,
-  ): Observable<void> {
+  archiveUploadBox(boxId: string, currentVersion: number): Observable<void> {
     const changes: ResearchDataUploadBoxUpdate = {
       version: currentVersion,
       state: UploadBoxState.archived,
     };
-    // `force` makes the backend archive despite incomplete uploads; it is a
-    // request flag, not part of the persisted box state, so it is kept out of
-    // the local update below.
-    const body = force ? { ...changes, force: true } : changes;
     return this.#http
-      .patch<void>(`${this.#boxesUrl}/${encodeURIComponent(boxId)}`, body)
+      .patch<void>(`${this.#boxesUrl}/${encodeURIComponent(boxId)}`, changes)
       .pipe(tap(() => this.#updateUploadBoxLocally(boxId, changes)));
   }
 


### PR DESCRIPTION
The backend blocks upload box state changes from open to locked when there are incomplete file uploads.

So this needs to be handled on the user-facing path where the user submits an upload box, not in the upload box manager when the state is set to archived, as it was implemented before.