### PR TITLE
Align boxes with local metadata (GSI-2437)

### DIFF
--- a/src/app/upload/features/upload-box-mapping/upload-box-mapping.html
+++ b/src/app/upload/features/upload-box-mapping/upload-box-mapping.html
@@ -1,316 +1,341 @@
 <div class="flex flex-col gap-4">
-  <!-- Study card -->
-  <mat-card>
-    <mat-card-header>
-      <mat-card-title><h2>Study</h2></mat-card-title>
-    </mat-card-header>
+  <!-- Metadata source toggle -->
+  <div class="flex flex-wrap items-center gap-4">
+    <span class="font-medium">Metadata source:</span>
+    <mat-button-toggle-group
+      [value]="source()"
+      (change)="source.set($event.value)"
+      aria-label="Metadata source"
+    >
+      <mat-button-toggle value="study">Already ingested metadata</mat-button-toggle>
+      <mat-button-toggle value="upload">Uploaded metadata file</mat-button-toggle>
+    </mat-button-toggle-group>
+  </div>
 
-    <mat-card-content>
-      @if (studiesLoading()) {
-        <!-- Studies still loading -->
-        <mat-progress-bar mode="indeterminate" class="my-[1em]" />
-      } @else if (selectedStudy(); as study) {
-        <!-- Study details with change button -->
-        <p class="flex items-center">
-          <strong class="inline-block w-40">Accession:</strong>
-          <a [routerLink]="['/study', study.id]" class="text-primary">{{ study.id }}</a>
-          <button
-            mat-icon-button
-            class="ml-2"
-            title="Select a different study"
-            aria-label="Select a different study"
-            (click)="onChangeStudy()"
-          >
-            <mat-icon fontIcon="change_circle" />
-          </button>
-        </p>
-        <p>
-          <strong class="inline-block w-40">Title:</strong>
-          <span>{{ study.title }}</span>
-        </p>
-        <p class="flex">
-          <strong class="inline-block min-w-40">Description:</strong>
-          <span>{{ study.description }}</span>
-        </p>
-        <p>
-          <strong class="inline-block w-40">Datasets:</strong>
-          <span>{{ study.num_datasets }}</span>
-        </p>
-      } @else {
-        <!-- Intro text + study selector -->
-        <p
-          >In order to establish a mapping from the uploaded files to the Experimental
-          Metadata, you need to select the corresponding study.</p
-        >
-        <mat-form-field appearance="outline" class="w-full">
-          <mat-select
-            [value]="selectedStudyId()"
-            (valueChange)="selectedStudyId.set($event)"
-            placeholder="Please select the study corresponding to this upload box"
-          >
-            @for (study of studiesArray(); track study.id) {
-              <mat-option [value]="study.id">
-                {{ study.id }}: {{ study.title }}
-              </mat-option>
-            }
-          </mat-select>
-        </mat-form-field>
-      }
-    </mat-card-content>
-  </mat-card>
-
-  <!-- File Mapping card (only shown when a study is selected) -->
-  @if (selectedStudyId()) {
+  @if (source() === 'upload') {
+    <app-upload-box-metadata-alignment [box]="box()" />
+  } @else {
+    <!-- Study card -->
     <mat-card>
       <mat-card-header>
-        <mat-card-title><h2>File Mapping</h2></mat-card-title>
+        <mat-card-title><h2>Study</h2></mat-card-title>
       </mat-card-header>
 
       <mat-card-content>
-        <div class="flex flex-col gap-4">
-          <!-- Mapped field selector -->
-          <div class="flex items-center gap-4">
-            <span class="font-medium">Mapped field in Experimental Metadata:</span>
-            <mat-radio-group
-              [value]="pendingMappedField() ?? null"
-              (change)="pendingMappedField.set($event.value)"
-              class="larger-mat-radio-label flex gap-4"
+        @if (studiesLoading()) {
+          <!-- Studies still loading -->
+          <mat-progress-bar mode="indeterminate" class="my-[1em]" />
+        } @else if (selectedStudy(); as study) {
+          <!-- Study details with change button -->
+          <p class="flex items-center">
+            <strong class="inline-block w-40">Accession:</strong>
+            <a [routerLink]="['/study', study.id]" class="text-primary">{{
+              study.id
+            }}</a>
+            <button
+              mat-icon-button
+              class="ml-2"
+              title="Select a different study"
+              aria-label="Select a different study"
+              (click)="onChangeStudy()"
             >
-              <mat-radio-button value="alias">File alias</mat-radio-button>
-              <mat-radio-button value="name">File name</mat-radio-button>
-            </mat-radio-group>
-          </div>
-
-          <!-- File counts summary, filter, table, and buttons (only when field is committed) -->
-          @if (committedMappedField()) {
-            @if (metadataFilesLoading() || boxFilesLoading()) {
-              <!-- Files still loading -->
-              <mat-progress-bar mode="indeterminate" class="my-[0.5em]" />
-            }
-            <div class="flex text-base">
-              <span class="w-1/2 pl-4"
-                ><strong>Files in Experimental Metadata:</strong>
-                {{ metadataFiles().length }}</span
-              >
-              <span class="w-1/2 pl-4"
-                ><strong>Files in Upload Box:</strong> {{ boxFiles().length }}</span
-              >
-            </div>
-            <mat-form-field appearance="outline" class="mt-2 w-full">
-              <mat-label>Filter by part of filename or extension</mat-label>
-              <input
-                matInput
-                [ngModel]="filterText()"
-                (ngModelChange)="filterText.set($event)"
-                placeholder="Type part of filename or extension to filter…"
-              />
-              @if (filterText()) {
-                <button
-                  matSuffix
-                  mat-icon-button
-                  aria-label="Clear filter"
-                  (click)="filterText.set('')"
-                >
-                  <mat-icon fontIcon="close" />
-                </button>
+              <mat-icon fontIcon="change_circle" />
+            </button>
+          </p>
+          <p>
+            <strong class="inline-block w-40">Title:</strong>
+            <span>{{ study.title }}</span>
+          </p>
+          <p class="flex">
+            <strong class="inline-block min-w-40">Description:</strong>
+            <span>{{ study.description }}</span>
+          </p>
+          <p>
+            <strong class="inline-block w-40">Datasets:</strong>
+            <span>{{ study.num_datasets }}</span>
+          </p>
+        } @else {
+          <!-- Intro text + study selector -->
+          <p
+            >In order to establish a mapping from the uploaded files to the Experimental
+            Metadata, you need to select the corresponding study.</p
+          >
+          <mat-form-field appearance="outline" class="w-full">
+            <mat-select
+              [value]="selectedStudyId()"
+              (valueChange)="selectedStudyId.set($event)"
+              placeholder="Please select the study corresponding to this upload box"
+            >
+              @for (study of studiesArray(); track study.id) {
+                <mat-option [value]="study.id">
+                  {{ study.id }}: {{ study.title }}
+                </mat-option>
               }
-            </mat-form-field>
+            </mat-select>
+          </mat-form-field>
+        }
+      </mat-card-content>
+    </mat-card>
 
-            <!-- Mapping table -->
-            <div class="overflow-x-auto">
-              <table
-                mat-table
-                matSort
-                matSortActive="metadataName"
-                matSortDirection="asc"
-                [dataSource]="tableDataSource"
-                class="w-full"
+    <!-- File Mapping card (only shown when a study is selected) -->
+    @if (selectedStudyId()) {
+      <mat-card>
+        <mat-card-header>
+          <mat-card-title><h2>File Mapping</h2></mat-card-title>
+        </mat-card-header>
+
+        <mat-card-content>
+          <div class="flex flex-col gap-4">
+            <!-- Mapped field selector -->
+            <div class="flex items-center gap-4">
+              <span class="font-medium">Mapped field in Experimental Metadata:</span>
+              <mat-radio-group
+                [value]="pendingMappedField() ?? null"
+                (change)="pendingMappedField.set($event.value)"
+                class="larger-mat-radio-label flex gap-4"
               >
-                <!-- Metadata file name column -->
-                <ng-container matColumnDef="metadataName">
-                  <th
-                    mat-header-cell
-                    *matHeaderCellDef
-                    mat-sort-header
-                    class="w-1/2 !py-3"
-                  >
-                    <div class="flex w-full flex-col">
-                      <span class="pr-2">Name in Experimental Metadata</span>
-                      <span class="mt-1 flex gap-4 pr-2 text-sm font-normal">
-                        @if (mappedMetaCount() > 0) {
-                          <span class="text-gray-700"
-                            >Mapped: {{ mappedMetaCount() }}</span
-                          >
-                        }
-                        @if (unmappedMetaCount() > 0) {
-                          <span class="text-warning"
-                            >Unmapped: {{ unmappedMetaCount() }}</span
-                          >
-                        }
-                      </span>
-                    </div>
-                  </th>
-                  <td mat-cell *matCellDef="let row" class="py-1">
-                    {{
-                      committedMappedField() === 'alias'
-                        ? row.metadataFile.alias
-                        : row.metadataFile.name
-                    }}
-                  </td>
-                </ng-container>
-
-                <!-- Upload box file name column -->
-                <ng-container matColumnDef="boxFileName">
-                  <th
-                    mat-header-cell
-                    *matHeaderCellDef
-                    mat-sort-header
-                    class="w-1/2 !py-3"
-                  >
-                    <div class="flex w-full flex-col">
-                      <span class="pr-2">Name in Upload Box</span>
-                      <span class="mt-1 flex gap-4 pr-2 text-sm font-normal">
-                        @if (exactMatchCount() > 0) {
-                          <span class="text-success"
-                            >Matches: {{ exactMatchCount() }}</span
-                          >
-                        }
-                        @if (manualMappingCount() > 0) {
-                          <span class="text-blue-700"
-                            >Manual: {{ manualMappingCount() }}</span
-                          >
-                        }
-                        @if (unmappedBoxCount() > 0) {
-                          <span class="text-error"
-                            >Unmapped: {{ unmappedBoxCount() }}</span
-                          >
-                        }
-                      </span>
-                    </div>
-                  </th>
-                  <td mat-cell *matCellDef="let row" class="py-1">
-                    @if (editingMetaAccession() === row.metadataFile.accession) {
-                      <!-- Inline autocomplete editor -->
-                      <mat-form-field
-                        appearance="outline"
-                        class="w-full"
-                        subscriptSizing="dynamic"
-                      >
-                        <input
-                          #inlineInput
-                          matInput
-                          [ngModel]="inlineInputValue()"
-                          (ngModelChange)="inlineInputValue.set($event)"
-                          [matAutocomplete]="autocomplete"
-                          [attr.aria-label]="
-                            'Map upload box file for ' +
-                            (committedMappedField() === 'name'
-                              ? row.metadataFile.name
-                              : row.metadataFile.alias)
-                          "
-                          autocomplete="off"
-                          type="search"
-                          placeholder="Type or select file name in upload box…"
-                          (keydown.enter)="commitInlineEdit(row)"
-                          (keydown.escape)="editingMetaAccession.set(null)"
-                        />
-                        <mat-autocomplete
-                          #autocomplete="matAutocomplete"
-                          [displayWith]="displayBoxFileAlias"
-                          (optionSelected)="
-                            inlineInputValue.set($event.option.value.alias);
-                            commitInlineEdit(row)
-                          "
-                        >
-                          @for (opt of autocompleteOptions(); track opt.id) {
-                            <mat-option [value]="opt">{{ opt.alias }}</mat-option>
-                          }
-                        </mat-autocomplete>
-                        <button
-                          matSuffix
-                          mat-icon-button
-                          aria-label="Confirm"
-                          (click)="commitInlineEdit(row)"
-                        >
-                          <mat-icon fontIcon="check" />
-                        </button>
-                      </mat-form-field>
-                    } @else {
-                      <!-- Display mode with click-to-edit -->
-                      <button
-                        class="flex items-center gap-1 text-left"
-                        (click)="startEditing(row)"
-                        [title]="
-                          'Click to ' + (row.boxFile ? 'change' : 'set') + ' mapping'
-                        "
-                        [attr.aria-label]="
-                          'Click to ' +
-                          (row.boxFile ? 'change' : 'set') +
-                          ' mapping for ' +
-                          row.metadataFile.alias
-                        "
-                      >
-                        @if (row.boxFile) {
-                          <span
-                            [class.text-success]="row.mappingType === 'exact'"
-                            [class.text-blue-700]="row.mappingType === 'manual'"
-                            >{{ row.boxFile.alias }}</span
-                          >
-                        } @else {
-                          <span class="text-warning italic">unmapped</span>
-                        }
-                        <mat-icon
-                          fontIcon="change_circle"
-                          class="ml-2 !text-base opacity-50"
-                        />
-                      </button>
-                    }
-                  </td>
-                </ng-container>
-
-                <tr mat-header-row *matHeaderRowDef="columns"></tr>
-                <tr mat-row *matRowDef="let row; columns: columns"></tr>
-              </table>
-
-              <mat-paginator
-                [pageSizeOptions]="[10, 25, 50]"
-                showFirstLastButtons
-                aria-label="Select page of file mappings"
-              ></mat-paginator>
+                <mat-radio-button value="alias">File alias</mat-radio-button>
+                <mat-radio-button value="name">File name</mat-radio-button>
+              </mat-radio-group>
             </div>
 
-            <!-- Action buttons -->
-            <div class="mt-4 flex w-full flex-wrap items-center justify-between gap-3">
-              <button
-                mat-raised-button
-                color="primary"
-                [disabled]="!canConfirmAndArchive()"
-                (click)="onConfirmAndArchive()"
+            <!-- File counts summary, filter, table, and buttons (only when field is committed) -->
+            @if (committedMappedField()) {
+              @if (metadataFilesLoading() || boxFilesLoading()) {
+                <!-- Files still loading -->
+                <mat-progress-bar mode="indeterminate" class="my-[0.5em]" />
+              }
+              <div class="flex text-base">
+                <span class="w-1/2 pl-4"
+                  ><strong>Files in Experimental Metadata:</strong>
+                  {{ metadataFiles().length }}</span
+                >
+                <span class="w-1/2 pl-4"
+                  ><strong>Files in Upload Box:</strong> {{ boxFiles().length }}</span
+                >
+              </div>
+              <mat-form-field appearance="outline" class="mt-2 w-full">
+                <mat-label>Filter by part of filename or extension</mat-label>
+                <input
+                  matInput
+                  [ngModel]="filterText()"
+                  (ngModelChange)="filterText.set($event)"
+                  placeholder="Type part of filename or extension to filter…"
+                />
+                @if (filterText()) {
+                  <button
+                    matSuffix
+                    mat-icon-button
+                    aria-label="Clear filter"
+                    (click)="filterText.set('')"
+                  >
+                    <mat-icon fontIcon="close" />
+                  </button>
+                }
+              </mat-form-field>
+
+              <!-- Mapping table -->
+              <div class="overflow-x-auto">
+                <table
+                  mat-table
+                  matSort
+                  matSortActive="metadataName"
+                  matSortDirection="asc"
+                  [dataSource]="tableDataSource"
+                  class="w-full"
+                >
+                  <!-- Metadata file name column -->
+                  <ng-container matColumnDef="metadataName">
+                    <th
+                      mat-header-cell
+                      *matHeaderCellDef
+                      mat-sort-header
+                      class="w-1/2 !py-3"
+                    >
+                      <div class="flex w-full flex-col">
+                        <span class="pr-2">Name in Experimental Metadata</span>
+                        <span class="mt-1 flex gap-4 pr-2 text-sm font-normal">
+                          @if (mappedMetaCount() > 0) {
+                            <span class="text-gray-700"
+                              >Mapped: {{ mappedMetaCount() }}</span
+                            >
+                          }
+                          @if (unmappedMetaCount() > 0) {
+                            <span class="text-warning"
+                              >Unmapped: {{ unmappedMetaCount() }}</span
+                            >
+                          }
+                        </span>
+                      </div>
+                    </th>
+                    <td mat-cell *matCellDef="let row" class="py-1">
+                      {{
+                        committedMappedField() === 'alias'
+                          ? row.metadataFile.alias
+                          : row.metadataFile.name
+                      }}
+                    </td>
+                  </ng-container>
+
+                  <!-- Upload box file name column -->
+                  <ng-container matColumnDef="boxFileName">
+                    <th
+                      mat-header-cell
+                      *matHeaderCellDef
+                      mat-sort-header
+                      class="w-1/2 !py-3"
+                    >
+                      <div class="flex w-full flex-col">
+                        <span class="pr-2">Name in Upload Box</span>
+                        <span class="mt-1 flex gap-4 pr-2 text-sm font-normal">
+                          @if (exactMatchCount() > 0) {
+                            <span class="text-success"
+                              >Matches: {{ exactMatchCount() }}</span
+                            >
+                          }
+                          @if (manualMappingCount() > 0) {
+                            <span class="text-blue-700"
+                              >Manual: {{ manualMappingCount() }}</span
+                            >
+                          }
+                          @if (unmappedBoxCount() > 0) {
+                            <span class="text-error"
+                              >Unmapped: {{ unmappedBoxCount() }}</span
+                            >
+                          }
+                        </span>
+                      </div>
+                    </th>
+                    <td mat-cell *matCellDef="let row" class="py-1">
+                      @if (editingMetaAccession() === row.metadataFile.accession) {
+                        <!-- Inline autocomplete editor -->
+                        <mat-form-field
+                          appearance="outline"
+                          class="w-full"
+                          subscriptSizing="dynamic"
+                        >
+                          <input
+                            #inlineInput
+                            matInput
+                            [ngModel]="inlineInputValue()"
+                            (ngModelChange)="inlineInputValue.set($event)"
+                            [matAutocomplete]="autocomplete"
+                            [attr.aria-label]="
+                              'Map upload box file for ' +
+                              (committedMappedField() === 'name'
+                                ? row.metadataFile.name
+                                : row.metadataFile.alias)
+                            "
+                            autocomplete="off"
+                            type="search"
+                            placeholder="Type or select file name in upload box…"
+                            (keydown.enter)="commitInlineEdit(row)"
+                            (keydown.escape)="editingMetaAccession.set(null)"
+                          />
+                          <mat-autocomplete
+                            #autocomplete="matAutocomplete"
+                            [displayWith]="displayBoxFileAlias"
+                            (optionSelected)="
+                              inlineInputValue.set($event.option.value.alias);
+                              commitInlineEdit(row)
+                            "
+                          >
+                            @for (opt of autocompleteOptions(); track opt.id) {
+                              <mat-option [value]="opt">{{ opt.alias }}</mat-option>
+                            }
+                          </mat-autocomplete>
+                          <button
+                            matSuffix
+                            mat-icon-button
+                            aria-label="Confirm"
+                            (click)="commitInlineEdit(row)"
+                          >
+                            <mat-icon fontIcon="check" />
+                          </button>
+                        </mat-form-field>
+                      } @else {
+                        <!-- Display mode with click-to-edit -->
+                        <button
+                          class="flex items-center gap-1 text-left"
+                          (click)="startEditing(row)"
+                          [title]="
+                            'Click to ' + (row.boxFile ? 'change' : 'set') + ' mapping'
+                          "
+                          [attr.aria-label]="
+                            'Click to ' +
+                            (row.boxFile ? 'change' : 'set') +
+                            ' mapping for ' +
+                            row.metadataFile.alias
+                          "
+                        >
+                          @if (row.boxFile) {
+                            <span
+                              [class.text-success]="row.mappingType === 'exact'"
+                              [class.text-blue-700]="row.mappingType === 'manual'"
+                              >{{ row.boxFile.alias }}</span
+                            >
+                          } @else {
+                            <span class="text-warning italic">unmapped</span>
+                          }
+                          <mat-icon
+                            fontIcon="change_circle"
+                            class="ml-2 !text-base opacity-50"
+                          />
+                        </button>
+                      }
+                    </td>
+                  </ng-container>
+
+                  <tr mat-header-row *matHeaderRowDef="columns"></tr>
+                  <tr mat-row *matRowDef="let row; columns: columns"></tr>
+                </table>
+
+                <mat-paginator
+                  [pageSizeOptions]="[10, 25, 50]"
+                  showFirstLastButtons
+                  aria-label="Select page of file mappings"
+                ></mat-paginator>
+              </div>
+
+              <!-- Action buttons -->
+              <div
+                class="mt-4 flex w-full flex-wrap items-center justify-between gap-3"
               >
-                <mat-icon fontIcon="archive" />
-                Confirm mapping and archive
-              </button>
-              <div class="flex gap-3">
-                <button mat-stroked-button [disabled]="!canReset()" (click)="onReset()">
-                  <mat-icon fontIcon="refresh" />
-                  Reset
+                <button
+                  mat-raised-button
+                  color="primary"
+                  [disabled]="!canConfirmAndArchive()"
+                  (click)="onConfirmAndArchive()"
+                >
+                  <mat-icon fontIcon="archive" />
+                  Confirm mapping and archive
                 </button>
+                <div class="flex gap-3">
+                  <button
+                    mat-stroked-button
+                    [disabled]="!canReset()"
+                    (click)="onReset()"
+                  >
+                    <mat-icon fontIcon="refresh" />
+                    Reset
+                  </button>
+                  <button mat-stroked-button (click)="onCancel()">
+                    <mat-icon fontIcon="cancel" />
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            } @else if (pendingMappedField()) {
+              <div class="flex flex-wrap items-center gap-3">
                 <button mat-stroked-button (click)="onCancel()">
                   <mat-icon fontIcon="cancel" />
                   Cancel
                 </button>
               </div>
-            </div>
-          } @else if (pendingMappedField()) {
-            <div class="flex flex-wrap items-center gap-3">
-              <button mat-stroked-button (click)="onCancel()">
-                <mat-icon fontIcon="cancel" />
-                Cancel
-              </button>
-            </div>
-          }
-        </div>
-      </mat-card-content>
-    </mat-card>
+            }
+          </div>
+        </mat-card-content>
+      </mat-card>
+    }
   }
 </div>

--- a/src/app/upload/features/upload-box-mapping/upload-box-mapping.html
+++ b/src/app/upload/features/upload-box-mapping/upload-box-mapping.html
@@ -13,7 +13,7 @@
   </div>
 
   @if (source() === 'upload') {
-    <app-upload-box-metadata-alignment [box]="box()" />
+    <app-upload-box-metadata-alignment />
   } @else {
     <!-- Study card -->
     <mat-card>

--- a/src/app/upload/features/upload-box-mapping/upload-box-mapping.ts
+++ b/src/app/upload/features/upload-box-mapping/upload-box-mapping.ts
@@ -19,6 +19,7 @@ import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { MatButtonModule } from '@angular/material/button';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatCardModule } from '@angular/material/card';
 import { MatDialog } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -61,6 +62,10 @@ import {
   MappingConfirmDialogData,
   UploadBoxMappingConfirmDialogComponent,
 } from './upload-box-mapping-confirm-dialog';
+import { UploadBoxMetadataAlignmentComponent } from './upload-box-metadata-alignment';
+
+/** The source of the metadata to map or align the upload box files against */
+export type MappingSource = 'study' | 'upload';
 
 /** A single row in the mapping table */
 export interface MappingRow {
@@ -142,6 +147,7 @@ function computeAutoMappings(
     FormsModule,
     MatAutocompleteModule,
     MatButtonModule,
+    MatButtonToggleModule,
     MatCardModule,
     MatFormFieldModule,
     MatIconModule,
@@ -153,6 +159,7 @@ function computeAutoMappings(
     MatSortModule,
     MatTableModule,
     RouterLink,
+    UploadBoxMetadataAlignmentComponent,
   ],
   providers: [MetadataService],
   templateUrl: './upload-box-mapping.html',
@@ -171,6 +178,12 @@ export class UploadBoxMappingComponent implements OnInit {
 
   /** Emitted after a successful mapping submission */
   archived = output<void>();
+
+  /**
+   * Whether to map against a backend study or to check the alignment against an
+   * uploaded metadata file that has not been ingested into the system yet.
+   */
+  source = signal<MappingSource>('study');
 
   /** Currently selected study ID (equal to the GHGA study accession) */
   selectedStudyId = signal<string | undefined>(undefined);

--- a/src/app/upload/features/upload-box-mapping/upload-box-metadata-alignment.html
+++ b/src/app/upload/features/upload-box-mapping/upload-box-metadata-alignment.html
@@ -81,7 +81,7 @@
                 >
               </p>
               <p>
-                <strong>Matching files:</strong>&ngsp;<span class="text-success">{{
+                <strong>Matching files:</strong>&nbsp;<span class="text-success">{{
                   result.matchCount
                 }}</span>
                 of {{ result.totalMetadata }} metadata files and

--- a/src/app/upload/features/upload-box-mapping/upload-box-metadata-alignment.html
+++ b/src/app/upload/features/upload-box-mapping/upload-box-metadata-alignment.html
@@ -1,0 +1,144 @@
+<div class="flex flex-col gap-4">
+  <!-- Metadata file card -->
+  <mat-card>
+    <mat-card-header>
+      <mat-card-title><h2>Metadata file</h2></mat-card-title>
+    </mat-card-header>
+
+    <mat-card-content>
+      <p
+        >Upload a metadata JSON file to check how well the files in this upload box
+        align with metadata that has not been ingested into the system yet. Nothing is
+        submitted to the backend.</p
+      >
+
+      <!-- File picker -->
+      <input
+        #fileInput
+        type="file"
+        accept="application/json,.json"
+        class="hidden"
+        (change)="onFileSelected($event)"
+      />
+      <div class="mt-2 flex flex-wrap items-center gap-3">
+        <button mat-stroked-button (click)="fileInput.click()">
+          <mat-icon fontIcon="upload_file" />
+          {{
+            uploadedMetadata() || parseError()
+              ? 'Choose a different file'
+              : 'Upload metadata file'
+          }}
+        </button>
+        @if (fileName()) {
+          <span class="text-gray-700">{{ fileName() }}</span>
+        }
+      </div>
+
+      @if (parseError(); as error) {
+        <p class="text-error mt-3 flex items-center gap-2">
+          <mat-icon fontIcon="error" />
+          <span>{{ error }}</span>
+        </p>
+      }
+
+      <!-- First study details -->
+      @if (uploadedMetadata(); as metadata) {
+        <div class="mt-4">
+          <p>
+            <strong class="inline-block w-40">Study title:</strong>
+            <span>{{ metadata.study.title }}</span>
+          </p>
+          <p class="flex">
+            <strong class="inline-block min-w-40">Description:</strong>
+            <span>{{ metadata.study.description }}</span>
+          </p>
+        </div>
+      }
+    </mat-card-content>
+  </mat-card>
+
+  <!-- Alignment card -->
+  @if (uploadedMetadata()) {
+    <mat-card>
+      <mat-card-header>
+        <mat-card-title><h2>Alignment</h2></mat-card-title>
+      </mat-card-header>
+
+      <mat-card-content>
+        @if (boxFilesLoading()) {
+          <mat-progress-bar mode="indeterminate" class="my-[0.5em]" />
+        }
+        @if (alignment(); as result) {
+          <div class="flex flex-col gap-4">
+            <!-- Summary -->
+            <div class="flex flex-col gap-1 text-base">
+              <p>
+                <strong>Aligned by:</strong>
+                {{ result.field === 'alias' ? 'file alias' : 'file name' }}
+                <span class="text-gray-700"
+                  >(alias: {{ result.aliasMatchCount }}, name:
+                  {{ result.nameMatchCount }} matches)</span
+                >
+              </p>
+              <p>
+                <strong>Matching files:</strong>&ngsp;<span class="text-success">{{
+                  result.matchCount
+                }}</span>
+                of {{ result.totalMetadata }} metadata files and
+                {{ result.totalBoxFiles }} upload box files
+              </p>
+            </div>
+
+            <!-- Unmatched metadata files -->
+            <div>
+              <p class="font-medium">
+                Metadata files without a match
+                @if (result.unmatchedMetadata.length > 0) {
+                  <span class="text-warning"
+                    >({{ result.unmatchedMetadata.length }})</span
+                  >
+                }
+              </p>
+              @if (result.unmatchedMetadata.length > 0) {
+                <ul class="ml-4 list-disc text-base">
+                  @for (file of result.unmatchedMetadata; track $index) {
+                    <li>
+                      {{ result.field === 'alias' ? file.alias : file.name }}
+                      <span class="text-gray-600"
+                        >({{ result.field === 'alias' ? 'name' : 'alias' }}:
+                        {{ result.field === 'alias' ? file.name : file.alias }})</span
+                      >
+                    </li>
+                  }
+                </ul>
+              } @else {
+                <p class="text-gray-700">All metadata files were matched.</p>
+              }
+            </div>
+
+            <!-- Unmatched box files -->
+            <div>
+              <p class="font-medium">
+                Upload box files without a match
+                @if (result.unmatchedBoxFiles.length > 0) {
+                  <span class="text-error"
+                    >({{ result.unmatchedBoxFiles.length }})</span
+                  >
+                }
+              </p>
+              @if (result.unmatchedBoxFiles.length > 0) {
+                <ul class="ml-4 list-disc text-base">
+                  @for (file of result.unmatchedBoxFiles; track file.id) {
+                    <li>{{ file.alias }}</li>
+                  }
+                </ul>
+              } @else {
+                <p class="text-gray-700">All upload box files were matched.</p>
+              }
+            </div>
+          </div>
+        }
+      </mat-card-content>
+    </mat-card>
+  }
+</div>

--- a/src/app/upload/features/upload-box-mapping/upload-box-metadata-alignment.spec.ts
+++ b/src/app/upload/features/upload-box-mapping/upload-box-metadata-alignment.spec.ts
@@ -6,20 +6,10 @@
 
 import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { uploadBoxes } from '@app/../mocks/data';
-import { UploadBoxState } from '@app/upload/models/box';
 import { FileUploadWithAccession } from '@app/upload/models/file-upload';
 import { UploadBoxService } from '@app/upload/services/upload-box';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { UploadBoxMetadataAlignmentComponent } from './upload-box-metadata-alignment';
-
-const TEST_BOX = {
-  ...uploadBoxes.boxes[0],
-  id: 'box-1',
-  version: 4,
-  state: UploadBoxState.locked,
-  file_count: 2,
-};
 
 /**
  * Build a box file upload with the given id and alias.
@@ -105,7 +95,6 @@ describe('UploadBoxMetadataAlignmentComponent', () => {
     }).compileComponents();
 
     fixture = TestBed.createComponent(UploadBoxMetadataAlignmentComponent);
-    fixture.componentRef.setInput('box', TEST_BOX);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/src/app/upload/features/upload-box-mapping/upload-box-metadata-alignment.spec.ts
+++ b/src/app/upload/features/upload-box-mapping/upload-box-metadata-alignment.spec.ts
@@ -1,0 +1,145 @@
+/**
+ * Tests for the upload box metadata alignment component.
+ * @copyright The GHGA Authors
+ * @license Apache-2.0
+ */
+
+import { signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { uploadBoxes } from '@app/../mocks/data';
+import { UploadBoxState } from '@app/upload/models/box';
+import { FileUploadWithAccession } from '@app/upload/models/file-upload';
+import { UploadBoxService } from '@app/upload/services/upload-box';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { UploadBoxMetadataAlignmentComponent } from './upload-box-metadata-alignment';
+
+const TEST_BOX = {
+  ...uploadBoxes.boxes[0],
+  id: 'box-1',
+  version: 4,
+  state: UploadBoxState.locked,
+  file_count: 2,
+};
+
+/**
+ * Build a box file upload with the given id and alias.
+ * @param id - the file id
+ * @param alias - the file alias (filename)
+ * @returns a file upload object
+ */
+function boxFile(id: string, alias: string): FileUploadWithAccession {
+  return {
+    id,
+    box_id: 'box-1',
+    alias,
+    state: 'interrogated',
+    state_updated: '2025-01-01T00:00:00Z',
+    storage_alias: 'TUE01',
+    bucket_id: `bucket-${id}`,
+    decrypted_sha256: null,
+    decrypted_size: 1024,
+    encrypted_size: 1536,
+    part_size: 512,
+    accession: null,
+  };
+}
+
+const TEST_BOX_FILES = [
+  boxFile('file-1', 'sample-1.fastq.gz'),
+  boxFile('file-2', 'sample-2.fastq.gz'),
+];
+
+const VALID_METADATA = {
+  studies: [{ title: 'My study', description: 'A description' }],
+  datasets: [],
+  research_data_files: [
+    {
+      alias: 'alias-1',
+      name: 'sample-1.fastq.gz',
+      included_in_submission: true,
+      dataset: 'd1',
+    },
+    {
+      alias: 'alias-2',
+      name: 'unmatched.fastq.gz',
+      included_in_submission: true,
+      dataset: 'd1',
+    },
+  ],
+};
+
+/**
+ * Minimal mock of UploadBoxService for alignment component tests.
+ */
+class MockUploadBoxService {
+  #boxFileUploads = signal<FileUploadWithAccession[]>(TEST_BOX_FILES);
+
+  boxFileUploads = {
+    value: this.#boxFileUploads.asReadonly(),
+    isLoading: () => false,
+    error: () => undefined,
+  };
+}
+
+/**
+ * Build a fake file input change event whose file resolves to the given text.
+ * @param text - the text content the file should yield
+ * @returns a change event usable with onFileSelected
+ */
+function fileEvent(text: string): Event {
+  const file = {
+    name: 'metadata.json',
+    text: () => Promise.resolve(text),
+  } as unknown as File;
+  return { target: { files: [file], value: '' } } as unknown as Event;
+}
+
+describe('UploadBoxMetadataAlignmentComponent', () => {
+  let component: UploadBoxMetadataAlignmentComponent;
+  let fixture: ComponentFixture<UploadBoxMetadataAlignmentComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [UploadBoxMetadataAlignmentComponent],
+      providers: [{ provide: UploadBoxService, useClass: MockUploadBoxService }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(UploadBoxMetadataAlignmentComponent);
+    fixture.componentRef.setInput('box', TEST_BOX);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('reports alignment for a valid metadata file', async () => {
+    await component.onFileSelected(fileEvent(JSON.stringify(VALID_METADATA)));
+
+    expect(component.parseError()).toBeUndefined();
+    expect(component.uploadedMetadata()?.study.title).toBe('My study');
+
+    const result = component.alignment();
+    expect(result?.field).toBe('name');
+    expect(result?.matchCount).toBe(1);
+    expect(result?.unmatchedMetadata).toEqual([
+      { alias: 'alias-2', name: 'unmatched.fastq.gz' },
+    ]);
+    expect(result?.unmatchedBoxFiles.map((f) => f.id)).toEqual(['file-2']);
+  });
+
+  it('reports an error for invalid JSON', async () => {
+    await component.onFileSelected(fileEvent('{ not json'));
+
+    expect(component.uploadedMetadata()).toBeUndefined();
+    expect(component.parseError()).toBe('The file does not contain valid JSON.');
+  });
+
+  it('reports an error for a metadata file with the wrong shape', async () => {
+    await component.onFileSelected(fileEvent(JSON.stringify({ studies: [] })));
+
+    expect(component.uploadedMetadata()).toBeUndefined();
+    expect(component.parseError()).toBeDefined();
+  });
+});

--- a/src/app/upload/features/upload-box-mapping/upload-box-metadata-alignment.ts
+++ b/src/app/upload/features/upload-box-mapping/upload-box-metadata-alignment.ts
@@ -1,0 +1,98 @@
+/**
+ * Read-only alignment check between an upload box's files and an uploaded metadata file.
+ * @copyright The GHGA Authors
+ * @license Apache-2.0
+ */
+
+import { Component, computed, inject, input, signal } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+
+import { ResearchDataUploadBox } from '@app/upload/models/box';
+import { FileUploadWithAccession } from '@app/upload/models/file-upload';
+import {
+  computeMetadataAlignment,
+  parseUploadedMetadata,
+  UploadedMetadata,
+} from '@app/upload/models/metadata-alignment';
+import { UploadBoxService } from '@app/upload/services/upload-box';
+
+/**
+ * Embedded card that lets a data steward upload a metadata JSON file and see
+ * how well the upload box files align with it, without submitting anything to
+ * the backend. The alignment is reported for whichever metadata field (alias or
+ * name) matches best.
+ */
+@Component({
+  selector: 'app-upload-box-metadata-alignment',
+  imports: [MatButtonModule, MatCardModule, MatIconModule, MatProgressBarModule],
+  templateUrl: './upload-box-metadata-alignment.html',
+})
+export class UploadBoxMetadataAlignmentComponent {
+  #uploadBoxService = inject(UploadBoxService);
+
+  /** The locked upload box */
+  box = input.required<ResearchDataUploadBox>();
+
+  /** The parsed and validated uploaded metadata, if any */
+  uploadedMetadata = signal<UploadedMetadata | undefined>(undefined);
+
+  /** An error describing why the last uploaded file was rejected, if any */
+  parseError = signal<string | undefined>(undefined);
+
+  /** The name of the currently loaded metadata file, if any */
+  fileName = signal<string | undefined>(undefined);
+
+  /** Files in the upload box (excluding deleted and failed ones) */
+  boxFiles = computed<FileUploadWithAccession[]>(() =>
+    this.#uploadBoxService.boxFileUploads
+      .value()
+      .filter((file) => file.state !== 'cancelled' && file.state !== 'failed'),
+  );
+
+  /** Whether upload box files are still loading */
+  boxFilesLoading = computed<boolean>(() =>
+    this.#uploadBoxService.boxFileUploads.isLoading(),
+  );
+
+  /** The alignment result for the currently loaded metadata, if any */
+  alignment = computed(() => {
+    const metadata = this.uploadedMetadata();
+    if (!metadata) return undefined;
+    return computeMetadataAlignment(metadata.files, this.boxFiles());
+  });
+
+  /**
+   * Read the selected file, validate it, and store the result or an error.
+   * @param event - the file input change event
+   */
+  async onFileSelected(event: Event): Promise<void> {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    // Reset so selecting the same file again re-triggers the change event.
+    input.value = '';
+    if (!file) return;
+
+    this.fileName.set(file.name);
+    let data: unknown;
+    try {
+      data = JSON.parse(await file.text());
+    } catch {
+      this.uploadedMetadata.set(undefined);
+      this.parseError.set('The file does not contain valid JSON.');
+      return;
+    }
+
+    const result = parseUploadedMetadata(data);
+    if (!result.ok) {
+      this.uploadedMetadata.set(undefined);
+      this.parseError.set(result.error);
+      return;
+    }
+
+    this.parseError.set(undefined);
+    this.uploadedMetadata.set(result.metadata);
+  }
+}

--- a/src/app/upload/features/upload-box-mapping/upload-box-metadata-alignment.ts
+++ b/src/app/upload/features/upload-box-mapping/upload-box-metadata-alignment.ts
@@ -4,13 +4,12 @@
  * @license Apache-2.0
  */
 
-import { Component, computed, inject, input, signal } from '@angular/core';
+import { Component, computed, inject, signal } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 
-import { ResearchDataUploadBox } from '@app/upload/models/box';
 import { FileUploadWithAccession } from '@app/upload/models/file-upload';
 import {
   computeMetadataAlignment,
@@ -32,9 +31,6 @@ import { UploadBoxService } from '@app/upload/services/upload-box';
 })
 export class UploadBoxMetadataAlignmentComponent {
   #uploadBoxService = inject(UploadBoxService);
-
-  /** The locked upload box */
-  box = input.required<ResearchDataUploadBox>();
 
   /** The parsed and validated uploaded metadata, if any */
   uploadedMetadata = signal<UploadedMetadata | undefined>(undefined);

--- a/src/app/upload/models/metadata-alignment.spec.ts
+++ b/src/app/upload/models/metadata-alignment.spec.ts
@@ -50,6 +50,17 @@ describe('parseUploadedMetadata', () => {
     expect(result.ok).toBe(false);
   });
 
+  it('rejects a non-boolean included_in_submission', () => {
+    const result = parseUploadedMetadata(
+      makeMetadata({
+        research_data_files: [
+          { alias: 'a', name: 'b', included_in_submission: 'true', dataset: 'd' },
+        ],
+      }),
+    );
+    expect(result.ok).toBe(false);
+  });
+
   it('extracts the first study and allows extra properties', () => {
     const result = parseUploadedMetadata(
       makeMetadata({

--- a/src/app/upload/models/metadata-alignment.spec.ts
+++ b/src/app/upload/models/metadata-alignment.spec.ts
@@ -1,0 +1,149 @@
+/**
+ * Tests for the metadata alignment models and logic.
+ * @copyright The GHGA Authors
+ * @license Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  computeMetadataAlignment,
+  parseUploadedMetadata,
+  UploadedMetadataFile,
+} from './metadata-alignment';
+
+/**
+ * Build a minimal valid metadata object with the given overrides.
+ * @param overrides - properties to merge into the base object
+ * @returns a metadata-shaped object
+ */
+function makeMetadata(overrides: Record<string, unknown> = {}): unknown {
+  return {
+    studies: [{ title: 'A title', description: 'A description' }],
+    datasets: [],
+    ...overrides,
+  };
+}
+
+describe('parseUploadedMetadata', () => {
+  it('rejects non-objects', () => {
+    expect(parseUploadedMetadata(null).ok).toBe(false);
+    expect(parseUploadedMetadata([]).ok).toBe(false);
+    expect(parseUploadedMetadata('x').ok).toBe(false);
+  });
+
+  it('rejects an empty or missing studies list', () => {
+    expect(parseUploadedMetadata({ datasets: [] }).ok).toBe(false);
+    expect(parseUploadedMetadata({ studies: [] }).ok).toBe(false);
+  });
+
+  it('rejects studies without a title or description', () => {
+    expect(parseUploadedMetadata({ studies: [{ title: 'x' }] }).ok).toBe(false);
+    expect(parseUploadedMetadata({ studies: [{ description: 'x' }] }).ok).toBe(false);
+  });
+
+  it('rejects file entries missing required properties', () => {
+    const result = parseUploadedMetadata(
+      makeMetadata({
+        research_data_files: [{ alias: 'a', name: 'b', dataset: 'd' }],
+      }),
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  it('extracts the first study and allows extra properties', () => {
+    const result = parseUploadedMetadata(
+      makeMetadata({
+        studies: [
+          { title: 'First', description: 'Desc', extra: 1 },
+          { title: 'Second', description: 'Other' },
+        ],
+      }),
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.metadata.study).toEqual({
+        title: 'First',
+        description: 'Desc',
+      });
+    }
+  });
+
+  it('collects included files from all *_files lists', () => {
+    const result = parseUploadedMetadata(
+      makeMetadata({
+        research_data_files: [
+          { alias: 'a1', name: 'n1', included_in_submission: true, dataset: 'd' },
+          { alias: 'a2', name: 'n2', included_in_submission: false, dataset: 'd' },
+        ],
+        process_data_files: [
+          { alias: 'a3', name: 'n3', included_in_submission: true, dataset: 'd' },
+        ],
+      }),
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.metadata.files).toEqual([
+        { alias: 'a1', name: 'n1' },
+        { alias: 'a3', name: 'n3' },
+      ]);
+    }
+  });
+
+  it('rejects a *_files property that is not a list', () => {
+    const result = parseUploadedMetadata(makeMetadata({ research_data_files: {} }));
+    expect(result.ok).toBe(false);
+  });
+});
+
+const META_FILES: UploadedMetadataFile[] = [
+  { alias: 'alias-1', name: 'name-1.fastq.gz' },
+  { alias: 'alias-2', name: 'name-2.fastq.gz' },
+  { alias: 'alias-3', name: 'name-3.fastq.gz' },
+];
+
+describe('computeMetadataAlignment', () => {
+  it('prefers the field with more matches', () => {
+    const boxFiles = [
+      { id: 'f1', alias: 'name-1.fastq.gz' },
+      { id: 'f2', alias: 'name-2.fastq.gz' },
+    ];
+    const result = computeMetadataAlignment(META_FILES, boxFiles);
+    expect(result.field).toBe('name');
+    expect(result.nameMatchCount).toBe(2);
+    expect(result.aliasMatchCount).toBe(0);
+    expect(result.matchCount).toBe(2);
+    expect(result.unmatchedMetadata).toEqual([
+      { alias: 'alias-3', name: 'name-3.fastq.gz' },
+    ]);
+    expect(result.unmatchedBoxFiles).toEqual([]);
+  });
+
+  it('breaks a tie in favor of the alias', () => {
+    const boxFiles = [
+      { id: 'f1', alias: 'alias-1' },
+      { id: 'f2', alias: 'name-2.fastq.gz' },
+    ];
+    const result = computeMetadataAlignment(META_FILES, boxFiles);
+    expect(result.aliasMatchCount).toBe(1);
+    expect(result.nameMatchCount).toBe(1);
+    expect(result.field).toBe('alias');
+  });
+
+  it('reports unmatched box files', () => {
+    const boxFiles = [
+      { id: 'f1', alias: 'alias-1' },
+      { id: 'f2', alias: 'unrelated.txt' },
+    ];
+    const result = computeMetadataAlignment(META_FILES, boxFiles);
+    expect(result.field).toBe('alias');
+    expect(result.matchCount).toBe(1);
+    expect(result.unmatchedBoxFiles).toEqual([{ id: 'f2', alias: 'unrelated.txt' }]);
+  });
+
+  it('matches case-insensitively when unambiguous', () => {
+    const boxFiles = [{ id: 'f1', alias: 'ALIAS-1' }];
+    const result = computeMetadataAlignment(META_FILES, boxFiles);
+    expect(result.field).toBe('alias');
+    expect(result.matchCount).toBe(1);
+  });
+});

--- a/src/app/upload/models/metadata-alignment.ts
+++ b/src/app/upload/models/metadata-alignment.ts
@@ -77,10 +77,10 @@ function validateFileEntry(entry: unknown, key: string): string | undefined {
   if (
     typeof e['alias'] !== 'string' ||
     typeof e['name'] !== 'string' ||
-    !('included_in_submission' in e) ||
+    typeof e['included_in_submission'] !== 'boolean' ||
     !('dataset' in e)
   ) {
-    return `Each entry in "${key}" must have "alias", "name", "included_in_submission", and "dataset".`;
+    return `Each entry in "${key}" must have a string "alias" and "name", a boolean "included_in_submission", and a "dataset".`;
   }
   return undefined;
 }

--- a/src/app/upload/models/metadata-alignment.ts
+++ b/src/app/upload/models/metadata-alignment.ts
@@ -1,0 +1,230 @@
+/**
+ * Models and logic for aligning an upload box's files with an uploaded metadata file.
+ * @copyright The GHGA Authors
+ * @license Apache-2.0
+ */
+
+import { MappedField } from './mapping';
+
+/** A study as found in an uploaded metadata file (only the shown fields) */
+export interface UploadedMetadataStudy {
+  /** The study title */
+  title: string;
+  /** The study description */
+  description: string;
+}
+
+/** A single file entry collected from an uploaded metadata file */
+export interface UploadedMetadataFile {
+  /** The file alias */
+  alias: string;
+  /** The file name */
+  name: string;
+}
+
+/** The relevant parts extracted from a validated uploaded metadata file */
+export interface UploadedMetadata {
+  /** The first study in the metadata file */
+  study: UploadedMetadataStudy;
+  /** All files with `included_in_submission: true` across all `*_files` lists */
+  files: UploadedMetadataFile[];
+}
+
+/** Result of parsing and validating an uploaded metadata file */
+export type MetadataParseResult =
+  | { ok: true; metadata: UploadedMetadata }
+  | { ok: false; error: string };
+
+/** A box file as far as the alignment check is concerned */
+interface AlignmentBoxFile {
+  /** Unique identifier for the box file */
+  id: string;
+  /** The alias (filename) of the box file */
+  alias: string;
+}
+
+/** The outcome of aligning box files against uploaded metadata files */
+export interface MetadataAlignmentResult {
+  /** The metadata field that aligned best (the one reported to the user) */
+  field: MappedField;
+  /** Number of matches when aligning by the file alias */
+  aliasMatchCount: number;
+  /** Number of matches when aligning by the file name */
+  nameMatchCount: number;
+  /** Number of matches for the chosen field */
+  matchCount: number;
+  /** Total number of metadata files */
+  totalMetadata: number;
+  /** Total number of box files */
+  totalBoxFiles: number;
+  /** Metadata files that did not match any box file (for the chosen field) */
+  unmatchedMetadata: UploadedMetadataFile[];
+  /** Box files that were not matched by any metadata file (for the chosen field) */
+  unmatchedBoxFiles: AlignmentBoxFile[];
+}
+
+/**
+ * Validate an entry from a `*_files` list and report problems.
+ * @param entry - the raw entry to validate
+ * @param key - the name of the list the entry belongs to (for messages)
+ * @returns an error message, or `undefined` if the entry is valid
+ */
+function validateFileEntry(entry: unknown, key: string): string | undefined {
+  if (typeof entry !== 'object' || entry === null) {
+    return `Each entry in "${key}" must be an object.`;
+  }
+  const e = entry as Record<string, unknown>;
+  if (
+    typeof e['alias'] !== 'string' ||
+    typeof e['name'] !== 'string' ||
+    !('included_in_submission' in e) ||
+    !('dataset' in e)
+  ) {
+    return `Each entry in "${key}" must have "alias", "name", "included_in_submission", and "dataset".`;
+  }
+  return undefined;
+}
+
+/**
+ * Parse and validate an uploaded metadata file. Validation is lenient: only the
+ * properties that are needed are checked for existence, additional properties
+ * are allowed. All files with `included_in_submission: true` are collected from
+ * every property whose name ends in `_files`.
+ * @param data - the parsed JSON value to validate
+ * @returns the extracted metadata, or an error message describing the problem
+ */
+export function parseUploadedMetadata(data: unknown): MetadataParseResult {
+  if (typeof data !== 'object' || data === null || Array.isArray(data)) {
+    return { ok: false, error: 'The metadata must be a JSON object.' };
+  }
+  const obj = data as Record<string, unknown>;
+
+  const studies = obj['studies'];
+  if (!Array.isArray(studies) || studies.length === 0) {
+    return {
+      ok: false,
+      error: 'The metadata must contain a non-empty "studies" list.',
+    };
+  }
+  for (const study of studies) {
+    if (
+      typeof study !== 'object' ||
+      study === null ||
+      typeof (study as Record<string, unknown>)['title'] !== 'string' ||
+      typeof (study as Record<string, unknown>)['description'] !== 'string'
+    ) {
+      return {
+        ok: false,
+        error: 'Each study must have a "title" and a "description".',
+      };
+    }
+  }
+  const firstStudy = studies[0] as Record<string, unknown>;
+
+  const files: UploadedMetadataFile[] = [];
+  for (const [key, value] of Object.entries(obj)) {
+    if (!key.endsWith('_files')) continue;
+    if (!Array.isArray(value)) {
+      return { ok: false, error: `The "${key}" property must be a list.` };
+    }
+    for (const entry of value) {
+      const error = validateFileEntry(entry, key);
+      if (error) return { ok: false, error };
+      const e = entry as Record<string, unknown>;
+      if (e['included_in_submission'] === true) {
+        files.push({ alias: e['alias'] as string, name: e['name'] as string });
+      }
+    }
+  }
+
+  return {
+    ok: true,
+    metadata: {
+      study: {
+        title: firstStudy['title'] as string,
+        description: firstStudy['description'] as string,
+      },
+      files,
+    },
+  };
+}
+
+/**
+ * Match metadata files against box files using a single field.
+ *
+ * This mirrors the matching rule used by the study-based mapping
+ * (`computeAutoMappings` in `upload-box-mapping.ts`): a case-sensitive exact
+ * match takes priority, otherwise the single case-insensitive match is used if
+ * exactly one exists. Box files are never reused. Keep both in sync.
+ * @param metaFiles - the metadata files to match
+ * @param boxFiles - the box files to match against
+ * @param field - which metadata field to compare against the box file alias
+ * @returns a map from metadata file index to matched box file id
+ */
+function matchByField(
+  metaFiles: UploadedMetadataFile[],
+  boxFiles: AlignmentBoxFile[],
+  field: MappedField,
+): Map<number, string> {
+  const result = new Map<number, string>();
+  const usedBoxIds = new Set<string>();
+
+  metaFiles.forEach((meta, index) => {
+    const metaValue = meta[field];
+    if (!metaValue) return;
+
+    // Case-sensitive exact match
+    const exact = boxFiles.find(
+      (bf) => bf.alias === metaValue && !usedBoxIds.has(bf.id),
+    );
+    if (exact) {
+      result.set(index, exact.id);
+      usedBoxIds.add(exact.id);
+      return;
+    }
+
+    // Case-insensitive single match
+    const lower = metaValue.toLowerCase();
+    const caseMatches = boxFiles.filter(
+      (bf) => bf.alias.toLowerCase() === lower && !usedBoxIds.has(bf.id),
+    );
+    if (caseMatches.length === 1) {
+      result.set(index, caseMatches[0].id);
+      usedBoxIds.add(caseMatches[0].id);
+    }
+  });
+
+  return result;
+}
+
+/**
+ * Align box files against uploaded metadata files, trying both the alias and
+ * the name field and reporting on whichever yields more matches (a tie is
+ * resolved in favor of the alias).
+ * @param metaFiles - the metadata files to align
+ * @param boxFiles - the box files to align against
+ * @returns the alignment result for the better field
+ */
+export function computeMetadataAlignment(
+  metaFiles: UploadedMetadataFile[],
+  boxFiles: AlignmentBoxFile[],
+): MetadataAlignmentResult {
+  const aliasMatches = matchByField(metaFiles, boxFiles, 'alias');
+  const nameMatches = matchByField(metaFiles, boxFiles, 'name');
+
+  // Prefer the field with more matches; a tie favors the alias.
+  const field: MappedField = nameMatches.size > aliasMatches.size ? 'name' : 'alias';
+  const matches = field === 'name' ? nameMatches : aliasMatches;
+  const matchedBoxIds = new Set(matches.values());
+
+  return {
+    field,
+    aliasMatchCount: aliasMatches.size,
+    nameMatchCount: nameMatches.size,
+    matchCount: matches.size,
+    totalMetadata: metaFiles.length,
+    totalBoxFiles: boxFiles.length,
+    unmatchedMetadata: metaFiles.filter((_, index) => !matches.has(index)),
+    unmatchedBoxFiles: boxFiles.filter((bf) => !matchedBoxIds.has(bf.id)),
+  };
+}

--- a/src/mocks/example-metadata.json
+++ b/src/mocks/example-metadata.json
@@ -1,0 +1,111 @@
+{
+  "studies": [
+    {
+      "title": "RNA sequencing study of Jane",
+      "description": "Example metadata for testing the upload box alignment check. Its file names match most of the files in the locked mock upload box 'Research Data Upload Box of Jane', so the tool aligns by name and reports a few unmatched entries on both sides.",
+      "type": "research"
+    }
+  ],
+  "datasets": [
+    { "alias": "DATASET_A", "title": "Primary dataset" },
+    { "alias": "DATASET_B", "title": "Supporting dataset" }
+  ],
+  "experiment_method_supporting_files": [
+    {
+      "alias": "FILE_EMSF_001",
+      "name": "reference_genome.fasta",
+      "included_in_submission": true,
+      "dataset": "DATASET_A"
+    },
+    {
+      "alias": "FILE_EMSF_002",
+      "name": "variants_cohort.vcf",
+      "included_in_submission": true,
+      "dataset": "DATASET_A"
+    }
+  ],
+  "individual_supporting_files": [
+    {
+      "alias": "FILE_ISF_001",
+      "name": "methylation_sample_001.meth",
+      "included_in_submission": true,
+      "dataset": "DATASET_B"
+    },
+    {
+      "alias": "FILE_ISF_002",
+      "name": "chip_peaks_001.bed",
+      "included_in_submission": true,
+      "dataset": "DATASET_B"
+    }
+  ],
+  "process_data_files": [
+    {
+      "alias": "FILE_PDF_001",
+      "name": "aligned_reads_001.bam",
+      "included_in_submission": true,
+      "dataset": "DATASET_A"
+    },
+    {
+      "alias": "FILE_PDF_002",
+      "name": "aligned_reads_002.cram",
+      "included_in_submission": true,
+      "dataset": "DATASET_A"
+    },
+    {
+      "alias": "FILE_PDF_003",
+      "name": "aligned_reads_003.bam",
+      "included_in_submission": true,
+      "dataset": "DATASET_A"
+    },
+    {
+      "alias": "FILE_PDF_004",
+      "name": "extra_unaligned_reads.bam",
+      "included_in_submission": true,
+      "dataset": "DATASET_A"
+    },
+    {
+      "alias": "FILE_PDF_005",
+      "name": "draft_only_file.txt",
+      "included_in_submission": false,
+      "dataset": "DATASET_A"
+    }
+  ],
+  "research_data_files": [
+    {
+      "alias": "FILE_RDF_001",
+      "name": "sample_001_R1.fastq",
+      "included_in_submission": true,
+      "dataset": "DATASET_A"
+    },
+    {
+      "alias": "FILE_RDF_002",
+      "name": "sample_001_R2.fastq",
+      "included_in_submission": true,
+      "dataset": "DATASET_A"
+    },
+    {
+      "alias": "FILE_RDF_003",
+      "name": "sample_002_R1.fastq.gz",
+      "included_in_submission": true,
+      "dataset": "DATASET_A"
+    },
+    {
+      "alias": "FILE_RDF_004",
+      "name": "sample_002_R2.fastq.gz",
+      "included_in_submission": true,
+      "dataset": "DATASET_A"
+    },
+    {
+      "alias": "FILE_RDF_005",
+      "name": "sample_003_R1.fastq.gz",
+      "included_in_submission": true,
+      "dataset": "DATASET_A"
+    },
+    {
+      "alias": "FILE_RDF_006",
+      "name": "sample_004_R1.fastq.gz",
+      "included_in_submission": true,
+      "dataset": "DATASET_A"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds an "Uploaded metadata file" mode to the upload box mapping tool. Data stewards can upload a metadata JSON file (not yet ingested into the backend) and see how well the files in the RDUB align with it (i.e. read-only, nothing is submitted).

- A toggle in the mapping card switches between already-ingested metadata and an uploaded file.
- Files are collected from all `*_files` lists with `included_in_submission: true`; the first study's title/description is shown.
- Alignment is tried against both alias and name; the better-matching field is auto-chosen and reported, along with the match count and the unmatched files on both sides.
- Invalid/malformed metadata shows an error.
- Includes `src/mocks/example-metadata.json` for manual testing against the locked mock box.