### PR TITLE
Load file-mapping studies and unmapped files from registry service

### DIFF
--- a/src/app/metadata/services/metadata-search.ts
+++ b/src/app/metadata/services/metadata-search.ts
@@ -4,21 +4,9 @@
  * @license Apache-2.0
  */
 
-import { HttpClient, httpResource } from '@angular/common/http';
+import { httpResource } from '@angular/common/http';
 import { Service, computed, inject, signal } from '@angular/core';
 import { ConfigService } from '@app/shared/services/config';
-import {
-  Observable,
-  concatMap,
-  from,
-  last,
-  map,
-  mergeMap,
-  mergeScan,
-  of,
-  reduce,
-} from 'rxjs';
-import { DatasetSummary } from '../models/dataset-summary';
 import { FacetFilterSetting } from '../models/facet-filter';
 import {
   DEFAULT_PAGE_SIZE,
@@ -26,13 +14,6 @@ import {
   SearchResults,
   emptySearchResults,
 } from '../models/search-results';
-import { Study } from '../models/study';
-
-interface StudyMapAccumulator {
-  studyMap: Map<string, Study>;
-  skippedDatasetIds: Set<string>;
-  fetchedStudyAccessions: Set<string>;
-}
 
 /**
  * Metadata search service
@@ -44,11 +25,6 @@ export class MetadataSearchService {
   #config = inject(ConfigService);
   #massUrl = this.#config.massUrl;
   #searchUrl = `${this.#massUrl}/search`;
-  #metldataUrl = this.#config.metldataUrl;
-  #artifactsUrl = `${this.#metldataUrl}/artifacts`;
-  #datasetSummaryUrl = `${this.#artifactsUrl}/stats_public/classes/DatasetStats/resources`;
-  #studyUrl = `${this.#artifactsUrl}/embedded_public/classes/Study/resources`;
-  #http = inject(HttpClient);
   #className = signal<string | undefined>(undefined);
   #limit = signal<number>(DEFAULT_PAGE_SIZE);
   #skip = signal<number>(DEFAULT_SKIP_VALUE);
@@ -174,75 +150,5 @@ export class MetadataSearchService {
       massQueryUrl += `&skip=${skip}`;
     }
     return massQueryUrl;
-  }
-
-  /**
-   * Load a map of all studies keyed by study accession.
-   *
-   * Because there is no dedicated backend endpoint for listing studies, this
-   * method first fetches all dataset IDs via a MASS search, then walks each
-   * dataset summary to discover study accessions and fetches each study
-   * individually. Dataset IDs that are already accounted for by a fetched
-   * study's datasets list are skipped so each study is fetched at most once.
-   *
-   * Unfortunately, this method is not efficient, but it is only used temporarily
-   * until we switch to a study-based backend.
-   * @returns An observable that emits a Map from study accession to Study
-   */
-  loadStudiesMap(): Observable<Map<string, Study>> {
-    return this.#http
-      .get<SearchResults>(`${this.#searchUrl}?class_name=EmbeddedDataset`)
-      .pipe(
-        map((searchResults) => searchResults.hits.map((hit) => hit.id_)),
-        mergeMap((datasetIds) => from(datasetIds)),
-        mergeScan(
-          (acc: StudyMapAccumulator, datasetId: string) => {
-            if (acc.skippedDatasetIds.has(datasetId)) {
-              return of(acc);
-            }
-
-            return this.#http
-              .get<DatasetSummary>(`${this.#datasetSummaryUrl}/${datasetId}`)
-              .pipe(
-                mergeMap((summary) => from(summary.studies_summary.stats.accession)),
-                concatMap((studyAccession) => {
-                  if (acc.fetchedStudyAccessions.has(studyAccession)) {
-                    return of(undefined);
-                  }
-
-                  return this.#http.get<Study>(`${this.#studyUrl}/${studyAccession}`);
-                }),
-                reduce((datasetAcc: StudyMapAccumulator, study: Study | undefined) => {
-                  if (!study) {
-                    return datasetAcc;
-                  }
-
-                  const studyMap = new Map(datasetAcc.studyMap);
-                  studyMap.set(study.accession, study);
-
-                  const skippedDatasetIds = new Set(datasetAcc.skippedDatasetIds);
-                  for (const linkedDatasetId of study.datasets) {
-                    skippedDatasetIds.add(linkedDatasetId);
-                  }
-
-                  const fetchedStudyAccessions = new Set(
-                    datasetAcc.fetchedStudyAccessions,
-                  );
-                  fetchedStudyAccessions.add(study.accession);
-
-                  return { studyMap, skippedDatasetIds, fetchedStudyAccessions };
-                }, acc),
-              );
-          },
-          {
-            studyMap: new Map<string, Study>(),
-            skippedDatasetIds: new Set<string>(),
-            fetchedStudyAccessions: new Set<string>(),
-          },
-          1,
-        ),
-        last(),
-        map((acc) => acc.studyMap),
-      );
   }
 }

--- a/src/app/metadata/services/metadata.ts
+++ b/src/app/metadata/services/metadata.ts
@@ -105,6 +105,22 @@ export class MetadataService {
   }
 
   /**
+   * Fetch the unique files for a study given its accession.
+   *
+   * Fetches the metldata Study resource for the accession and then resolves its
+   * files via {@link filesOfStudy}. This is used by the upload box mapping tool,
+   * which only knows the study accession (the rs study ID) and needs the file
+   * names/aliases that only metldata carries.
+   * @param accession Study accession (equal to the rs study ID)
+   * @returns An observable emitting a list of unique EM files
+   */
+  filesOfStudyId(accession: string): Observable<EmFile[]> {
+    return this.#http
+      .get<Study>(`${this.#studyUrl}/${accession}`)
+      .pipe(concatMap((study) => this.filesOfStudy(study)));
+  }
+
+  /**
    * Fetch the unique files for a study.
    *
    * Unfortunately, this method is not efficient, but it is only used temporarily

--- a/src/app/upload/features/upload-box-manager-detail/upload-box-manager-detail.spec.ts
+++ b/src/app/upload/features/upload-box-manager-detail/upload-box-manager-detail.spec.ts
@@ -12,12 +12,12 @@ import { uploadBox1FileUploads, uploadBoxes, uploadGrants } from '@app/../mocks/
 import { fakeActivatedRoute } from '@app/../mocks/route';
 import { UserService } from '@app/auth/services/user';
 import { MetadataService } from '@app/metadata/services/metadata';
-import { MetadataSearchService } from '@app/metadata/services/metadata-search';
 import { NavigationTrackingService } from '@app/shared/services/navigation';
 import { NotificationService } from '@app/shared/services/notification';
 import { ResearchDataUploadBox, UploadBoxState } from '@app/upload/models/box';
 import { FileUploadWithAccession } from '@app/upload/models/file-upload';
 import { UploadGrant } from '@app/upload/models/grant';
+import { StudyService } from '@app/upload/services/study';
 import { UploadBoxService } from '@app/upload/services/upload-box';
 import { screen } from '@testing-library/angular';
 import { of, throwError } from 'rxjs';
@@ -126,17 +126,24 @@ class MockUploadBoxService {
 }
 
 /**
- * Minimal mock of MetadataSearchService for the embedded mapping component.
+ * Minimal mock of StudyService for the embedded mapping component.
  */
-class MockMetadataSearchService {
-  loadStudiesMap = vitest.fn(() => of(new Map()));
+class MockStudyService {
+  studies = {
+    value: () => [],
+    isLoading: () => false,
+    error: () => undefined,
+  };
+
+  loadStudies = vitest.fn();
+  loadFileIds = vitest.fn(() => of({}));
 }
 
 /**
  * Minimal mock of MetadataService for the embedded mapping component.
  */
 class MockMetadataService {
-  filesOfStudy = vitest.fn(() => of([]));
+  filesOfStudyId = vitest.fn(() => of([]));
 }
 
 const mockDialog = { open: vitest.fn() };
@@ -179,7 +186,7 @@ describe('UploadBoxManagerDetailComponent', () => {
         { provide: NavigationTrackingService, useValue: mockNavigationService },
         { provide: NotificationService, useValue: mockNotificationService },
         { provide: ActivatedRoute, useValue: fakeActivatedRoute },
-        { provide: MetadataSearchService, useClass: MockMetadataSearchService },
+        { provide: StudyService, useClass: MockStudyService },
         { provide: MatDialog, useValue: mockDialog },
       ],
     })

--- a/src/app/upload/features/upload-box-mapping/upload-box-mapping.html
+++ b/src/app/upload/features/upload-box-mapping/upload-box-mapping.html
@@ -6,16 +6,14 @@
     </mat-card-header>
 
     <mat-card-content>
-      @if (!studiesMap()) {
+      @if (studiesLoading()) {
         <!-- Studies still loading -->
         <mat-progress-bar mode="indeterminate" class="my-[1em]" />
       } @else if (selectedStudy(); as study) {
         <!-- Study details with change button -->
         <p class="flex items-center">
           <strong class="inline-block w-40">Accession:</strong>
-          <a [routerLink]="['/study', study.accession]" class="text-primary">{{
-            study.accession
-          }}</a>
+          <a [routerLink]="['/study', study.id]" class="text-primary">{{ study.id }}</a>
           <button
             mat-icon-button
             class="ml-2"
@@ -36,7 +34,7 @@
         </p>
         <p>
           <strong class="inline-block w-40">Datasets:</strong>
-          <span>{{ study.datasets.length }}</span>
+          <span>{{ study.num_datasets }}</span>
         </p>
       } @else {
         <!-- Intro text + study selector -->
@@ -46,13 +44,13 @@
         >
         <mat-form-field appearance="outline" class="w-full">
           <mat-select
-            [value]="selectedStudyAccession()"
-            (valueChange)="selectedStudyAccession.set($event)"
+            [value]="selectedStudyId()"
+            (valueChange)="selectedStudyId.set($event)"
             placeholder="Please select the study corresponding to this upload box"
           >
-            @for (study of studiesArray(); track study.accession) {
-              <mat-option [value]="study.accession">
-                {{ study.accession }}: {{ study.title }}
+            @for (study of studiesArray(); track study.id) {
+              <mat-option [value]="study.id">
+                {{ study.id }}: {{ study.title }}
               </mat-option>
             }
           </mat-select>
@@ -62,7 +60,7 @@
   </mat-card>
 
   <!-- File Mapping card (only shown when a study is selected) -->
-  @if (selectedStudyAccession()) {
+  @if (selectedStudyId()) {
     <mat-card>
       <mat-card-header>
         <mat-card-title><h2>File Mapping</h2></mat-card-title>

--- a/src/app/upload/features/upload-box-mapping/upload-box-mapping.spec.ts
+++ b/src/app/upload/features/upload-box-mapping/upload-box-mapping.spec.ts
@@ -10,13 +10,13 @@ import { MatDialog } from '@angular/material/dialog';
 import { provideRouter } from '@angular/router';
 import { uploadBoxes } from '@app/../mocks/data';
 import { EmFile } from '@app/metadata/models/dataset-information';
-import { Study } from '@app/metadata/models/study';
 import { MetadataService } from '@app/metadata/services/metadata';
-import { MetadataSearchService } from '@app/metadata/services/metadata-search';
 import { NavigationTrackingService } from '@app/shared/services/navigation';
 import { NotificationService } from '@app/shared/services/notification';
 import { UploadBoxState } from '@app/upload/models/box';
 import { FileUploadWithAccession } from '@app/upload/models/file-upload';
+import { FileIdMap, Study } from '@app/upload/models/study';
+import { StudyService } from '@app/upload/services/study';
 import { UploadBoxService } from '@app/upload/services/upload-box';
 import {
   MappingSnapshot,
@@ -35,15 +35,26 @@ const TEST_BOX = {
 };
 
 const TEST_STUDY: Study = {
-  accession: 'STUDY-001',
-  alias: 'study-alias',
+  id: 'STUDY-001',
   title: 'Study Title',
   description: 'Study Description',
   types: [],
-  ega_accession: 'EGAS000001',
   affiliations: [],
-  datasets: ['DS1'],
-  publications: [],
+  status: 'draft',
+  num_datasets: 1,
+  num_publications: 0,
+  has_em: true,
+  created: '2026-01-01T00:00:00Z',
+  created_by: 'doe@test.dev',
+  approved: null,
+  approved_by: null,
+  superseded_by_id: null,
+};
+
+const TEST_FILE_IDS: FileIdMap = {
+  'meta-1': null,
+  'meta-2': null,
+  'meta-3': null,
 };
 
 const TEST_METADATA_FILES: EmFile[] = [
@@ -137,12 +148,19 @@ class MockUploadBoxService {
 }
 
 /**
- * Minimal mock of MetadataSearchService for mapping component tests.
+ * Minimal mock of StudyService for mapping component tests.
  */
-class MockMetadataSearchService {
-  studiesMap = new Map<string, Study>([[TEST_STUDY.accession, TEST_STUDY]]);
+class MockStudyService {
+  #studies = signal<Study[]>([TEST_STUDY]);
 
-  loadStudiesMap = vitest.fn(() => of(this.studiesMap));
+  studies = {
+    value: this.#studies.asReadonly(),
+    isLoading: () => false,
+    error: () => undefined,
+  };
+
+  loadStudies = vitest.fn();
+  loadFileIds = vitest.fn((_studyId: string) => of(TEST_FILE_IDS));
 }
 
 /**
@@ -151,7 +169,7 @@ class MockMetadataSearchService {
 class MockMetadataService {
   files = TEST_METADATA_FILES;
 
-  filesOfStudy = vitest.fn(() => of(this.files));
+  filesOfStudyId = vitest.fn(() => of(this.files));
 }
 
 const mockNotificationService = {
@@ -203,7 +221,7 @@ describe('UploadBoxMappingComponent', () => {
       providers: [
         provideRouter([]),
         { provide: UploadBoxService, useClass: MockUploadBoxService },
-        { provide: MetadataSearchService, useClass: MockMetadataSearchService },
+        { provide: StudyService, useClass: MockStudyService },
         { provide: MatDialog, useValue: mockDialog },
         { provide: NotificationService, useValue: mockNotificationService },
         { provide: NavigationTrackingService, useValue: mockNavigationService },
@@ -230,12 +248,12 @@ describe('UploadBoxMappingComponent', () => {
 
   it('should restore a saved snapshot on init', async () => {
     await createComponent({
-      studyAccession: TEST_STUDY.accession,
+      studyId: TEST_STUDY.id,
       mappedField: 'name',
       manualMappings: [['meta-3', 'file-3']],
     });
 
-    expect(component.selectedStudyAccession()).toBe(TEST_STUDY.accession);
+    expect(component.selectedStudyId()).toBe(TEST_STUDY.id);
     expect(component.committedMappedField()).toBe('name');
     expect(component.pendingMappedField()).toBe('name');
     expect(component.manualMappings()).toEqual(new Map([['meta-3', 'file-3']]));
@@ -243,7 +261,7 @@ describe('UploadBoxMappingComponent', () => {
 
   it('should compute exact and unique case-insensitive auto mappings without reusing a box file', async () => {
     await createComponent({
-      studyAccession: TEST_STUDY.accession,
+      studyId: TEST_STUDY.id,
       mappedField: 'alias',
       manualMappings: [],
     });
@@ -283,7 +301,7 @@ describe('UploadBoxMappingComponent', () => {
 
   it('should confirm field changes before discarding manual mappings', async () => {
     await createComponent({
-      studyAccession: TEST_STUDY.accession,
+      studyId: TEST_STUDY.id,
       mappedField: 'alias',
       manualMappings: [['meta-3', 'file-3']],
     });
@@ -309,7 +327,7 @@ describe('UploadBoxMappingComponent', () => {
 
   it('should allow a manual remap to an unused box file and reject a reused one', async () => {
     await createComponent({
-      studyAccession: TEST_STUDY.accession,
+      studyId: TEST_STUDY.id,
       mappedField: 'alias',
       manualMappings: [],
     });
@@ -335,7 +353,7 @@ describe('UploadBoxMappingComponent', () => {
 
   it('should submit the mapping, archive the box, clear saved state, and emit archived on success', async () => {
     await createComponent({
-      studyAccession: TEST_STUDY.accession,
+      studyId: TEST_STUDY.id,
       mappedField: 'alias',
       manualMappings: [
         ['meta-1', 'file-1'],
@@ -363,7 +381,7 @@ describe('UploadBoxMappingComponent', () => {
     );
     expect(uploadBoxService.submitFileMapping).toHaveBeenCalledWith('box-1', {
       box_version: 4,
-      study_id: TEST_STUDY.accession,
+      study_id: TEST_STUDY.id,
       mapping: {
         'meta-1': 'file-1',
         'meta-2': 'file-2',
@@ -380,7 +398,7 @@ describe('UploadBoxMappingComponent', () => {
 
   it('should show an error and skip archival when submitting the mapping fails', async () => {
     await createComponent({
-      studyAccession: TEST_STUDY.accession,
+      studyId: TEST_STUDY.id,
       mappedField: 'alias',
       manualMappings: [['meta-1', 'file-1']],
     });
@@ -400,7 +418,7 @@ describe('UploadBoxMappingComponent', () => {
 
   it('should show a specific error when archival fails after a successful mapping submission', async () => {
     await createComponent({
-      studyAccession: TEST_STUDY.accession,
+      studyId: TEST_STUDY.id,
       mappedField: 'alias',
       manualMappings: [['meta-1', 'file-1']],
     });

--- a/src/app/upload/features/upload-box-mapping/upload-box-mapping.ts
+++ b/src/app/upload/features/upload-box-mapping/upload-box-mapping.ts
@@ -31,12 +31,19 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatSort, MatSortModule } from '@angular/material/sort';
 import { MatTableDataSource, MatTableModule } from '@angular/material/table';
 import { RouterLink } from '@angular/router';
-import { catchError, concatMap, of, startWith, switchMap, throwError } from 'rxjs';
+import {
+  catchError,
+  concatMap,
+  forkJoin,
+  map,
+  of,
+  startWith,
+  switchMap,
+  throwError,
+} from 'rxjs';
 
 import { EmFile } from '@app/metadata/models/dataset-information';
-import { Study } from '@app/metadata/models/study';
 import { MetadataService } from '@app/metadata/services/metadata';
-import { MetadataSearchService } from '@app/metadata/services/metadata-search';
 import { NavigationTrackingService } from '@app/shared/services/navigation';
 import { NotificationService } from '@app/shared/services/notification';
 import {
@@ -46,6 +53,8 @@ import {
 import { ResearchDataUploadBox } from '@app/upload/models/box';
 import { FileUploadWithAccession } from '@app/upload/models/file-upload';
 import { MappedField } from '@app/upload/models/mapping';
+import { Study } from '@app/upload/models/study';
+import { StudyService } from '@app/upload/services/study';
 import { UploadBoxService } from '@app/upload/services/upload-box';
 import { UploadBoxMappingStateService } from '@app/upload/services/upload-box-mapping-state';
 import {
@@ -150,7 +159,7 @@ function computeAutoMappings(
 })
 export class UploadBoxMappingComponent implements OnInit {
   #uploadBoxService = inject(UploadBoxService);
-  #metadataSearchService = inject(MetadataSearchService);
+  #studyService = inject(StudyService);
   #metadataService = inject(MetadataService);
   #dialog = inject(MatDialog);
   #notificationService = inject(NotificationService);
@@ -163,8 +172,8 @@ export class UploadBoxMappingComponent implements OnInit {
   /** Emitted after a successful mapping submission */
   archived = output<void>();
 
-  /** Currently selected study accession */
-  selectedStudyAccession = signal<string | undefined>(undefined);
+  /** Currently selected study ID (equal to the GHGA study accession) */
+  selectedStudyId = signal<string | undefined>(undefined);
 
   /** The metadata field currently committed for auto-matching */
   committedMappedField = signal<MappedField | undefined>(undefined);
@@ -196,29 +205,52 @@ export class UploadBoxMappingComponent implements OnInit {
   /** Guard to prevent opening a second field-change confirmation dialog */
   #fieldChangeDialogOpen = signal<boolean>(false);
 
-  /** All available studies, keyed by accession. `null` while loading. */
-  studiesMap = toSignal(
-    this.#metadataSearchService.loadStudiesMap().pipe(startWith(null)),
-  );
+  /** All studies that still have unmapped files, as served by rs */
+  #studiesResource = this.#studyService.studies;
+
+  /** Whether the studies list is still loading */
+  studiesLoading = computed<boolean>(() => this.#studiesResource.isLoading());
 
   /** Studies as a sorted array for the dropdown */
-  studiesArray = computed(() =>
-    Array.from((this.studiesMap() ?? new Map()).values()).sort((a, b) =>
-      a.accession.localeCompare(b.accession),
-    ),
+  studiesArray = computed<Study[]>(() =>
+    [...this.#studiesResource.value()].sort((a, b) => a.id.localeCompare(b.id)),
   );
 
   /** The currently selected Study object */
   selectedStudy = computed<Study | undefined>(() =>
-    (this.studiesMap() ?? new Map()).get(this.selectedStudyAccession() ?? ''),
+    this.#studiesResource.value().find((study) => study.id === this.selectedStudyId()),
   );
 
-  /** Files from the selected study in metadata. `null` while loading. */
+  /**
+   * Unmapped metadata files of the selected study. `null` while loading.
+   *
+   * File display metadata (accession, name, alias, format) comes from metldata
+   * via `filesOfStudyId`, while the unmapped status comes from rs via
+   * `loadFileIds`. Only files whose file-ids value is explicitly `null`
+   * (unmapped) are kept; files that are already mapped or absent from the
+   * file-ids map are treated as not mappable and excluded.
+   *
+   * Already-mapped files are filtered out on purpose: the backend only ever
+   * adds new file mappings for a study, it never changes an existing one. So a
+   * file that already has an internal file ID cannot be re-mapped here, and
+   * showing it would only offer an action the backend would reject.
+   */
   #metadataFilesOrNull = toSignal(
     toObservable(this.selectedStudy).pipe(
       switchMap((study) =>
         study
-          ? this.#metadataService.filesOfStudy(study).pipe(startWith(null))
+          ? forkJoin({
+              files: this.#metadataService.filesOfStudyId(study.id),
+              fileIds: this.#studyService.loadFileIds(study.id),
+            }).pipe(
+              // Keep only still-unmapped files (value `null`); already-mapped
+              // files cannot be re-mapped (backend only supports adding
+              // mappings), and unknown accessions are not mappable.
+              map(({ files, fileIds }) =>
+                files.filter((file) => fileIds[file.accession] === null),
+              ),
+              startWith(null),
+            )
           : of([] as EmFile[]),
       ),
     ),
@@ -468,7 +500,7 @@ export class UploadBoxMappingComponent implements OnInit {
   /** Persist mapping state whenever the three persistent signals change */
   #saveStateEffect = effect(() => {
     this.#mappingStateService.saveSnapshot(this.box().id, {
-      studyAccession: this.selectedStudyAccession(),
+      studyId: this.selectedStudyId(),
       mappedField: this.committedMappedField(),
       manualMappings: Array.from(this.manualMappings()),
     });
@@ -521,9 +553,10 @@ export class UploadBoxMappingComponent implements OnInit {
 
   /** @inheritdoc */
   ngOnInit(): void {
+    this.#studyService.loadStudies();
     const snapshot = this.#mappingStateService.snapshotFor(this.box().id);
     if (snapshot) {
-      this.selectedStudyAccession.set(snapshot.studyAccession);
+      this.selectedStudyId.set(snapshot.studyId);
       this.committedMappedField.set(snapshot.mappedField);
       this.pendingMappedField.set(snapshot.mappedField);
       this.manualMappings.set(new Map(snapshot.manualMappings));
@@ -611,7 +644,7 @@ export class UploadBoxMappingComponent implements OnInit {
   /** Reset all form state back to initial values and clear the saved snapshot */
   #resetForm(): void {
     this.#mappingStateService.clearSnapshot(this.box().id);
-    this.selectedStudyAccession.set(undefined);
+    this.selectedStudyId.set(undefined);
     this.committedMappedField.set(undefined);
     this.pendingMappedField.set(undefined);
     this.filterText.set('');
@@ -682,7 +715,7 @@ export class UploadBoxMappingComponent implements OnInit {
    * @param effective - the final mapping to submit
    */
   #submitMapping(effective: Map<string, string>): void {
-    const studyId = this.selectedStudyAccession();
+    const studyId = this.selectedStudyId();
     if (!studyId) return;
 
     const mapping: Record<string, string> = {};
@@ -740,9 +773,7 @@ export class UploadBoxMappingComponent implements OnInit {
   /** Whether the "Confirm and archive" button should be enabled */
   canConfirmAndArchive = computed<boolean>(
     () =>
-      !!this.selectedStudyAccession() &&
-      !!this.committedMappedField() &&
-      !this.isSubmitting(),
+      !!this.selectedStudyId() && !!this.committedMappedField() && !this.isSubmitting(),
   );
 
   /** Whether the Reset button should be enabled */

--- a/src/app/upload/models/study.ts
+++ b/src/app/upload/models/study.ts
@@ -1,0 +1,74 @@
+/**
+ * Interface for the study datatype as served by the research service (rs).
+ * @copyright The GHGA Authors
+ * @license Apache-2.0
+ */
+
+/** Lifecycle status of an rs study */
+export type StudyStatus = 'draft' | 'archived';
+
+/**
+ * Map from a file accession to its internal file ID, or `null` when the file
+ * is still unmapped (no internal file ID assigned yet).
+ *
+ * A non-null value means the file is already mapped. Such mappings are final:
+ * the backend only ever adds new file mappings for a study, it never changes an
+ * existing one, so the mapping tool lists only the files whose value is `null`
+ * and hides the already-mapped ones.
+ */
+export type FileIdMap = Record<string, string | null>;
+
+/**
+ * A study as served by the research service (rs).
+ *
+ * Note that `id` equals the GHGA study accession (rs sets it during ingestion),
+ * so it can be used directly to fetch the corresponding metldata Study resource.
+ */
+export interface Study {
+  /** The study ID, equal to the GHGA study accession */
+  id: string;
+  /** The study title */
+  title: string;
+  /** The study description */
+  description: string;
+  /** The study types */
+  types: string[];
+  /** The affiliations associated with the study */
+  affiliations: string[];
+  /** The lifecycle status of the study */
+  status: StudyStatus;
+  /** The number of datasets belonging to the study */
+  num_datasets: number;
+  /** The number of publications associated with the study */
+  num_publications: number;
+  /** Whether the study has experimental metadata */
+  has_em: boolean;
+  /** The creation timestamp as an ISO datetime string */
+  created: string;
+  /** The ID of the user who created the study */
+  created_by: string;
+  /** The approval timestamp as an ISO datetime string, if approved */
+  approved?: string | null;
+  /** The ID of the user who approved the study, if approved */
+  approved_by?: string | null;
+  /** The ID of the study superseding this one, if any */
+  superseded_by_id?: string | null;
+}
+
+/** An empty study used as a default value while loading */
+export const emptyStudy: Study = {
+  id: '',
+  title: '',
+  description: '',
+  types: [],
+  affiliations: [],
+  status: 'draft',
+  num_datasets: 0,
+  num_publications: 0,
+  has_em: false,
+  created: '',
+  created_by: '',
+  approved: null,
+  approved_by: null,
+  superseded_by_id: null,
+};

--- a/src/app/upload/services/study.spec.ts
+++ b/src/app/upload/services/study.spec.ts
@@ -1,0 +1,118 @@
+/**
+ * Test the study service.
+ * @copyright The GHGA Authors
+ * @license Apache-2.0
+ */
+
+import { provideHttpClient } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { ConfigService } from '@app/shared/services/config';
+import { FileIdMap, Study } from '../models/study';
+import { StudyService } from './study';
+
+const TEST_STUDIES: Study[] = [
+  {
+    id: 'GHGAS00000000000001',
+    title: 'Test Study',
+    description: 'A study with unmapped files',
+    types: ['test_genomics'],
+    affiliations: ['Test affiliation'],
+    status: 'draft',
+    num_datasets: 2,
+    num_publications: 1,
+    has_em: true,
+    created: '2026-01-01T00:00:00Z',
+    created_by: 'doe@test.dev',
+    approved: null,
+    approved_by: null,
+    superseded_by_id: null,
+  },
+];
+
+const TEST_FILE_IDS: FileIdMap = {
+  GHGAF00000000000001: null,
+  GHGAF00000000000002: 'd2c8b6a4-0000-4000-8000-000000000001',
+};
+
+/**
+ * Mock the config service as needed for the study service.
+ */
+class MockConfigService {
+  rsUrl = 'http://mock.dev/rs';
+}
+
+describe('StudyService', () => {
+  let service: StudyService;
+  let httpMock: HttpTestingController;
+  let testBed: TestBed;
+
+  beforeEach(() => {
+    testBed = TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: ConfigService, useClass: MockConfigService },
+      ],
+    });
+    service = TestBed.inject(StudyService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should not request studies before loadStudies is called', () => {
+    testBed.tick();
+    httpMock.expectNone('http://mock.dev/rs/studies?with_unmapped_files=true');
+  });
+
+  it('should load studies with unmapped files once triggered', async () => {
+    service.loadStudies();
+    testBed.tick();
+
+    expect(service.studies.isLoading()).toBe(true);
+
+    const req = httpMock.expectOne(
+      'http://mock.dev/rs/studies?with_unmapped_files=true',
+    );
+    expect(req.request.method).toBe('GET');
+    req.flush(TEST_STUDIES);
+
+    await Promise.resolve();
+
+    expect(service.studies.isLoading()).toBe(false);
+    expect(service.studies.error()).toBeUndefined();
+    expect(service.studies.value()).toEqual(TEST_STUDIES);
+  });
+
+  it('should load the file IDs for a study', () => {
+    let result: FileIdMap | undefined;
+    service.loadFileIds('GHGAS00000000000001').subscribe((map) => {
+      result = map;
+    });
+    const req = httpMock.expectOne(
+      'http://mock.dev/rs/studies/GHGAS00000000000001/file-ids',
+    );
+    expect(req.request.method).toBe('GET');
+    req.flush(TEST_FILE_IDS);
+    expect(result).toEqual(TEST_FILE_IDS);
+  });
+
+  it('should URL-encode the study ID when loading file IDs', () => {
+    service.loadFileIds('GHGAS 0001/x').subscribe();
+    const req = httpMock.expectOne(
+      'http://mock.dev/rs/studies/GHGAS%200001%2Fx/file-ids',
+    );
+    expect(req.request.method).toBe('GET');
+    req.flush({});
+  });
+});

--- a/src/app/upload/services/study.ts
+++ b/src/app/upload/services/study.ts
@@ -1,0 +1,64 @@
+/**
+ * Service handling studies served by the research service (rs).
+ * @copyright The GHGA Authors
+ * @license Apache-2.0
+ */
+
+import { HttpClient, httpResource } from '@angular/common/http';
+import { inject, Service, signal } from '@angular/core';
+import { ConfigService } from '@app/shared/services/config';
+import { Observable } from 'rxjs';
+import { FileIdMap, Study } from '../models/study';
+
+/**
+ * Service for loading studies and their file mapping status from the
+ * research service (rs).
+ *
+ * This service is used by the upload box file mapping tool to determine which
+ * studies still have unmapped files and which of a study's files are unmapped.
+ * File display metadata (names, aliases, formats) is obtained separately from
+ * metldata, since rs does not carry filenames.
+ */
+@Service()
+export class StudyService {
+  #config = inject(ConfigService);
+  #http = inject(HttpClient);
+  #rsUrl = this.#config.rsUrl;
+  #studiesUrl = `${this.#rsUrl}/studies`;
+
+  #loadStudies = signal<boolean>(false);
+
+  /**
+   * Resource for loading the studies that still have unmapped files.
+   * Only triggered once `loadStudies()` has been called.
+   */
+  studies = httpResource<Study[]>(
+    () =>
+      this.#loadStudies() ? `${this.#studiesUrl}?with_unmapped_files=true` : undefined,
+    { defaultValue: [] },
+  );
+
+  /**
+   * Trigger loading of the studies that still have unmapped files.
+   */
+  loadStudies(): void {
+    this.#loadStudies.set(true);
+  }
+
+  /**
+   * Load the file mapping status for a single study.
+   *
+   * The mapping tool uses this to show only the files that still need mapping:
+   * a `null` value marks a file as unmapped, while a non-null value marks a file
+   * that is already mapped and cannot be re-mapped (the backend only supports
+   * adding new mappings, not changing existing ones).
+   * @param studyId - the study ID (equal to the GHGA study accession)
+   * @returns An observable emitting a map from file accession to internal file
+   *   ID, where a `null` value marks a file that is still unmapped
+   */
+  loadFileIds(studyId: string): Observable<FileIdMap> {
+    return this.#http.get<FileIdMap>(
+      `${this.#studiesUrl}/${encodeURIComponent(studyId)}/file-ids`,
+    );
+  }
+}

--- a/src/app/upload/services/upload-box-mapping-state.spec.ts
+++ b/src/app/upload/services/upload-box-mapping-state.spec.ts
@@ -22,7 +22,7 @@ describe('UploadBoxMappingStateService', () => {
 
   it('should save and return a snapshot for the requested box id', () => {
     const snapshot: MappingSnapshot = {
-      studyAccession: 'STUDY-001',
+      studyId: 'STUDY-001',
       mappedField: 'alias',
       manualMappings: [['meta-1', 'file-1']],
     };
@@ -34,12 +34,12 @@ describe('UploadBoxMappingStateService', () => {
 
   it('should keep snapshots isolated per upload box id', () => {
     const firstSnapshot: MappingSnapshot = {
-      studyAccession: 'STUDY-001',
+      studyId: 'STUDY-001',
       mappedField: 'alias',
       manualMappings: [['meta-1', 'file-1']],
     };
     const secondSnapshot: MappingSnapshot = {
-      studyAccession: 'STUDY-002',
+      studyId: 'STUDY-002',
       mappedField: 'name',
       manualMappings: [['meta-2', null]],
     };
@@ -53,12 +53,12 @@ describe('UploadBoxMappingStateService', () => {
 
   it('should clear only the requested box snapshot', () => {
     service.saveSnapshot('box-1', {
-      studyAccession: 'STUDY-001',
+      studyId: 'STUDY-001',
       mappedField: 'alias',
       manualMappings: [['meta-1', 'file-1']],
     });
     service.saveSnapshot('box-2', {
-      studyAccession: 'STUDY-002',
+      studyId: 'STUDY-002',
       mappedField: 'name',
       manualMappings: [['meta-2', 'file-2']],
     });
@@ -67,7 +67,7 @@ describe('UploadBoxMappingStateService', () => {
 
     expect(service.snapshotFor('box-1')).toBeUndefined();
     expect(service.snapshotFor('box-2')).toEqual({
-      studyAccession: 'STUDY-002',
+      studyId: 'STUDY-002',
       mappedField: 'name',
       manualMappings: [['meta-2', 'file-2']],
     });

--- a/src/app/upload/services/upload-box-mapping-state.ts
+++ b/src/app/upload/services/upload-box-mapping-state.ts
@@ -9,8 +9,8 @@ import { MappedField } from '../models/mapping';
 
 /** Persisted state for a single upload box mapping session */
 export interface MappingSnapshot {
-  /** The selected study accession */
-  studyAccession: string | undefined;
+  /** The selected study ID (equal to the GHGA study accession) */
+  studyId: string | undefined;
   /** The committed mapped field */
   mappedField: MappedField | undefined;
   /** Manual mappings serialised as Map entries (JSON-serialisable) */

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -17,6 +17,7 @@ import { BaseStorageLabels } from '@app/metadata/models/well-known-values';
 import { BoxRetrievalResults, UploadBoxState } from '@app/upload/models/box';
 import { FileUploadWithAccession } from '@app/upload/models/file-upload';
 import { GrantWithBoxInfo } from '@app/upload/models/grant';
+import { FileIdMap, Study as RsStudy } from '@app/upload/models/study';
 import { DatasetWithExpiration } from '@app/work-packages/models/dataset';
 import { WorkPackageResponse } from '@app/work-packages/models/work-package';
 
@@ -1837,3 +1838,228 @@ export const uploadBoxTestDatasetDetails: DatasetDetailsRaw = {
     },
   ],
 };
+
+/**
+ * The dedicated upload-box file-mapping test study as served by rs.
+ *
+ * Its `id` equals the GHGA study accession of `uploadBoxTestStudyData`, so the
+ * metldata Study/EmbeddedDataset chain resolves and the file names/aliases can
+ * be shown in the mapping tool. This is the study the mapping e2e test drives.
+ */
+export const uploadBoxTestRsStudy: RsStudy = {
+  id: 'GHGAS99999999999001',
+  title: 'Upload Box File Mapping Test Study',
+  description: 'Dedicated study for testing the file mapping UI with upload box 2.',
+  types: ['test_genomics'],
+  affiliations: ['Test affiliation'],
+  status: 'draft',
+  num_datasets: 1,
+  num_publications: 0,
+  has_em: true,
+  created: '2026-01-10T08:00:00Z',
+  created_by: 'doe@test.dev',
+  approved: null,
+  approved_by: null,
+  superseded_by_id: null,
+};
+
+/**
+ * RS file mapping status for the upload-box test study.
+ *
+ * Served at `GET /studies/GHGAS99999999999001/file-ids`. Maps each metadata
+ * research-data-file accession to its internal file ID, or `null` when the file
+ * is still unmapped. All files are unmapped except `GHGAF99999999999016`
+ * (some_unessential_data.csv), which is already mapped (has an internal file ID)
+ * and is therefore filtered out of the mapping tool — demonstrating that the
+ * tool only lists files that still need mapping.
+ */
+export const uploadBoxTestFileIds: FileIdMap = {
+  GHGAF99999999999001: null,
+  GHGAF99999999999002: null,
+  GHGAF99999999999003: null,
+  GHGAF99999999999004: null,
+  GHGAF99999999999005: null,
+  GHGAF99999999999006: null,
+  GHGAF99999999999007: null,
+  GHGAF99999999999008: null,
+  GHGAF99999999999009: null,
+  GHGAF99999999999010: null,
+  GHGAF99999999999011: null,
+  GHGAF99999999999012: null,
+  GHGAF99999999999013: null,
+  GHGAF99999999999014: null,
+  GHGAF99999999999015: null,
+  GHGAF99999999999016: '2b9f4d6e-1c3a-4e7b-9f0d-7a5c8e2b1d40',
+};
+
+/*
+ * Additional studies for the mapping-tool study selector.
+ *
+ * These are realistic studies (not the dedicated file-mapping test study, so
+ * they deliberately do not carry "File Mapping Test" in their name) that exist
+ * mainly to populate the dropdown with more than one entry. Each one still
+ * resolves through its own small metldata Study/EmbeddedDataset chain and has a
+ * file-ids endpoint, so selecting it shows a coherent set of unmapped files.
+ */
+
+/** metldata Study resource for the pediatric leukemia study */
+export const pediatricLeukemiaStudyData: Study = {
+  accession: 'GHGAS00000000000002',
+  ega_accession: 'EGAS00000000002',
+  alias: 'PEDIATRIC_LEUKEMIA',
+  types: ['cancer_genomics'],
+  title: 'Genomic Landscape of Pediatric Acute Leukemia',
+  affiliations: ['University Children’s Hospital'],
+  datasets: ['GHGAD00000000000002'],
+  description:
+    'Whole-genome sequencing of matched tumor and normal samples from a pediatric acute leukemia cohort.',
+  publications: ['GHGA000000002'],
+};
+
+/** metldata EmbeddedDataset resource for the pediatric leukemia study */
+export const pediatricLeukemiaDatasetDetails: DatasetDetailsRaw = {
+  ...datasetDetails,
+  accession: 'GHGAD00000000000002',
+  ega_accession: 'EGAD00000000002',
+  title: 'Pediatric Acute Leukemia WGS',
+  description: 'Matched tumor/normal whole-genome sequencing data.',
+  process_data_files: [],
+  experiment_method_supporting_files: [],
+  analysis_method_supporting_files: [],
+  individual_supporting_files: [],
+  experiments: [],
+  samples: [],
+  research_data_files: [
+    {
+      accession: 'GHGAF00000000000201',
+      ega_accession: 'EGAF00000201',
+      alias: 'tumor_wgs_R1.fastq.gz',
+      name: 'Tumor WGS Read 1',
+      format: 'FASTQ',
+    },
+    {
+      accession: 'GHGAF00000000000202',
+      ega_accession: 'EGAF00000202',
+      alias: 'tumor_wgs_R2.fastq.gz',
+      name: 'Tumor WGS Read 2',
+      format: 'FASTQ',
+    },
+    {
+      accession: 'GHGAF00000000000203',
+      ega_accession: 'EGAF00000203',
+      alias: 'normal_wgs.bam',
+      name: 'Normal WGS Alignment',
+      format: 'BAM',
+    },
+  ],
+};
+
+/** RS file mapping status for the pediatric leukemia study */
+export const pediatricLeukemiaFileIds: FileIdMap = {
+  GHGAF00000000000201: null,
+  GHGAF00000000000202: null,
+  // already mapped, hence filtered out of the mapping tool
+  GHGAF00000000000203: 'b71e0c92-5a4d-4f18-8c2a-1e6d3f905b22',
+};
+
+/** RS study entry for the pediatric leukemia study */
+export const pediatricLeukemiaRsStudy: RsStudy = {
+  id: 'GHGAS00000000000002',
+  title: 'Genomic Landscape of Pediatric Acute Leukemia',
+  description:
+    'Whole-genome sequencing of matched tumor and normal samples from a pediatric acute leukemia cohort.',
+  types: ['cancer_genomics'],
+  affiliations: ['University Children’s Hospital'],
+  status: 'draft',
+  num_datasets: 1,
+  num_publications: 1,
+  has_em: true,
+  created: '2026-02-03T09:30:00Z',
+  created_by: 'doe@test.dev',
+  approved: null,
+  approved_by: null,
+  superseded_by_id: null,
+};
+
+/** metldata Study resource for the rare neurological disorders study */
+export const rareNeuroStudyData: Study = {
+  accession: 'GHGAS00000000000003',
+  ega_accession: 'EGAS00000000003',
+  alias: 'RARE_NEURO',
+  types: ['rare_disease_genomics'],
+  title: 'Whole-Genome Sequencing of Rare Neurological Disorders',
+  affiliations: ['Institute of Human Genetics'],
+  datasets: ['GHGAD00000000000003'],
+  description:
+    'Whole-genome sequencing of families affected by undiagnosed rare neurological disorders.',
+  publications: [],
+};
+
+/** metldata EmbeddedDataset resource for the rare neurological disorders study */
+export const rareNeuroDatasetDetails: DatasetDetailsRaw = {
+  ...datasetDetails,
+  accession: 'GHGAD00000000000003',
+  ega_accession: 'EGAD00000000003',
+  title: 'Rare Neurological Disorders WGS',
+  description: 'Family-based whole-genome sequencing data.',
+  process_data_files: [],
+  experiment_method_supporting_files: [],
+  analysis_method_supporting_files: [],
+  individual_supporting_files: [],
+  experiments: [],
+  samples: [],
+  research_data_files: [
+    {
+      accession: 'GHGAF00000000000301',
+      ega_accession: 'EGAF00000301',
+      alias: 'proband_wgs.cram',
+      name: 'Proband WGS Alignment',
+      format: 'CRAM',
+    },
+    {
+      accession: 'GHGAF00000000000302',
+      ega_accession: 'EGAF00000302',
+      alias: 'trio_variants.vcf',
+      name: 'Trio Joint Variant Calls',
+      format: 'VCF',
+    },
+  ],
+};
+
+/** RS file mapping status for the rare neurological disorders study */
+export const rareNeuroFileIds: FileIdMap = {
+  GHGAF00000000000301: null,
+  GHGAF00000000000302: null,
+};
+
+/** RS study entry for the rare neurological disorders study */
+export const rareNeuroRsStudy: RsStudy = {
+  id: 'GHGAS00000000000003',
+  title: 'Whole-Genome Sequencing of Rare Neurological Disorders',
+  description:
+    'Whole-genome sequencing of families affected by undiagnosed rare neurological disorders.',
+  types: ['rare_disease_genomics'],
+  affiliations: ['Institute of Human Genetics'],
+  status: 'draft',
+  num_datasets: 1,
+  num_publications: 0,
+  has_em: true,
+  created: '2026-03-18T14:05:00Z',
+  created_by: 'roe@test.dev',
+  approved: null,
+  approved_by: null,
+  superseded_by_id: null,
+};
+
+/**
+ * RS studies that still have unmapped files.
+ *
+ * Served at `GET /studies?with_unmapped_files=true`. Each entry's `id` equals a
+ * GHGA study accession whose metldata Study/EmbeddedDataset chain and file-ids
+ * endpoint are mocked, so any of them can be selected in the mapping tool.
+ */
+export const studiesWithUnmappedFiles: RsStudy[] = [
+  pediatricLeukemiaRsStudy,
+  rareNeuroRsStudy,
+  uploadBoxTestRsStudy,
+];

--- a/src/mocks/responses.ts
+++ b/src/mocks/responses.ts
@@ -25,8 +25,16 @@ import {
   uploadBox2FileUploads,
   uploadBox3FileUploads,
   uploadBoxes,
+  pediatricLeukemiaDatasetDetails,
+  pediatricLeukemiaFileIds,
+  pediatricLeukemiaStudyData,
+  rareNeuroDatasetDetails,
+  rareNeuroFileIds,
+  rareNeuroStudyData,
+  studiesWithUnmappedFiles,
   uploadBoxTestDatasetDetails,
   uploadBoxTestDatasetSummary,
+  uploadBoxTestFileIds,
   uploadBoxTestStudyData,
   uploadGrants,
   users,
@@ -145,10 +153,20 @@ export const responses: { [endpoint: string]: ResponseValue } = {
   // Upload box mapping test dataset details (files match box 2 aliases for testing)
   'GET /api/metldata/artifacts/embedded_public/classes/EmbeddedDataset/resources/GHGAD99999999999001':
     uploadBoxTestDatasetDetails,
+  // Dataset details for additional studies shown in the mapping-tool selector
+  'GET /api/metldata/artifacts/embedded_public/classes/EmbeddedDataset/resources/GHGAD00000000000002':
+    pediatricLeukemiaDatasetDetails,
+  'GET /api/metldata/artifacts/embedded_public/classes/EmbeddedDataset/resources/GHGAD00000000000003':
+    rareNeuroDatasetDetails,
 
   // Get study details (embedded) — specific entries before the wildcard catch-all
   'GET /api/metldata/artifacts/embedded_public/classes/Study/resources/GHGAS99999999999001':
     uploadBoxTestStudyData,
+  // Study resources for additional studies shown in the mapping-tool selector
+  'GET /api/metldata/artifacts/embedded_public/classes/Study/resources/GHGAS00000000000002':
+    pediatricLeukemiaStudyData,
+  'GET /api/metldata/artifacts/embedded_public/classes/Study/resources/GHGAS00000000000003':
+    rareNeuroStudyData,
   // Get study details (embedded)
   'GET /api/metldata/artifacts/embedded_public/classes/Study/resources/*': studyData,
 
@@ -224,6 +242,18 @@ export const responses: { [endpoint: string]: ResponseValue } = {
    */
   // Download metadata for a study
   'GET /api/rts/studies/GHGAS12345678901234': 404,
+
+  /**
+   * RS Studies API
+   */
+
+  // Fetch studies that still have unmapped files (for the mapping tool)
+  'GET /api/rs/studies?with_unmapped_files=true': studiesWithUnmappedFiles,
+
+  // Fetch the file mapping status (accession -> file ID or null) for a study
+  'GET /api/rs/studies/GHGAS99999999999001/file-ids': uploadBoxTestFileIds,
+  'GET /api/rs/studies/GHGAS00000000000002/file-ids': pediatricLeukemiaFileIds,
+  'GET /api/rs/studies/GHGAS00000000000003/file-ids': rareNeuroFileIds,
 
   /**
    * RS Upload Boxes API

--- a/tests/admin-pages/upload-box-mapping-tool.spec.ts
+++ b/tests/admin-pages/upload-box-mapping-tool.spec.ts
@@ -99,14 +99,18 @@ test('can map files and archive locked upload box using mapping tool', async ({
   await expect(aliasRadio).toBeVisible();
   await aliasRadio.check();
 
-  await expect(mappingCard).toContainText('Files in Experimental Metadata: 16');
+  // The study has 16 metadata files, but some_unessential_data.csv is already
+  // mapped (its file-ids value is a file ID rather than null), so the mapping
+  // tool filters it out, leaving 15 still-unmapped files.
+  await expect(mappingCard).toContainText('Files in Experimental Metadata: 15');
   // the failed file sample_003_R1.fastq.gz is excluded from the 15 box files,
   // so the corresponding metadata file is counted as unmapped
   await expect(mappingCard).toContainText('Files in Upload Box: 14');
-  await expect(mappingCard).toContainText('Unmapped: 3');
+  await expect(mappingCard).toContainText('Unmapped: 2');
   await expect(mappingCard).toContainText('Unmapped: 1');
 
-  await expect(mappingCard.getByText('some_unessential_data.csv')).toBeVisible();
+  // the already-mapped file is filtered out and never shown
+  await expect(mappingCard.getByText('some_unessential_data.csv')).toHaveCount(0);
   await expect(mappingCard.getByText('methylation_data.meth')).toHaveCount(0);
 
   const nextPageButton = mappingCard.getByRole('button', { name: 'Next page' });
@@ -162,7 +166,7 @@ test('can map files and archive locked upload box using mapping tool', async ({
   await clickWithFallback(inlineMappingOption);
 
   await expect(mappingCard).toContainText('Mapped: 14');
-  await expect(mappingCard).toContainText('Unmapped: 2');
+  await expect(mappingCard).toContainText('Unmapped: 1');
   await expect(mappingCard).toContainText('Matches: 13');
   await expect(mappingCard).toContainText('Manual: 1');
 
@@ -176,7 +180,7 @@ test('can map files and archive locked upload box using mapping tool', async ({
     'The following file in the upload box has not been mapped:',
   );
   await expect(finalConfirmDialog).toContainText(
-    '2 metadata files have not been mapped',
+    'The following metadata file has not been mapped:',
   );
   await expect(finalConfirmDialog).toContainText('sample_003_R1.fastq.gz');
 


### PR DESCRIPTION
Replace MetadataSearchService.loadStudiesMap with a new StudyService (placed in the upload section for now until we have a study section) that uses rs to list studies with unmapped files and per-study file-ids, showing only still-unmappable files. We still keep fetching filenames from metldata, since they are not available via rs yet.
