### PR TITLE
Locking and unlocking of boxes by data stewards

### DIFF
--- a/src/app/upload/features/upload-box-manager-detail/upload-box-manager-detail.html
+++ b/src/app/upload/features/upload-box-manager-detail/upload-box-manager-detail.html
@@ -72,6 +72,31 @@
                 {{ box.max_size | parseBytes }}</span
               >
             </p>
+            @if (box.state === 'open') {
+              <button
+                mat-raised-button
+                color="primary"
+                class="mt-4"
+                (click)="lockBox()"
+                [disabled]="isChangingState()"
+                data-umami-event="Upload Box Manager Detail Lock Box Clicked"
+              >
+                <mat-icon fontIcon="lock"></mat-icon>
+                Lock the box
+              </button>
+            } @else if (box.state === 'locked') {
+              <button
+                mat-raised-button
+                color="primary"
+                class="mt-4"
+                (click)="openBox()"
+                [disabled]="isChangingState()"
+                data-umami-event="Upload Box Manager Detail Open Box Clicked"
+              >
+                <mat-icon fontIcon="lock_open"></mat-icon>
+                Open the box again
+              </button>
+            }
           </mat-card-content>
         </mat-card>
 

--- a/src/app/upload/features/upload-box-manager-detail/upload-box-manager-detail.spec.ts
+++ b/src/app/upload/features/upload-box-manager-detail/upload-box-manager-detail.spec.ts
@@ -70,6 +70,8 @@ class MockUploadBoxService {
   submitFileMapping = vitest.fn(() => of(undefined));
   archiveUploadBox = vitest.fn(() => of(undefined));
   deleteFileUpload = vitest.fn(() => of(undefined));
+  lockUploadBox = vitest.fn(() => of(undefined));
+  openUploadBox = vitest.fn(() => of(undefined));
 
   getStorageLocationLabel = (alias: string) =>
     this.storageLabels.value()[alias] ?? alias;
@@ -393,6 +395,148 @@ describe('UploadBoxManagerDetailComponent', () => {
 
       expect(mockNotificationService.showError).toHaveBeenCalled();
       expect(mockNotificationService.showSuccess).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('changing the box state', () => {
+    beforeEach(() => {
+      mockDialog.open.mockReset();
+      mockNotificationService.showSuccess.mockClear();
+      mockNotificationService.showError.mockClear();
+      uploadBoxService.lockUploadBox.mockClear();
+      uploadBoxService.lockUploadBox.mockReturnValue(of(undefined));
+      uploadBoxService.openUploadBox.mockClear();
+      uploadBoxService.openUploadBox.mockReturnValue(of(undefined));
+    });
+
+    describe('when the box is open', () => {
+      beforeEach(async () => {
+        uploadBoxService.setUploadBoxes(uploadBoxes.boxes);
+        fixture.componentRef.setInput('id', TEST_BOX.id);
+        await fixture.whenStable();
+      });
+
+      it('should show the lock button but not the reopen button', () => {
+        expect(screen.getByRole('button', { name: /lock the box/i })).toBeVisible();
+        expect(
+          screen.queryByRole('button', { name: /open the box again/i }),
+        ).not.toBeInTheDocument();
+      });
+
+      it('should lock the box after confirmation', async () => {
+        mockDialog.open.mockReturnValue({ afterClosed: () => of(true) });
+
+        component.lockBox();
+        await fixture.whenStable();
+
+        expect(mockDialog.open).toHaveBeenCalledTimes(1);
+        expect(uploadBoxService.lockUploadBox).toHaveBeenCalledWith(
+          TEST_BOX.id,
+          TEST_BOX.version,
+          false,
+        );
+        expect(mockNotificationService.showSuccess).toHaveBeenCalled();
+      });
+
+      it('should not lock the box when the confirmation is cancelled', async () => {
+        mockDialog.open.mockReturnValue({ afterClosed: () => of(false) });
+
+        component.lockBox();
+        await fixture.whenStable();
+
+        expect(uploadBoxService.lockUploadBox).not.toHaveBeenCalled();
+        expect(mockNotificationService.showSuccess).not.toHaveBeenCalled();
+      });
+
+      it('should offer to force the lock when uploads are incomplete', async () => {
+        mockDialog.open.mockReturnValue({ afterClosed: () => of(true) });
+        const conflict = Object.assign(new Error('Conflict'), {
+          status: 409,
+          error: { data: { incomplete_uploads: ['file1', 'file2'] } },
+        });
+        uploadBoxService.lockUploadBox.mockReturnValueOnce(throwError(() => conflict));
+
+        component.lockBox();
+        await fixture.whenStable();
+
+        expect(mockDialog.open).toHaveBeenCalledTimes(2);
+        expect(uploadBoxService.lockUploadBox).toHaveBeenLastCalledWith(
+          TEST_BOX.id,
+          TEST_BOX.version,
+          true,
+        );
+        expect(mockNotificationService.showSuccess).toHaveBeenCalled();
+        expect(mockNotificationService.showError).not.toHaveBeenCalled();
+      });
+
+      it('should show an error notification when locking fails', async () => {
+        mockDialog.open.mockReturnValue({ afterClosed: () => of(true) });
+        uploadBoxService.lockUploadBox.mockReturnValueOnce(
+          throwError(() => new Error('failed')),
+        );
+
+        component.lockBox();
+        await fixture.whenStable();
+
+        expect(mockNotificationService.showError).toHaveBeenCalled();
+        expect(mockNotificationService.showSuccess).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when the box is locked', () => {
+      const lockedBox = uploadBoxes.boxes[1];
+
+      beforeEach(async () => {
+        uploadBoxService.setUploadBoxes(uploadBoxes.boxes);
+        fixture.componentRef.setInput('id', lockedBox.id);
+        await fixture.whenStable();
+      });
+
+      it('should show the reopen button but not the lock button', () => {
+        expect(
+          screen.getByRole('button', { name: /open the box again/i }),
+        ).toBeVisible();
+        expect(
+          screen.queryByRole('button', { name: /lock the box/i }),
+        ).not.toBeInTheDocument();
+      });
+
+      it('should reopen the box after confirmation', async () => {
+        mockDialog.open.mockReturnValue({ afterClosed: () => of(true) });
+
+        component.openBox();
+        await fixture.whenStable();
+
+        expect(mockDialog.open).toHaveBeenCalledTimes(1);
+        expect(uploadBoxService.openUploadBox).toHaveBeenCalledWith(
+          lockedBox.id,
+          lockedBox.version,
+        );
+        expect(mockNotificationService.showSuccess).toHaveBeenCalled();
+      });
+
+      it('should not reopen the box when the confirmation is cancelled', async () => {
+        mockDialog.open.mockReturnValue({ afterClosed: () => of(false) });
+
+        component.openBox();
+        await fixture.whenStable();
+
+        expect(uploadBoxService.openUploadBox).not.toHaveBeenCalled();
+        expect(mockNotificationService.showSuccess).not.toHaveBeenCalled();
+      });
+
+      it('should show an error notification when reopening fails', async () => {
+        mockDialog.open.mockReturnValue({ afterClosed: () => of(true) });
+        uploadBoxService.openUploadBox.mockReturnValueOnce(
+          throwError(() => new Error('failed')),
+        );
+
+        component.openBox();
+        await fixture.whenStable();
+
+        expect(mockNotificationService.showError).toHaveBeenCalled();
+        expect(mockNotificationService.showSuccess).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/src/app/upload/features/upload-box-manager-detail/upload-box-manager-detail.ts
+++ b/src/app/upload/features/upload-box-manager-detail/upload-box-manager-detail.ts
@@ -216,6 +216,127 @@ export class UploadBoxManagerDetailComponent implements OnInit {
     return grant.valid_from <= today && today <= grant.valid_until;
   }
 
+  /** Whether a box state change (lock or reopen) is currently in flight. */
+  isChangingState = signal<boolean>(false);
+
+  /**
+   * Ask for confirmation and, on approval, lock the upload box.
+   */
+  lockBox(): void {
+    const box = this.uploadBox();
+    if (!box) return;
+    this.#confirmationService.confirm({
+      title: 'Lock upload box?',
+      message:
+        'Locking the box prevents further file uploads by its users. ' +
+        'Are you sure you want to proceed?',
+      confirmText: 'Lock the box',
+      callback: (confirmed) => {
+        if (confirmed) this.#lockBox(box, false);
+      },
+    });
+  }
+
+  /**
+   * Lock the upload box (set state to locked). When the backend rejects the
+   * request with a 409 because some uploads are still incomplete, ask the
+   * user whether to force it and retry once with force=true.
+   * @param box - the upload box to lock
+   * @param force - whether to lock despite incomplete uploads
+   */
+  #lockBox(box: ResearchDataUploadBox, force: boolean): void {
+    this.isChangingState.set(true);
+    this.#uploadBoxService.lockUploadBox(box.id, box.version, force).subscribe({
+      next: () => {
+        this.isChangingState.set(false);
+        this.#notificationService.showSuccess('The upload box has been locked.');
+      },
+      error: (err: unknown) => {
+        // Offer the force option only on the first attempt and only when the
+        // conflict is specifically caused by incomplete uploads. A forced
+        // retry that still fails falls through to the generic message.
+        const incompleteUploads = force ? null : this.#incompleteUploads(err);
+        if (incompleteUploads) {
+          this.#confirmForceLock(box, incompleteUploads.length);
+        } else {
+          this.isChangingState.set(false);
+          this.#notificationService.showError(
+            'Failed to lock the upload box. Please try again.',
+          );
+        }
+      },
+    });
+  }
+
+  /**
+   * Extract the incomplete uploads reported by a 409 locking conflict, which
+   * the user may override by forcing the lock.
+   * @param err - the error thrown by the lock request
+   * @returns the incomplete uploads, or null if this is not such a conflict
+   */
+  #incompleteUploads(err: unknown): unknown[] | null {
+    const response = err as HttpErrorResponse;
+    const data: unknown = response?.error?.data;
+    if (response?.status !== 409 || !data || typeof data !== 'object') return null;
+    const uploads = (data as { incomplete_uploads?: unknown }).incomplete_uploads;
+    return Array.isArray(uploads) ? uploads : null;
+  }
+
+  /**
+   * Ask the user whether to lock despite incomplete uploads. On confirmation,
+   * retry the lock with force=true; otherwise leave the box open.
+   * @param box - the upload box to lock
+   * @param count - the number of still-incomplete file uploads
+   */
+  #confirmForceLock(box: ResearchDataUploadBox, count: number): void {
+    const [are, uploads] = count === 1 ? ['is', 'upload'] : ['are', 'uploads'];
+    this.#confirmationService.confirm({
+      title: 'Incomplete uploads detected!',
+      message: `Locking failed because there ${are} still ${count} incomplete file ${uploads}. Do you want to lock the box anyway?`,
+      confirmText: 'Lock anyway',
+      callback: (confirmed) => {
+        if (!confirmed) {
+          this.isChangingState.set(false);
+          return;
+        }
+        this.#lockBox(box, true);
+      },
+    });
+  }
+
+  /**
+   * Ask for confirmation and, on approval, reopen the locked upload box.
+   */
+  openBox(): void {
+    const box = this.uploadBox();
+    if (!box) return;
+    this.#confirmationService.confirm({
+      title: 'Reopen upload box?',
+      message:
+        'Reopening the box allows its users to upload files again. ' +
+        'Are you sure you want to proceed?',
+      confirmText: 'Open the box',
+      callback: (confirmed) => {
+        if (!confirmed) return;
+        this.isChangingState.set(true);
+        this.#uploadBoxService.openUploadBox(box.id, box.version).subscribe({
+          next: () => {
+            this.isChangingState.set(false);
+            this.#notificationService.showSuccess(
+              'The upload box has been opened again.',
+            );
+          },
+          error: () => {
+            this.isChangingState.set(false);
+            this.#notificationService.showError(
+              'Failed to open the upload box. Please try again.',
+            );
+          },
+        });
+      },
+    });
+  }
+
   /**
    * Handle the archived event from the mapping component by clearing the cached
    * box and reloading fresh data, so the UI transitions out of the locked state.

--- a/src/app/upload/services/upload-box.spec.ts
+++ b/src/app/upload/services/upload-box.spec.ts
@@ -447,6 +447,20 @@ describe('UploadBoxService', () => {
     req.flush(null, { status: 204, statusText: 'No Content' });
   });
 
+  it('should reopen an upload box', () => {
+    const id = TEST_BOX_RETRIEVAL_RESULTS.boxes[0].id;
+
+    let completed = false;
+    service.openUploadBox(id, 2).subscribe({ complete: () => (completed = true) });
+
+    const req = httpMock.expectOne(`http://mock.dev/rs/upload-boxes/${id}`);
+    expect(req.request.method).toBe('PATCH');
+    expect(req.request.body).toEqual({ version: 2, state: UploadBoxState.open });
+    req.flush(null, { status: 204, statusText: 'No Content' });
+
+    expect(completed).toBe(true);
+  });
+
   describe('loadBoxGrants', () => {
     const BOX_ID = '0a36607a-b53f-49ed-bf3e-a5f2dbc68001';
     const GRANT: UploadGrant = {

--- a/src/app/upload/services/upload-box.ts
+++ b/src/app/upload/services/upload-box.ts
@@ -372,6 +372,23 @@ export class UploadBoxService {
   }
 
   /**
+   * Send a PATCH request to set the upload box state back to open.
+   * Used by data stewards to reopen a locked upload box.
+   * @param boxId - the ID of the upload box
+   * @param currentVersion - the current box version
+   * @returns An observable that completes when the reopening is accepted
+   */
+  openUploadBox(boxId: string, currentVersion: number): Observable<void> {
+    const changes: ResearchDataUploadBoxUpdate = {
+      version: currentVersion,
+      state: UploadBoxState.open,
+    };
+    return this.#http
+      .patch<void>(`${this.#boxesUrl}/${encodeURIComponent(boxId)}`, changes)
+      .pipe(tap(() => this.#updateUploadBoxLocally(boxId, changes)));
+  }
+
+  /**
    * Set the active filter for the upload box list.
    * @param filter - the filter to apply
    */


### PR DESCRIPTION
This PR allows data stewards to lock open boxes and reopen locked ones directly from the "Upload Box Info" card.