### PR TITLE
Fix IVA loading mechanism (GSI-2447)

### DIFF
--- a/src/app/access-requests/features/access-grant-manager-details/access-grant-manager-details.html
+++ b/src/app/access-requests/features/access-grant-manager-details/access-grant-manager-details.html
@@ -189,7 +189,14 @@
           <mat-card-content
             class="min-w-2xl *:mb-2 *:flex md:min-w-xl [&_div>strong]:inline-block [&_div>strong]:min-w-44"
           >
-            @if (iva(); as iva) {
+            @if (ivaError()) {
+              <span class="text-error flex items-center pb-2"
+                ><mat-icon fontIcon="error" class="me-4 shrink-0"></mat-icon> The IVA
+                could not be loaded. Please try again later.</span
+              >
+            } @else if (ivaLoading()) {
+              <span>Loading IVA…</span>
+            } @else if (iva(); as iva) {
               <div>
                 <strong>Type:</strong>
                 <span class="flex"

--- a/src/app/access-requests/features/access-grant-manager-details/access-grant-manager-details.spec.ts
+++ b/src/app/access-requests/features/access-grant-manager-details/access-grant-manager-details.spec.ts
@@ -4,6 +4,7 @@
  * @license Apache-2.0
  */
 
+import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ActivatedRoute } from '@angular/router';
@@ -19,10 +20,11 @@ import { AccessGrantManagerDetailsComponent } from './access-grant-manager-detai
  */
 class MockIvaService {
   loadUserIvas = () => undefined;
+  ivaError = signal<Error | undefined>(undefined);
   userIvas = {
     value: () => allIvasOfDoe,
     isLoading: () => false,
-    error: () => undefined,
+    error: this.ivaError,
   };
 }
 
@@ -49,5 +51,13 @@ describe('AccessGrantManagerDetailsComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should show an error message when the IVA could not be loaded', () => {
+    const ivaService = TestBed.inject(IvaService) as unknown as MockIvaService;
+    ivaService.ivaError.set(new Error('Internal server error'));
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('The IVA could not be loaded');
   });
 });

--- a/src/app/access-requests/features/access-grant-manager-details/access-grant-manager-details.ts
+++ b/src/app/access-requests/features/access-grant-manager-details/access-grant-manager-details.ts
@@ -139,6 +139,8 @@ export class AccessGrantManagerDetailsComponent implements OnInit {
     const userIvas = this.#ivaService.userIvas.value();
     return userIvas.find((iva) => iva.id === ivaId);
   });
+  ivaLoading = this.#ivaService.userIvas.isLoading;
+  ivaError = this.#ivaService.userIvas.error;
 
   sortedLog = computed(() =>
     [

--- a/src/app/access-requests/features/access-grant-revocation-dialog/access-grant-revocation-dialog.html
+++ b/src/app/access-requests/features/access-grant-revocation-dialog/access-grant-revocation-dialog.html
@@ -40,7 +40,6 @@
       mat-button
       (click)="onCancel()"
       data-umami-event="Confirm Grant Revocation Dialog Cancel Clicked"
-      class="larger-button-text"
     >
       Cancel
     </button>
@@ -49,7 +48,6 @@
       class="button-error"
       (click)="onConfirm()"
       data-umami-event="Confirm Grant Revocation Dialog Confirm Clicked"
-      class="larger-button-text"
       [disabled]="disabled()"
     >
       Confirm revocation

--- a/src/app/access-requests/features/active-access-grants-list/active-access-grants-list.html
+++ b/src/app/access-requests/features/active-access-grants-list/active-access-grants-list.html
@@ -12,7 +12,7 @@
       <div
         class="border-outline-dark mb-4 grid grid-cols-1 border-t [&_button>mat-icon]:-translate-y-0.75"
       >
-        @for (grant of grantWithIvas(); track grant.id) {
+        @for (grant of activeGrants(); track grant.id) {
           <div
             class="border-outline-dark grid grid-cols-12 items-center gap-2 border-b py-2 text-black"
           >

--- a/src/app/access-requests/features/active-access-grants-list/active-access-grants-list.ts
+++ b/src/app/access-requests/features/active-access-grants-list/active-access-grants-list.ts
@@ -4,17 +4,13 @@
  * @license Apache-2.0
  */
 
-import { Component, OnInit, computed, inject } from '@angular/core';
+import { Component, computed, inject } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialog } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
 import { RouterLink, RouterModule } from '@angular/router';
-import { AccessGrantWithIva } from '@app/access-requests/models/access-requests';
+import { AccessGrant } from '@app/access-requests/models/access-requests';
 import { AccessRequestService } from '@app/access-requests/services/access-request';
-import { AuthService } from '@app/auth/services/auth';
-import { Iva } from '@app/ivas/models/iva';
-import { IvaService } from '@app/ivas/services/iva';
-import { FRIENDLY_DATE_FORMAT } from '@app/shared/utils/date-formats';
 import { StencilComponent } from '../../../shared/ui/stencil/stencil/stencil';
 // eslint-disable-next-line boundaries/dependencies
 import { DownloadWorkPackageDialogComponent } from '@app/work-packages/features/download-work-package-dialog/download-work-package-dialog';
@@ -27,45 +23,20 @@ import { DownloadWorkPackageDialogComponent } from '@app/work-packages/features/
   imports: [RouterLink, StencilComponent, MatIconModule, MatButtonModule, RouterModule],
   templateUrl: './active-access-grants-list.html',
 })
-export class ActiveAccessGrantsListComponent implements OnInit {
-  readonly friendlyDateFormat = FRIENDLY_DATE_FORMAT;
+export class ActiveAccessGrantsListComponent {
   #ars = inject(AccessRequestService);
-  #iva = inject(IvaService);
-  #auth = inject(AuthService);
   #dialog = inject(MatDialog);
 
   protected activeGrants = computed(() => this.#ars.activeUserAccessGrants());
   protected isLoading = this.#ars.userAccessGrants.isLoading;
   protected hasError = this.#ars.userAccessGrants.error;
 
-  #userId = computed<string | undefined>(() => this.#auth.user()?.id || undefined);
-
-  #userIvas = computed<Iva[]>(() =>
-    this.#iva.userIvas.error() ? [] : this.#iva.userIvas.value(),
-  );
-
-  protected grantWithIvas = computed<AccessGrantWithIva[]>(() =>
-    this.activeGrants().map((g) => {
-      return { ...g, iva: this.#userIvas().find((iva) => iva.id === g.iva_id) };
-    }),
-  );
-
-  protected anyActiveGrantWithValidIva = computed<boolean>(() =>
-    Object.values(this.grantWithIvas()).some((x) => x.iva?.state === 'Verified'),
-  );
-
   /**
-   * On initialisation, load the current user's ID to obtain their IVAs
+   * Open the download work package dialog for a specific grant.
+   * The dialog resolves and loads the associated IVA itself.
+   * @param grant The access grant to download data for
    */
-  ngOnInit() {
-    this.#iva.loadUserIvas(this.#userId());
-  }
-
-  /**
-   * Open the download work package dialog for a specific grant
-   * @param grant The access grant with IVA information
-   */
-  openDownloadDialog(grant: AccessGrantWithIva): void {
+  openDownloadDialog(grant: AccessGrant): void {
     this.#dialog.open(DownloadWorkPackageDialogComponent, {
       data: grant,
       width: '64rem',

--- a/src/app/access-requests/features/dynamic-access-request-button/dynamic-access-request-button.html
+++ b/src/app/access-requests/features/dynamic-access-request-button/dynamic-access-request-button.html
@@ -1,18 +1,14 @@
 @let accessStatus = status();
 @switch (accessStatus) {
   @case (AccessRequestStatus.pending) {
-    <button
-      mat-raised-button
-      class="button-quaternary larger-button-text w-full"
-      [disabled]="true"
-    >
+    <button mat-raised-button class="button-quaternary w-full" [disabled]="true">
       <mat-icon fontIcon="key"></mat-icon> Pending Request …
     </button>
   }
   @case (AccessRequestStatus.allowed) {
     <button
       mat-raised-button
-      class="button-quaternary larger-button-text w-full"
+      class="button-quaternary w-full"
       (click)="showDownloadTokenDialog()"
       data-umami-event="Dynamic AR Button Download Clicked"
     >
@@ -22,7 +18,7 @@
   @case (AccessRequestStatus.denied) {
     <button
       mat-raised-button
-      class="button-quaternary larger-button-text w-full"
+      class="button-quaternary w-full"
       (click)="showNewAccessRequestDialog()"
       data-umami-event="Dynamic AR Button Request Access Clicked"
     >

--- a/src/app/access-requests/features/dynamic-access-request-button/dynamic-access-request-button.ts
+++ b/src/app/access-requests/features/dynamic-access-request-button/dynamic-access-request-button.ts
@@ -10,14 +10,12 @@ import { MatDialog } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
 import {
   AccessGrant,
-  AccessGrantWithIva,
   AccessRequest,
   AccessRequestDetailData,
   AccessRequestStatus,
 } from '@app/access-requests/models/access-requests';
 import { AccessRequestService } from '@app/access-requests/services/access-request';
 import { AuthService } from '@app/auth/services/auth';
-import { IvaService } from '@app/ivas/services/iva';
 import { NotificationService } from '@app/shared/services/notification';
 // eslint-disable-next-line boundaries/dependencies
 import { DownloadWorkPackageDialogComponent } from '@app/work-packages/features/download-work-package-dialog/download-work-package-dialog';
@@ -38,7 +36,6 @@ export class DynamicAccessRequestButtonComponent {
   #auth = inject(AuthService);
   #notification = inject(NotificationService);
   #dialog = inject(MatDialog);
-  #iva = inject(IvaService);
   #userId = computed<string | undefined>(() => this.#auth.user()?.id || undefined);
   #pendingAccessRequests = computed(() =>
     this.#accessRequestService
@@ -59,14 +56,6 @@ export class DynamicAccessRequestButtonComponent {
             (b.daysRemaining ?? 0) - (a.daysRemaining ?? 0) || a.id.localeCompare(b.id),
         )[0],
   );
-  #grantWithIva = computed<AccessGrantWithIva | undefined>(() => {
-    const grant = this.#activeGrant();
-    if (!grant) return undefined;
-    const ivas =
-      !grant.iva_id || this.#iva.userIvas.error() ? [] : this.#iva.userIvas.value();
-    const iva = ivas.find((i) => i.id === grant.iva_id);
-    return { ...grant, iva };
-  });
   status = computed<AccessRequestStatus>(() => {
     if (this.#activeGrant()) return AccessRequestStatus.allowed;
     if (this.#pendingAccessRequests()) return AccessRequestStatus.pending;
@@ -74,8 +63,7 @@ export class DynamicAccessRequestButtonComponent {
   });
 
   showDownloadTokenDialog = () => {
-    this.#iva.loadUserIvas(this.#userId());
-    const grant = this.#grantWithIva();
+    const grant = this.#activeGrant();
     if (!grant) return;
     this.#dialog.open(DownloadWorkPackageDialogComponent, {
       data: grant,

--- a/src/app/auth/features/user-manager-detail/user-manager-detail.html
+++ b/src/app/auth/features/user-manager-detail/user-manager-detail.html
@@ -154,7 +154,14 @@
       <mat-card-content
         class="divide-outline min-w-2xl space-y-3 divide-y-1 divide-solid"
       >
-        @if (userIvas().length) {
+        @if (ivaError()) {
+          <p class="text-error flex items-center">
+            <mat-icon fontIcon="error" class="me-2 shrink-0"></mat-icon> The IVAs could
+            not be loaded. Please try again later.
+          </p>
+        } @else if (ivaLoading()) {
+          <p>Loading IVAs…</p>
+        } @else if (userIvas().length) {
           @for (iva of userIvas(); track iva.id) {
             <div class="flex items-center gap-x-4 gap-y-4 pb-3">
               <span class="min-w-42"

--- a/src/app/auth/features/user-manager-detail/user-manager-detail.spec.ts
+++ b/src/app/auth/features/user-manager-detail/user-manager-detail.spec.ts
@@ -6,6 +6,7 @@
 
 import { DatePipe as CommonDatePipe } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
+import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 import { allIvasOfDoe } from '@app/../mocks/data';
@@ -22,10 +23,11 @@ import { UserManagerDetailComponent } from './user-manager-detail';
  */
 class MockIvaService {
   loadUserIvas = () => undefined;
+  ivaError = signal<Error | undefined>(undefined);
   userIvas = {
     value: () => allIvasOfDoe,
     isLoading: () => false,
-    error: () => undefined,
+    error: this.ivaError,
   };
 }
 
@@ -160,6 +162,14 @@ describe('UserManagerDetailComponent', () => {
     expect(compiled.textContent).toContain('john@example.com');
     expect(compiled.textContent).toContain('ext123');
     expect(compiled.textContent).toContain('Data Steward');
+  });
+
+  it('should show an error message when the IVAs could not be loaded', () => {
+    const ivaService = TestBed.inject(IvaService) as unknown as MockIvaService;
+    ivaService.ivaError.set(new Error('Internal server error'));
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('The IVAs could not be loaded');
   });
 
   it('should show not found message when user is not found', () => {

--- a/src/app/auth/features/user-manager-detail/user-manager-detail.ts
+++ b/src/app/auth/features/user-manager-detail/user-manager-detail.ts
@@ -103,6 +103,8 @@ export class UserManagerDetailComponent implements OnInit {
   userIvas = computed(() =>
     this.#ivaService.userIvas.error() ? [] : this.#ivaService.userIvas.value(),
   );
+  ivaLoading = this.#ivaService.userIvas.isLoading;
+  ivaError = this.#ivaService.userIvas.error;
 
   #accessRequestService = inject(AccessRequestService);
 

--- a/src/app/metadata/features/dataset-summary/dataset-summary.html
+++ b/src/app/metadata/features/dataset-summary/dataset-summary.html
@@ -1,11 +1,12 @@
 <div class="overflow-x-auto">
   <div class="pt-4 text-sm">
-    <div class="mb-4 flex flex-col gap-y-2 sm:float-right sm:w-52 md:ms-6 md:mb-4">
+    <div
+      class="smaller-button-text mb-4 flex flex-col gap-y-2 sm:float-right sm:w-52 md:ms-6 md:mb-4"
+    >
       @if (hasEgaAccession()) {
         <a
           appExtLink
           mat-stroked-button
-          class="larger-button-text"
           [href]="'https://ega-archive.org/datasets/' + hitContent().ega_accession"
           data-umami-event="Dataset Summary EGA Dataset Clicked"
           >EGA Dataset</a
@@ -14,7 +15,7 @@
       <app-dynamic-access-request-button datasetID="{{ hit().id_ }}" />
       <a
         mat-raised-button
-        class="button-quaternary larger-button-text"
+        class="button-quaternary"
         routerLink="/dataset/{{ hit().id_ }}"
         data-umami-event="Dataset Summary Dataset Details Clicked"
         ><mat-icon fontIcon="database_search"></mat-icon>Dataset Details</a

--- a/src/app/upload/features/upload-grant-manager-details/upload-grant-manager-details.html
+++ b/src/app/upload/features/upload-grant-manager-details/upload-grant-manager-details.html
@@ -111,7 +111,14 @@
           <mat-card-content
             class="min-w-2xl *:mb-2 *:flex md:min-w-xl [&_div>strong]:inline-block [&_div>strong]:min-w-44"
           >
-            @if (iva(); as iva) {
+            @if (ivaError()) {
+              <span class="text-error flex items-center pb-2"
+                ><mat-icon fontIcon="error" class="me-4 shrink-0"></mat-icon> The IVA
+                could not be loaded. Please try again later.</span
+              >
+            } @else if (ivaLoading()) {
+              <span>Loading IVA…</span>
+            } @else if (iva(); as iva) {
               <div>
                 <strong>Type:</strong>
                 <span class="flex"

--- a/src/app/upload/features/upload-grant-manager-details/upload-grant-manager-details.spec.ts
+++ b/src/app/upload/features/upload-grant-manager-details/upload-grant-manager-details.spec.ts
@@ -4,6 +4,7 @@
  * @license Apache-2.0
  */
 
+import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialog } from '@angular/material/dialog';
 
@@ -48,10 +49,11 @@ const mockDialog = {
  */
 class MockIvaService {
   loadUserIvas = () => undefined;
+  ivaError = signal<Error | undefined>(undefined);
   userIvas = {
     value: () => [],
     isLoading: () => false,
-    error: () => undefined,
+    error: this.ivaError,
   };
 }
 
@@ -98,6 +100,14 @@ describe('UploadGrantManagerDetailsComponent', () => {
   it('should include a Grant created entry in the audit log', () => {
     const log = component.sortedLog();
     expect(log.some((entry) => entry.status === 'Grant created')).toBe(true);
+  });
+
+  it('should show an error message when the IVA could not be loaded', () => {
+    const ivaService = TestBed.inject(IvaService) as unknown as MockIvaService;
+    ivaService.ivaError.set(new Error('Internal server error'));
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('The IVA could not be loaded');
   });
 
   describe('revokeGrant()', () => {

--- a/src/app/upload/features/upload-grant-manager-details/upload-grant-manager-details.ts
+++ b/src/app/upload/features/upload-grant-manager-details/upload-grant-manager-details.ts
@@ -136,6 +136,12 @@ export class UploadGrantManagerDetailsComponent implements OnInit {
     return userIvas.find((iva) => iva.id === grant.iva_id);
   });
 
+  /** Whether the user's IVAs are still being loaded. */
+  ivaLoading = this.#ivaService.userIvas.isLoading;
+
+  /** Whether loading the user's IVAs failed. */
+  ivaError = this.#ivaService.userIvas.error;
+
   /** Audit log entries sorted ascending by date. */
   sortedLog = computed(() => {
     const grant = this.grant();

--- a/src/app/upload/features/upload-grant-revocation-dialog/upload-grant-revocation-dialog.html
+++ b/src/app/upload/features/upload-grant-revocation-dialog/upload-grant-revocation-dialog.html
@@ -16,10 +16,10 @@
     }
   </mat-dialog-content>
   <mat-dialog-actions class="gap-y-2">
-    <button mat-button (click)="onCancel()" class="larger-button-text">Cancel</button>
+    <button mat-button (click)="onCancel()">Cancel</button>
     <button
       mat-flat-button
-      class="button-error larger-button-text"
+      class="button-error"
       (click)="onConfirm()"
       [disabled]="disabled()"
     >

--- a/src/app/work-packages/features/download-work-package-dialog/download-work-package-dialog.html
+++ b/src/app/work-packages/features/download-work-package-dialog/download-work-package-dialog.html
@@ -36,7 +36,22 @@
         {{ grant.valid_until | date: friendlyDateFormat }} &ndash;
         {{ grant.daysRemaining }} days left.
       </p>
-      @if (!iva) {
+      @if (ivaError()) {
+        <p class="flex items-center">
+          <span class="text-error"
+            ><mat-icon fontIcon="error" class="me-2 mt-1 shrink-0"></mat-icon></span
+          ><span class="text-error">Could not load IVA</span>
+        </p>
+        <p>
+          The independent verification address (IVA) for this grant could not be loaded.
+          Please try again later or contact the helpdesk if the problem persists.
+        </p>
+      } @else if (ivaLoading()) {
+        <div class="flex items-center gap-3 py-4">
+          <mat-spinner [diameter]="24"></mat-spinner>
+          <p class="text-base">Checking your IVA...</p>
+        </div>
+      } @else if (!iva()) {
         <p class="flex items-center">
           <span class="text-error"
             ><mat-icon fontIcon="error" class="me-2 mt-1 shrink-0"></mat-icon></span
@@ -46,14 +61,14 @@
           We could not find an independent verification address (IVA) associated with
           this grant. Please contact the helpdesk for assistance with this issue.
         </p>
-      } @else if (iva.state !== 'Verified') {
+      } @else if (iva()?.state !== 'Verified') {
         <p class="flex items-center">
           <span class="text-warning"
             ><mat-icon fontIcon="warning" class="me-2 mt-1 shrink-0"></mat-icon
           ></span>
           <span
             ><span class="text-warning">Unverified IVA:</span>
-            {{ (iva.type | IvaTypePipe).name }}: {{ iva.value }}</span
+            {{ (iva()!.type | IvaTypePipe).name }}: {{ iva()!.value }}</span
           >
         </p>
         <p
@@ -159,7 +174,7 @@
   </button>
   @if (
     dataset() &&
-    grant.iva?.state === 'Verified' &&
+    iva()?.state === 'Verified' &&
     !token() &&
     !tokenError() &&
     !tokenIsLoading()

--- a/src/app/work-packages/features/download-work-package-dialog/download-work-package-dialog.spec.ts
+++ b/src/app/work-packages/features/download-work-package-dialog/download-work-package-dialog.spec.ts
@@ -5,6 +5,7 @@
  */
 
 import { Clipboard } from '@angular/cdk/clipboard';
+import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { By } from '@angular/platform-browser';
@@ -12,7 +13,8 @@ import {
   AccessGrantStatus,
   AccessGrantWithIva,
 } from '@app/access-requests/models/access-requests';
-import { IvaState, IvaType } from '@app/ivas/models/iva';
+import { Iva, IvaState, IvaType } from '@app/ivas/models/iva';
+import { IvaService } from '@app/ivas/services/iva';
 import { NotificationService } from '@app/shared/services/notification';
 import { DatasetWithExpiration } from '@app/work-packages/models/dataset';
 import { WorkPackageService } from '@app/work-packages/services/work-package';
@@ -57,6 +59,18 @@ const TEST_GRANT: AccessGrantWithIva = {
   },
 };
 
+/**
+ * Minimal mock for the IVA service that exposes the current user's IVAs.
+ */
+class MockIvaService {
+  userIvas = {
+    value: signal<Iva[]>([TEST_GRANT.iva!]),
+    error: signal<Error | undefined>(undefined),
+    isLoading: signal(false),
+  };
+  loadUserIvas = vitest.fn();
+}
+
 describe('DownloadWorkPackageDialogComponent', () => {
   let component: DownloadWorkPackageDialogComponent;
   let fixture: ComponentFixture<DownloadWorkPackageDialogComponent>;
@@ -95,6 +109,7 @@ describe('DownloadWorkPackageDialogComponent', () => {
         { provide: WorkPackageService, useValue: wpServiceMock },
         { provide: NotificationService, useValue: notifyMock },
         { provide: Clipboard, useValue: clipboardMock },
+        { provide: IvaService, useClass: MockIvaService },
       ],
     }).compileComponents();
 
@@ -115,7 +130,15 @@ describe('DownloadWorkPackageDialogComponent', () => {
   describe('initialization', () => {
     it('should load grant data', () => {
       expect(component['grant']).toBe(TEST_GRANT);
-      expect(component['iva']).toBe(TEST_GRANT.iva);
+      expect(component['iva']()).toBe(TEST_GRANT.iva);
+    });
+
+    it('should show an error message when the IVA could not be loaded', () => {
+      const ivaService = TestBed.inject(IvaService) as unknown as MockIvaService;
+      ivaService.userIvas.error.set(new Error('Internal server error'));
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.textContent).toContain('Could not load IVA');
     });
 
     it('should load dataset from service', () => {

--- a/src/app/work-packages/features/download-work-package-dialog/download-work-package-dialog.ts
+++ b/src/app/work-packages/features/download-work-package-dialog/download-work-package-dialog.ts
@@ -24,6 +24,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { AccessGrantWithIva } from '@app/access-requests/models/access-requests';
 import { IvaTypePipe } from '@app/ivas/pipes/iva-type-pipe';
+import { IvaService } from '@app/ivas/services/iva';
 import { NotificationService } from '@app/shared/services/notification';
 import { ParagraphsComponent } from '@app/shared/ui/paragraphs/paragraphs';
 import { FRIENDLY_DATE_FORMAT } from '@app/shared/utils/date-formats';
@@ -64,10 +65,22 @@ export class DownloadWorkPackageDialogComponent {
   #notify = inject(NotificationService);
   #wpService = inject(WorkPackageService);
   #datasets = this.#wpService.datasets;
+  #iva = inject(IvaService);
 
   protected grant = inject<AccessGrantWithIva>(MAT_DIALOG_DATA);
-  protected iva = this.grant.iva;
+  // Resolve the IVA reactively from the loaded user IVAs so the warning reflects
+  // the current load state instead of a stale snapshot taken when the dialog opened.
+  protected iva = computed(() => {
+    if (!this.grant.iva_id || this.#iva.userIvas.error()) return undefined;
+    return this.#iva.userIvas.value().find((i) => i.id === this.grant.iva_id);
+  });
+  protected ivaLoading = this.#iva.userIvas.isLoading;
+  protected ivaError = this.#iva.userIvas.error;
   protected readonly friendlyDateFormat = FRIENDLY_DATE_FORMAT;
+
+  constructor() {
+    this.#iva.loadUserIvas();
+  }
 
   protected datasetLoading = this.#datasets.isLoading;
   protected dataset = computed<DatasetWithExpiration | undefined>(() =>

--- a/src/app/work-packages/features/upload-work-package-dialog/upload-work-package-dialog.html
+++ b/src/app/work-packages/features/upload-work-package-dialog/upload-work-package-dialog.html
@@ -21,7 +21,22 @@
       {{ grant.valid_until | date: friendlyDateFormat }}.
     </p>
 
-    @if (!iva()) {
+    @if (ivaError()) {
+      <p class="flex items-center">
+        <span class="text-error"
+          ><mat-icon fontIcon="error" class="me-2 mt-1 shrink-0"></mat-icon></span
+        ><span class="text-error">Could not load IVA</span>
+      </p>
+      <p>
+        The independent verification address (IVA) for this grant could not be loaded.
+        Please try again later or contact the helpdesk if the problem persists.
+      </p>
+    } @else if (ivaLoading()) {
+      <div class="flex items-center gap-3 py-4">
+        <mat-spinner [diameter]="24"></mat-spinner>
+        <p class="text-base">Checking your IVA...</p>
+      </div>
+    } @else if (!iva()) {
       <p class="flex items-center">
         <span class="text-error"
           ><mat-icon fontIcon="error" class="me-2 mt-1 shrink-0"></mat-icon></span

--- a/src/app/work-packages/features/upload-work-package-dialog/upload-work-package-dialog.spec.ts
+++ b/src/app/work-packages/features/upload-work-package-dialog/upload-work-package-dialog.spec.ts
@@ -50,9 +50,12 @@ class MockIvaService {
   ]);
   errorSignal = signal<Error | undefined>(undefined);
 
+  loadingSignal = signal(false);
+
   userIvas = {
     value: this.ivasSignal,
     error: this.errorSignal,
+    isLoading: this.loadingSignal,
   };
 
   loadUserIvas = vitest.fn();
@@ -113,6 +116,13 @@ describe('UploadWorkPackageDialogComponent', () => {
 
   it('should initialize with the selected grant', () => {
     expect(component['grant']).toBe(TEST_GRANT);
+  });
+
+  it('should show an error message when the IVA could not be loaded', () => {
+    ivaService.errorSignal.set(new Error('Internal server error'));
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('Could not load IVA');
   });
 
   it('should close dialog', () => {

--- a/src/app/work-packages/features/upload-work-package-dialog/upload-work-package-dialog.ts
+++ b/src/app/work-packages/features/upload-work-package-dialog/upload-work-package-dialog.ts
@@ -65,6 +65,8 @@ export class UploadWorkPackageDialogComponent {
     if (!this.grant.iva_id || this.#iva.userIvas.error()) return undefined;
     return this.#iva.userIvas.value().find((i) => i.id === this.grant.iva_id);
   });
+  protected ivaLoading = this.#iva.userIvas.isLoading;
+  protected ivaError = this.#iva.userIvas.error;
   protected readonly friendlyDateFormat = FRIENDLY_DATE_FORMAT;
 
   constructor() {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -44,6 +44,8 @@
   );
   @include mat.button-overrides(
     (
+      // Material's default button label size (label-large, 14px) reads a touch
+      // small for this app, so bump all button labels up to 16px globally.
       text-label-text-size: medium,
       filled-container-color: var(--mat-sys-tertiary),
       filled-label-text-size: medium,
@@ -52,7 +54,7 @@
       outlined-label-text-color: var(--mat-sys-quaternary),
       protected-label-text-size: medium,
       protected-container-color: var(--mat-sys-tertiary),
-      protected-label-text-color: var(--mat-sys-on-tertiary),
+      protected-label-text-color: var(--mat-sys-on-tertiary)
     )
   );
   @media (prefers-contrast: more) {
@@ -289,6 +291,21 @@ mat-dialog-container mat-card-header mat-card-title h2 {
   );
 }
 
+// Shrinks button labels back to Material's default (label-large, 14px) for all
+// buttons within, overriding the global 16px. Set on a container so it also
+// cascades (via inherited CSS custom properties) into reusable button
+// components like app-dynamic-access-request-button without modifying them.
+.smaller-button-text {
+  @include mat.button-overrides(
+    (
+      text-label-text-size: var(--mat-sys-label-large-size),
+      filled-label-text-size: var(--mat-sys-label-large-size),
+      outlined-label-text-size: var(--mat-sys-label-large-size),
+      protected-label-text-size: var(--mat-sys-label-large-size),
+    )
+  );
+}
+
 table.table-row-hover-highlight {
   tr.cdk-row:hover,
   tr.cdk-row:active {
@@ -390,16 +407,6 @@ $colour-suffixes: (
       )
     );
   }
-}
-
-button.larger-button-text,
-a.larger-button-text {
-  @include mat.button-overrides(
-    (
-      outlined-label-text-size: var(--mat-sys-label-large-size),
-      protected-label-text-size: var(--mat-sys-label-large-size),
-    )
-  );
 }
 
 button.active-page,


### PR DESCRIPTION
- Resolve the grant's IVA reactively in the download/upload dialogs instead of from a stale snapshot, so it no longer shows a false "Missing IVA" warning on first open.
- Add loading and error states across all IVA views (dialogs, access-grant/upload-grant manager details, user manager) so a slow or failed load no longer reads as a missing IVA or an invalid grant.
- Drop the now redundant eager IVA loading from the access-request button and grants list.
- Standardize inconsistent button sizes and rename misleading CSS classes on the access-request button, dataset summary, and revocation dialogs.