### PR TITLE
Show details of own upload boxes (GSI-2451)

### DIFF
--- a/src/app/upload/features/upload-box-files-table/upload-box-files-table.html
+++ b/src/app/upload/features/upload-box-files-table/upload-box-files-table.html
@@ -1,11 +1,11 @@
 <div class="overflow-auto">
-  <table mat-table [dataSource]="dataSource" class="w-full">
+  <table mat-table matSort [dataSource]="dataSource" class="w-full">
     <ng-container matColumnDef="alias">
-      <th mat-header-cell *matHeaderCellDef>Filename</th>
+      <th mat-header-cell *matHeaderCellDef mat-sort-header>Filename</th>
       <td mat-cell *matCellDef="let file">{{ file.alias }}</td>
     </ng-container>
     <ng-container matColumnDef="status">
-      <th mat-header-cell *matHeaderCellDef>Status</th>
+      <th mat-header-cell *matHeaderCellDef mat-sort-header>Status</th>
       <td mat-cell *matCellDef="let file">
         <span [class]="(file.state | FileUploadStatePipe).class">{{
           (file.state | FileUploadStatePipe).name
@@ -13,17 +13,17 @@
       </td>
     </ng-container>
     <ng-container matColumnDef="size">
-      <th mat-header-cell *matHeaderCellDef>Size</th>
+      <th mat-header-cell *matHeaderCellDef mat-sort-header>Size</th>
       <td mat-cell *matCellDef="let file">{{ file.decrypted_size | parseBytes }}</td>
     </ng-container>
     <ng-container matColumnDef="uploaded">
-      <th mat-header-cell *matHeaderCellDef>Uploaded</th>
+      <th mat-header-cell *matHeaderCellDef mat-sort-header>Uploaded</th>
       <td mat-cell *matCellDef="let file">{{
         file.state_updated | date: friendlyDateFormat : timeZone
       }}</td>
     </ng-container>
     <ng-container matColumnDef="accession">
-      <th mat-header-cell *matHeaderCellDef>Accession</th>
+      <th mat-header-cell *matHeaderCellDef mat-sort-header>Accession</th>
       <td mat-cell *matCellDef="let file">{{ file.accession ?? '—' }}</td>
     </ng-container>
     <ng-container matColumnDef="delete">

--- a/src/app/upload/features/upload-box-files-table/upload-box-files-table.html
+++ b/src/app/upload/features/upload-box-files-table/upload-box-files-table.html
@@ -1,0 +1,62 @@
+<div class="overflow-auto">
+  <table mat-table [dataSource]="dataSource" class="w-full">
+    <ng-container matColumnDef="alias">
+      <th mat-header-cell *matHeaderCellDef>Filename</th>
+      <td mat-cell *matCellDef="let file">{{ file.alias }}</td>
+    </ng-container>
+    <ng-container matColumnDef="status">
+      <th mat-header-cell *matHeaderCellDef>Status</th>
+      <td mat-cell *matCellDef="let file">
+        <span [class]="(file.state | FileUploadStatePipe).class">{{
+          (file.state | FileUploadStatePipe).name
+        }}</span>
+      </td>
+    </ng-container>
+    <ng-container matColumnDef="size">
+      <th mat-header-cell *matHeaderCellDef>Size</th>
+      <td mat-cell *matCellDef="let file">{{ file.decrypted_size | parseBytes }}</td>
+    </ng-container>
+    <ng-container matColumnDef="uploaded">
+      <th mat-header-cell *matHeaderCellDef>Uploaded</th>
+      <td mat-cell *matCellDef="let file">{{
+        file.state_updated | date: friendlyDateFormat : timeZone
+      }}</td>
+    </ng-container>
+    <ng-container matColumnDef="accession">
+      <th mat-header-cell *matHeaderCellDef>Accession</th>
+      <td mat-cell *matCellDef="let file">{{ file.accession ?? '—' }}</td>
+    </ng-container>
+    <ng-container matColumnDef="delete">
+      <th mat-header-cell *matHeaderCellDef class="w-16"></th>
+      <td mat-cell *matCellDef="let file">
+        @if (deletable()(file)) {
+          <button
+            mat-icon-button
+            (click)="deleteFile.emit(file)"
+            [attr.aria-label]="'Delete file ' + file.alias"
+            [attr.data-umami-event]="deleteEventLabel() || null"
+            class="text-error"
+          >
+            <mat-icon fontIcon="delete"></mat-icon>
+          </button>
+        }
+      </td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="columns()"></tr>
+    <tr mat-row *matRowDef="let row; columns: columns()"></tr>
+
+    <tr class="mat-row" *matNoDataRow>
+      <td class="mat-cell p-4 text-base" [attr.colspan]="columns().length"
+        >Loading files...</td
+      >
+    </tr>
+  </table>
+</div>
+@if (showPaginator()) {
+  <mat-paginator
+    showFirstLastButtons
+    class="sticky left-0"
+    aria-label="Select page of files"
+  ></mat-paginator>
+}

--- a/src/app/upload/features/upload-box-files-table/upload-box-files-table.spec.ts
+++ b/src/app/upload/features/upload-box-files-table/upload-box-files-table.spec.ts
@@ -7,7 +7,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { UploadBoxState } from '@app/upload/models/box';
 import { FileUploadWithAccession } from '@app/upload/models/file-upload';
-import { screen } from '@testing-library/angular';
+import { screen, within } from '@testing-library/angular';
 import { UploadBoxFilesTableComponent } from './upload-box-files-table';
 
 /**
@@ -110,6 +110,30 @@ describe('UploadBoxFilesTableComponent', () => {
     screen.getByLabelText('Delete file alpha.txt').click();
     expect(emitted).toHaveLength(1);
     expect(emitted[0].alias).toBe('alpha.txt');
+  });
+
+  it('should sort the files by a column when its header is clicked', async () => {
+    const fixture = await createComponent({
+      files: [
+        makeFile({ id: 'a', alias: 'gamma.txt' }),
+        makeFile({ id: 'b', alias: 'alpha.txt' }),
+        makeFile({ id: 'c', alias: 'beta.txt' }),
+      ],
+      boxState: UploadBoxState.open,
+    });
+
+    const aliasOrder = () =>
+      screen
+        .getAllByRole('row')
+        .slice(1)
+        .map((row) => within(row).getAllByRole('cell')[0].textContent?.trim());
+
+    expect(aliasOrder()).toEqual(['gamma.txt', 'alpha.txt', 'beta.txt']);
+
+    screen.getByRole('columnheader', { name: /Filename/i }).click();
+    await fixture.whenStable();
+
+    expect(aliasOrder()).toEqual(['alpha.txt', 'beta.txt', 'gamma.txt']);
   });
 
   it('should show the accession column for archived boxes', async () => {

--- a/src/app/upload/features/upload-box-files-table/upload-box-files-table.spec.ts
+++ b/src/app/upload/features/upload-box-files-table/upload-box-files-table.spec.ts
@@ -1,0 +1,126 @@
+/**
+ * Tests for the UploadBoxFilesTableComponent.
+ * @copyright The GHGA Authors
+ * @license Apache-2.0
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { UploadBoxState } from '@app/upload/models/box';
+import { FileUploadWithAccession } from '@app/upload/models/file-upload';
+import { screen } from '@testing-library/angular';
+import { UploadBoxFilesTableComponent } from './upload-box-files-table';
+
+/**
+ * Create a file upload fixture.
+ * @param overrides - fields to override on the default file
+ * @returns a file upload with accession
+ */
+function makeFile(
+  overrides: Partial<FileUploadWithAccession>,
+): FileUploadWithAccession {
+  return {
+    id: 'file-1',
+    box_id: 'box-1',
+    alias: 'file-1.txt',
+    state: 'inbox',
+    state_updated: '2026-01-01T00:00:00Z',
+    storage_alias: 'TUE01',
+    bucket_id: 'bucket-1',
+    decrypted_sha256: null,
+    decrypted_size: 1024,
+    encrypted_size: 2048,
+    part_size: 512,
+    accession: null,
+    ...overrides,
+  };
+}
+
+const files: FileUploadWithAccession[] = [
+  makeFile({ id: 'f1', alias: 'alpha.txt', state: 'init' }),
+  makeFile({ id: 'f2', alias: 'beta.txt', state: 'interrogated' }),
+];
+
+/**
+ * Render the component with the given inputs.
+ * @param inputs - the signal inputs to set
+ * @param inputs.files - the file uploads to display
+ * @param inputs.boxState - the state of the box the files belong to
+ * @param inputs.showDelete - whether to show the delete column
+ * @param inputs.deletable - predicate deciding which files are deletable
+ * @returns the created fixture
+ */
+async function createComponent(inputs: {
+  files: FileUploadWithAccession[];
+  boxState: UploadBoxState;
+  showDelete?: boolean;
+  deletable?: (file: FileUploadWithAccession) => boolean;
+}): Promise<ComponentFixture<UploadBoxFilesTableComponent>> {
+  await TestBed.configureTestingModule({
+    imports: [UploadBoxFilesTableComponent],
+  }).compileComponents();
+  const fixture = TestBed.createComponent(UploadBoxFilesTableComponent);
+  fixture.componentRef.setInput('files', inputs.files);
+  fixture.componentRef.setInput('boxState', inputs.boxState);
+  if (inputs.showDelete !== undefined) {
+    fixture.componentRef.setInput('showDelete', inputs.showDelete);
+  }
+  if (inputs.deletable !== undefined) {
+    fixture.componentRef.setInput('deletable', inputs.deletable);
+  }
+  await fixture.whenStable();
+  return fixture;
+}
+
+describe('UploadBoxFilesTableComponent', () => {
+  it('should render the file names', async () => {
+    await createComponent({ files, boxState: UploadBoxState.open });
+    expect(screen.getByText('alpha.txt')).toBeInTheDocument();
+    expect(screen.getByText('beta.txt')).toBeInTheDocument();
+  });
+
+  it('should not show a delete column unless enabled', async () => {
+    await createComponent({
+      files,
+      boxState: UploadBoxState.open,
+      deletable: () => true,
+    });
+    expect(screen.queryByLabelText(/^Delete file/)).not.toBeInTheDocument();
+  });
+
+  it('should show delete buttons only for deletable files when enabled', async () => {
+    await createComponent({
+      files,
+      boxState: UploadBoxState.open,
+      showDelete: true,
+      deletable: (file) => file.state === 'init',
+    });
+    expect(screen.getByLabelText('Delete file alpha.txt')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Delete file beta.txt')).not.toBeInTheDocument();
+  });
+
+  it('should emit deleteFile when a delete button is clicked', async () => {
+    const fixture = await createComponent({
+      files,
+      boxState: UploadBoxState.open,
+      showDelete: true,
+      deletable: () => true,
+    });
+    const emitted: FileUploadWithAccession[] = [];
+    fixture.componentInstance.deleteFile.subscribe((file) => emitted.push(file));
+    screen.getByLabelText('Delete file alpha.txt').click();
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].alias).toBe('alpha.txt');
+  });
+
+  it('should show the accession column for archived boxes', async () => {
+    await createComponent({
+      files: [
+        makeFile({ alias: 'gamma.txt', state: 'archived', accession: 'GHGAF001' }),
+      ],
+      boxState: UploadBoxState.archived,
+    });
+    expect(screen.getByText('Accession')).toBeInTheDocument();
+    expect(screen.getByText('GHGAF001')).toBeInTheDocument();
+    expect(screen.queryByText('Status')).not.toBeInTheDocument();
+  });
+});

--- a/src/app/upload/features/upload-box-files-table/upload-box-files-table.ts
+++ b/src/app/upload/features/upload-box-files-table/upload-box-files-table.ts
@@ -9,6 +9,7 @@ import { Component, computed, effect, input, output, viewChild } from '@angular/
 import { MatButtonModule } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
+import { MatSort, MatSortModule } from '@angular/material/sort';
 import { MatTableDataSource, MatTableModule } from '@angular/material/table';
 import { DatePipe } from '@app/shared/pipes/date-pipe';
 import { ParseBytes } from '@app/shared/pipes/parse-bytes-pipe';
@@ -34,6 +35,7 @@ import { FileUploadStatePipe } from '@app/upload/pipes/file-upload-state-pipe';
     MatButtonModule,
     MatIcon,
     MatPaginatorModule,
+    MatSortModule,
     MatTableModule,
     DatePipe,
     ParseBytes,
@@ -81,10 +83,11 @@ export class UploadBoxFilesTableComponent {
   /** Whether to show the paginator (only useful for larger file lists). */
   showPaginator = computed<boolean>(() => this.files().length > 10);
 
-  /** MatTableDataSource for paginated file uploads. */
+  /** MatTableDataSource for paginated and sortable file uploads. */
   dataSource = new MatTableDataSource<FileUploadWithAccession>();
 
   private readonly paginator = viewChild(MatPaginator);
+  private readonly sort = viewChild(MatSort);
 
   #syncFilesEffect = effect(() => {
     this.dataSource.data = this.files();
@@ -96,4 +99,32 @@ export class UploadBoxFilesTableComponent {
       this.dataSource.paginator = paginator;
     }
   });
+
+  #assignSortEffect = effect(() => {
+    const sort = this.sort();
+    if (sort) {
+      this.dataSource.sort = sort;
+    }
+  });
+
+  /**
+   * Wire up sorting that reads the value backing each visible column, since the
+   * column names do not match the file properties one-to-one.
+   */
+  constructor() {
+    this.dataSource.sortingDataAccessor = (file, column) => {
+      switch (column) {
+        case 'size':
+          return file.decrypted_size;
+        case 'uploaded':
+          return file.state_updated;
+        case 'status':
+          return file.state;
+        case 'accession':
+          return file.accession ?? '';
+        default:
+          return file.alias;
+      }
+    };
+  }
 }

--- a/src/app/upload/features/upload-box-files-table/upload-box-files-table.ts
+++ b/src/app/upload/features/upload-box-files-table/upload-box-files-table.ts
@@ -1,0 +1,99 @@
+/**
+ * Reusable table showing the file uploads contained in an upload box.
+ * @copyright The GHGA Authors
+ * @license Apache-2.0
+ */
+
+import { DatePipe as CommonDatePipe } from '@angular/common';
+import { Component, computed, effect, input, output, viewChild } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIcon } from '@angular/material/icon';
+import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
+import { MatTableDataSource, MatTableModule } from '@angular/material/table';
+import { DatePipe } from '@app/shared/pipes/date-pipe';
+import { ParseBytes } from '@app/shared/pipes/parse-bytes-pipe';
+import {
+  DEFAULT_TIME_ZONE,
+  FRIENDLY_DATE_FORMAT,
+} from '@app/shared/utils/date-formats';
+import { UploadBoxState } from '@app/upload/models/box';
+import { FileUploadWithAccession } from '@app/upload/models/file-upload';
+import { FileUploadStatePipe } from '@app/upload/pipes/file-upload-state-pipe';
+
+/**
+ * Presentational, paginated table of the file uploads in an upload box.
+ *
+ * The visible columns depend on the box state: archived boxes show the assigned
+ * accession, other boxes show the upload status. When `showDelete` is set, an
+ * extra column offers a delete button for each file for which `deletable`
+ * returns true, emitting `deleteFile` on click.
+ */
+@Component({
+  selector: 'app-upload-box-files-table',
+  imports: [
+    MatButtonModule,
+    MatIcon,
+    MatPaginatorModule,
+    MatTableModule,
+    DatePipe,
+    ParseBytes,
+    FileUploadStatePipe,
+  ],
+  providers: [CommonDatePipe],
+  templateUrl: './upload-box-files-table.html',
+})
+export class UploadBoxFilesTableComponent {
+  /** The file uploads to display. */
+  files = input.required<FileUploadWithAccession[]>();
+
+  /** The state of the box the files belong to (controls the visible columns). */
+  boxState = input.required<UploadBoxState>();
+
+  /** Whether to show a column with per-file delete buttons. */
+  showDelete = input<boolean>(false);
+
+  /** Predicate deciding whether an individual file may be deleted. */
+  deletable = input<(file: FileUploadWithAccession) => boolean>(() => false);
+
+  /** Umami analytics event label for the delete button, if any. */
+  deleteEventLabel = input<string>('');
+
+  /** Emitted when the delete button of a file is clicked. */
+  deleteFile = output<FileUploadWithAccession>();
+
+  /** Human-readable date format for the upload timestamp. */
+  readonly friendlyDateFormat = FRIENDLY_DATE_FORMAT;
+
+  /** Timezone for date display. */
+  readonly timeZone = DEFAULT_TIME_ZONE;
+
+  /** The columns to display, depending on box state and delete availability. */
+  columns = computed<string[]>(() => {
+    if (this.boxState() === UploadBoxState.archived) {
+      return ['alias', 'accession', 'size', 'uploaded'];
+    }
+    const columns = ['alias', 'status', 'size', 'uploaded'];
+    // Files can only be deleted while the box is still open for uploads.
+    if (this.showDelete()) columns.push('delete');
+    return columns;
+  });
+
+  /** Whether to show the paginator (only useful for larger file lists). */
+  showPaginator = computed<boolean>(() => this.files().length > 10);
+
+  /** MatTableDataSource for paginated file uploads. */
+  dataSource = new MatTableDataSource<FileUploadWithAccession>();
+
+  private readonly paginator = viewChild(MatPaginator);
+
+  #syncFilesEffect = effect(() => {
+    this.dataSource.data = this.files();
+  });
+
+  #assignPaginatorEffect = effect(() => {
+    const paginator = this.paginator();
+    if (paginator) {
+      this.dataSource.paginator = paginator;
+    }
+  });
+}

--- a/src/app/upload/features/upload-box-manager-detail/upload-box-manager-detail.html
+++ b/src/app/upload/features/upload-box-manager-detail/upload-box-manager-detail.html
@@ -206,68 +206,14 @@
           </p>
           <p><strong>Files:</strong></p>
           @if (box.file_count > 0) {
-            <div class="overflow-auto">
-              <table mat-table [dataSource]="fileUploadsDataSource" class="w-full">
-                <ng-container matColumnDef="alias">
-                  <th mat-header-cell *matHeaderCellDef>Filename</th>
-                  <td mat-cell *matCellDef="let file">{{ file.alias }}</td>
-                </ng-container>
-                <ng-container matColumnDef="status">
-                  <th mat-header-cell *matHeaderCellDef>Status</th>
-                  <td mat-cell *matCellDef="let file">
-                    <span [class]="(file.state | FileUploadStatePipe).class">{{
-                      (file.state | FileUploadStatePipe).name
-                    }}</span>
-                  </td>
-                </ng-container>
-                <ng-container matColumnDef="size">
-                  <th mat-header-cell *matHeaderCellDef>Size</th>
-                  <td mat-cell *matCellDef="let file">{{
-                    file.decrypted_size | parseBytes
-                  }}</td>
-                </ng-container>
-                <ng-container matColumnDef="uploaded">
-                  <th mat-header-cell *matHeaderCellDef>Uploaded</th>
-                  <td mat-cell *matCellDef="let file">{{
-                    file.state_updated | date: friendlyDateFormat : timeZone
-                  }}</td>
-                </ng-container>
-                <ng-container matColumnDef="accession">
-                  <th mat-header-cell *matHeaderCellDef>Accession</th>
-                  <td mat-cell *matCellDef="let file">{{ file.accession ?? '—' }}</td>
-                </ng-container>
-                <ng-container matColumnDef="delete">
-                  <th mat-header-cell *matHeaderCellDef class="w-16"></th>
-                  <td mat-cell *matCellDef="let file">
-                    @if (canDeleteFile(file)) {
-                      <button
-                        mat-icon-button
-                        (click)="deleteFile(file)"
-                        [attr.aria-label]="'Delete file ' + file.alias"
-                        data-umami-event="Upload Box Manager Detail Delete File Clicked"
-                        class="text-error"
-                      >
-                        <mat-icon fontIcon="delete"></mat-icon>
-                      </button>
-                    }
-                  </td>
-                </ng-container>
-
-                <tr mat-header-row *matHeaderRowDef="fileColumns()"></tr>
-                <tr mat-row *matRowDef="let row; columns: fileColumns()"></tr>
-
-                <tr class="mat-row" *matNoDataRow>
-                  <td class="mat-cell p-4 text-base" colspan="4">Loading files...</td>
-                </tr>
-              </table>
-            </div>
-            @if (box.file_count > 10) {
-              <mat-paginator
-                showFirstLastButtons
-                class="sticky left-0"
-                aria-label="Select page of files"
-              ></mat-paginator>
-            }
+            <app-upload-box-files-table
+              [files]="fileUploads()"
+              [boxState]="box.state"
+              [showDelete]="box.state === 'open'"
+              [deletable]="canDeleteFileFn"
+              deleteEventLabel="Upload Box Manager Detail Delete File Clicked"
+              (deleteFile)="deleteFile($event)"
+            />
           } @else {
             <p class="text-warning mt-2">This upload box is still empty.</p>
           }

--- a/src/app/upload/features/upload-box-manager-detail/upload-box-manager-detail.ts
+++ b/src/app/upload/features/upload-box-manager-detail/upload-box-manager-detail.ts
@@ -14,14 +14,12 @@ import {
   input,
   OnInit,
   signal,
-  viewChild,
 } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatDialog } from '@angular/material/dialog';
 import { MatIcon } from '@angular/material/icon';
-import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
-import { MatTableDataSource, MatTableModule } from '@angular/material/table';
+import { MatTableModule } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { Router, RouterLink } from '@angular/router';
 
@@ -46,9 +44,9 @@ import {
   FileUploadWithAccession,
 } from '@app/upload/models/file-upload';
 import { UploadGrant } from '@app/upload/models/grant';
-import { FileUploadStatePipe } from '@app/upload/pipes/file-upload-state-pipe';
 import { UploadBoxService } from '@app/upload/services/upload-box';
 import { UploadBoxEditDetailsDialogComponent } from '../upload-box-edit-details-dialog/upload-box-edit-details-dialog';
+import { UploadBoxFilesTableComponent } from '../upload-box-files-table/upload-box-files-table';
 import { UploadBoxMappingComponent } from '../upload-box-mapping/upload-box-mapping';
 
 /**
@@ -62,13 +60,12 @@ import { UploadBoxMappingComponent } from '../upload-box-mapping/upload-box-mapp
     MatButtonModule,
     MatCardModule,
     MatIcon,
-    MatPaginatorModule,
     MatTableModule,
     MatTooltipModule,
     RouterLink,
     Capitalise,
     ParseBytes,
-    FileUploadStatePipe,
+    UploadBoxFilesTableComponent,
     UploadBoxMappingComponent,
   ],
   providers: [CommonDatePipe, ParseBytes],
@@ -177,38 +174,13 @@ export class UploadBoxManagerDetailComponent implements OnInit {
   /** Placeholder columns for the upload grants table. */
   readonly grantColumns = ['grantee', 'status', 'validity', 'details'];
 
-  /** Columns for the file uploads table. */
-  fileColumns = computed<string[]>(() => {
-    const state = this.uploadBox()?.state;
-    if (state === UploadBoxState.archived) {
-      return ['alias', 'accession', 'size', 'uploaded'];
-    }
-    const columns = ['alias', 'status', 'size', 'uploaded'];
-    // Files can only be deleted while the box is still open for uploads.
-    if (state === UploadBoxState.open) {
-      columns.push('delete');
-    }
-    return columns;
-  });
-
   /** The upload grants for this box. */
   grants = computed<UploadGrant[]>(() => this.#uploadBoxService.boxGrants.value());
 
-  /** MatTableDataSource for paginated file uploads. */
-  fileUploadsDataSource = new MatTableDataSource<FileUploadWithAccession>();
-
-  private readonly fileUploadsPaginator = viewChild(MatPaginator);
-
-  #syncFileUploadsEffect = effect(() => {
-    this.fileUploadsDataSource.data = this.#uploadBoxService.boxFileUploads.value();
-  });
-
-  #assignPaginatorEffect = effect(() => {
-    const paginator = this.fileUploadsPaginator();
-    if (paginator) {
-      this.fileUploadsDataSource.paginator = paginator;
-    }
-  });
+  /** The file uploads contained in this box. */
+  fileUploads = computed<FileUploadWithAccession[]>(() =>
+    this.#uploadBoxService.boxFileUploads.value(),
+  );
 
   /**
    * Check if an upload grant is currently active.
@@ -452,6 +424,15 @@ export class UploadBoxManagerDetailComponent implements OnInit {
       this.#deletableFileStates.includes(file.state)
     );
   }
+
+  /**
+   * Bound predicate passed to the files table so it can decide, per file,
+   * whether to render a delete button.
+   * @param file - the file upload to check
+   * @returns true if the file can be deleted
+   */
+  readonly canDeleteFileFn = (file: FileUploadWithAccession): boolean =>
+    this.canDeleteFile(file);
 
   /**
    * Delete a file upload from the box. Files that are still being uploaded

--- a/src/app/upload/features/user-upload-box-details-dialog/user-upload-box-details-dialog.html
+++ b/src/app/upload/features/user-upload-box-details-dialog/user-upload-box-details-dialog.html
@@ -1,0 +1,50 @@
+<h2 mat-dialog-title>Upload Box Details</h2>
+
+<mat-dialog-content>
+  @if (isLoading()) {
+    <app-stencil></app-stencil>
+  } @else if (hasError()) {
+    <p class="text-error"
+      >There was an error retrieving the upload box. Please try again later.</p
+    >
+  } @else if (box(); as box) {
+    <div class="flex flex-col gap-4 pt-2">
+      <div>
+        <p>
+          <strong class="inline-block w-40">Title:</strong>
+          <span>{{ box.title }}</span>
+        </p>
+        <p class="flex">
+          <strong class="inline-block min-w-40">Description:</strong>
+          <span>{{ box.description }}</span>
+        </p>
+        <p>
+          <strong class="inline-block w-40">State:</strong>
+          <strong class="{{ stateClass[box.state] }} capitalize">{{
+            box.state | CapitalisePipe
+          }}</strong>
+        </p>
+        <p>
+          <strong class="inline-block w-40">Files / Size:</strong>
+          <span
+            >{{ box.file_count }} files using {{ box.size | parseBytes }} of
+            {{ box.max_size | parseBytes }}</span
+          >
+        </p>
+      </div>
+
+      <div>
+        <p class="mb-2"><strong>Files:</strong></p>
+        @if (box.file_count > 0) {
+          <app-upload-box-files-table [files]="files()" [boxState]="box.state" />
+        } @else {
+          <p class="text-warning">This upload box is still empty.</p>
+        }
+      </div>
+    </div>
+  }
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-button mat-dialog-close type="button">Close</button>
+</mat-dialog-actions>

--- a/src/app/upload/features/user-upload-box-details-dialog/user-upload-box-details-dialog.spec.ts
+++ b/src/app/upload/features/user-upload-box-details-dialog/user-upload-box-details-dialog.spec.ts
@@ -1,0 +1,160 @@
+/**
+ * Tests for the UserUploadBoxDetailsDialogComponent.
+ * @copyright The GHGA Authors
+ * @license Apache-2.0
+ */
+
+import { signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { ResearchDataUploadBox, UploadBoxState } from '@app/upload/models/box';
+import { FileUploadWithAccession } from '@app/upload/models/file-upload';
+import { GrantWithBoxInfo } from '@app/upload/models/grant';
+import { UploadBoxService } from '@app/upload/services/upload-box';
+import { screen } from '@testing-library/angular';
+import { UserUploadBoxDetailsDialogComponent } from './user-upload-box-details-dialog';
+
+const TIB = 1_099_511_627_776;
+
+const box: ResearchDataUploadBox = {
+  id: 'box-1',
+  version: 1,
+  title: 'My Box',
+  description: 'My description',
+  storage_alias: 'TUE01',
+  max_size: 4 * TIB,
+  state: UploadBoxState.locked,
+  last_changed: '2026-01-01T00:00:00Z',
+  changed_by: 'user-1',
+  file_count: 1,
+  size: 1024,
+};
+
+const grant = { box_id: 'box-1' } as GrantWithBoxInfo;
+
+const file: FileUploadWithAccession = {
+  id: 'file-1',
+  box_id: 'box-1',
+  alias: 'alpha.txt',
+  state: 'interrogated',
+  state_updated: '2026-01-01T00:00:00Z',
+  storage_alias: 'TUE01',
+  bucket_id: 'bucket-1',
+  decrypted_sha256: null,
+  decrypted_size: 1024,
+  encrypted_size: 2048,
+  part_size: 512,
+  accession: null,
+};
+
+/**
+ * Minimal mock of UploadBoxService for the details dialog tests.
+ */
+class MockUploadBoxService {
+  #boxValue = signal<ResearchDataUploadBox | undefined>(undefined);
+  #boxLoading = signal<boolean>(false);
+  #boxError = signal<Error | undefined>(undefined);
+  #files = signal<FileUploadWithAccession[]>([]);
+
+  uploadBox = {
+    value: this.#boxValue.asReadonly(),
+    isLoading: this.#boxLoading.asReadonly(),
+    error: this.#boxError.asReadonly(),
+  };
+
+  boxFileUploads = {
+    value: this.#files.asReadonly(),
+    isLoading: () => false,
+    error: () => undefined,
+  };
+
+  loadUploadBox = vitest.fn();
+  loadFileUploadsForBox = vitest.fn();
+
+  /**
+   * Test helper: set the loaded box.
+   * @param value - the box value to expose
+   */
+  setBox(value: ResearchDataUploadBox | undefined): void {
+    this.#boxValue.set(value);
+  }
+
+  /**
+   * Test helper: set an error on the box resource.
+   * @param error - the error to expose
+   */
+  setError(error: Error): void {
+    this.#boxError.set(error);
+  }
+
+  /**
+   * Test helper: set the box file uploads.
+   * @param files - the files to expose
+   */
+  setFiles(files: FileUploadWithAccession[]): void {
+    this.#files.set(files);
+  }
+}
+
+/**
+ * Configure the testing module and create the component.
+ * @returns the created fixture and the mocked service
+ */
+async function createComponent(): Promise<{
+  fixture: ComponentFixture<UserUploadBoxDetailsDialogComponent>;
+  service: MockUploadBoxService;
+}> {
+  await TestBed.configureTestingModule({
+    imports: [UserUploadBoxDetailsDialogComponent],
+    providers: [
+      { provide: MAT_DIALOG_DATA, useValue: grant },
+      { provide: UploadBoxService, useClass: MockUploadBoxService },
+    ],
+  }).compileComponents();
+  const service = TestBed.inject(UploadBoxService) as unknown as MockUploadBoxService;
+  const fixture = TestBed.createComponent(UserUploadBoxDetailsDialogComponent);
+  return { fixture, service };
+}
+
+describe('UserUploadBoxDetailsDialogComponent', () => {
+  it('should request the box when opened', async () => {
+    const { fixture, service } = await createComponent();
+    await fixture.whenStable();
+    expect(service.loadUploadBox).toHaveBeenCalledWith('box-1');
+  });
+
+  it('should show the box details and files once loaded', async () => {
+    const { fixture, service } = await createComponent();
+    service.setBox(box);
+    service.setFiles([file]);
+    await fixture.whenStable();
+    expect(screen.getByText('My Box')).toBeInTheDocument();
+    expect(screen.getByText('alpha.txt')).toBeInTheDocument();
+    expect(service.loadFileUploadsForBox).toHaveBeenCalledWith('box-1');
+  });
+
+  it('should not offer any modifying actions', async () => {
+    const { fixture, service } = await createComponent();
+    service.setBox(box);
+    service.setFiles([file]);
+    await fixture.whenStable();
+    expect(screen.queryByLabelText(/^Delete file/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /edit|lock|delete|submit/i }),
+    ).toBeNull();
+  });
+
+  it('should show a notice when the box is empty', async () => {
+    const { fixture, service } = await createComponent();
+    service.setBox({ ...box, file_count: 0 });
+    await fixture.whenStable();
+    expect(screen.getByText(/still empty/i)).toBeInTheDocument();
+  });
+
+  it('should show an error message when loading fails', async () => {
+    const { fixture, service } = await createComponent();
+    service.setError(new Error('boom'));
+    await fixture.whenStable();
+    expect(screen.getByText(/error retrieving the upload box/i)).toBeInTheDocument();
+  });
+});

--- a/src/app/upload/features/user-upload-box-details-dialog/user-upload-box-details-dialog.ts
+++ b/src/app/upload/features/user-upload-box-details-dialog/user-upload-box-details-dialog.ts
@@ -1,0 +1,89 @@
+/**
+ * Read-only dialog showing an upload box owned by the current user.
+ * @copyright The GHGA Authors
+ * @license Apache-2.0
+ */
+
+import { Component, computed, effect, inject } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
+import { Capitalise } from '@app/shared/pipes/capitalise-pipe';
+import { ParseBytes } from '@app/shared/pipes/parse-bytes-pipe';
+import { StencilComponent } from '@app/shared/ui/stencil/stencil/stencil';
+import { ResearchDataUploadBox, UploadBoxStateClass } from '@app/upload/models/box';
+import { FileUploadWithAccession } from '@app/upload/models/file-upload';
+import { GrantWithBoxInfo } from '@app/upload/models/grant';
+import { UploadBoxService } from '@app/upload/services/upload-box';
+import { UploadBoxFilesTableComponent } from '../upload-box-files-table/upload-box-files-table';
+
+/**
+ * Read-only details view of one of the current user's upload boxes, shown in a
+ * dialog from the account page. Users can inspect the box metadata and the files
+ * it contains, but cannot modify the box or its files.
+ */
+@Component({
+  selector: 'app-user-upload-box-details-dialog',
+  imports: [
+    MatButtonModule,
+    MatDialogModule,
+    Capitalise,
+    ParseBytes,
+    StencilComponent,
+    UploadBoxFilesTableComponent,
+  ],
+  templateUrl: './user-upload-box-details-dialog.html',
+})
+export class UserUploadBoxDetailsDialogComponent {
+  #uploadBoxService = inject(UploadBoxService);
+
+  /** The grant identifying the box to display, injected as dialog data. */
+  #grant = inject<GrantWithBoxInfo>(MAT_DIALOG_DATA);
+
+  /** The ID of the box to display. */
+  protected readonly boxId = this.#grant.box_id;
+
+  #box = this.#uploadBoxService.uploadBox;
+
+  /** Map from box state to CSS class. */
+  protected readonly stateClass = UploadBoxStateClass;
+
+  /**
+   * The box to display, or undefined while it is still being loaded. Guards on
+   * the ID so a stale value from a previously opened box is not shown.
+   */
+  protected box = computed<ResearchDataUploadBox | undefined>(() => {
+    const box = this.#box.error() ? undefined : this.#box.value();
+    return box && box.id === this.boxId ? box : undefined;
+  });
+
+  /** Whether the box is currently being loaded. */
+  protected isLoading = computed<boolean>(() => !this.box() && this.#box.isLoading());
+
+  /** Whether loading the box failed. */
+  protected hasError = computed<boolean>(() => !this.box() && !!this.#box.error());
+
+  /**
+   * The files contained in the box. Filtered by box ID so files left over from a
+   * previously opened box are never shown while the fresh list is loading.
+   */
+  protected files = computed<FileUploadWithAccession[]>(() =>
+    this.#uploadBoxService.boxFileUploads
+      .value()
+      .filter((file) => file.box_id === this.boxId),
+  );
+
+  /** Load the box files once the box is available and known to be non-empty. */
+  #loadFilesEffect = effect(() => {
+    const box = this.box();
+    if (box && box.file_count > 0) {
+      this.#uploadBoxService.loadFileUploadsForBox(box.id);
+    }
+  });
+
+  /**
+   * Trigger loading of the single box when the dialog is opened.
+   */
+  constructor() {
+    this.#uploadBoxService.loadUploadBox(this.boxId);
+  }
+}

--- a/src/app/upload/features/user-upload-grants-list/user-upload-grants-list.html
+++ b/src/app/upload/features/user-upload-grants-list/user-upload-grants-list.html
@@ -33,6 +33,18 @@
                   <div class="w-full sm:max-w-64">
                     <button
                       mat-stroked-button
+                      (click)="viewDetails(grant)"
+                      aria-label="View details of this upload box"
+                      data-umami-event="User Upload Grants List View Details Clicked"
+                      class="w-full whitespace-nowrap"
+                    >
+                      <mat-icon fontIcon="visibility"></mat-icon>
+                      View details
+                    </button>
+                  </div>
+                  <div class="w-full sm:max-w-64">
+                    <button
+                      mat-stroked-button
                       (click)="createToken(grant)"
                       aria-label="Create an upload token for this upload box"
                       data-umami-event="User Upload Grants List Create Token Clicked"

--- a/src/app/upload/features/user-upload-grants-list/user-upload-grants-list.ts
+++ b/src/app/upload/features/user-upload-grants-list/user-upload-grants-list.ts
@@ -65,6 +65,9 @@ export class UserUploadGrantsListComponent {
       data: grant,
       width: 'clamp(40em, 85vw, 64em)',
       maxWidth: 'calc(100vw - 2rem)',
+      // Focus the dialog heading instead of the first tabbable element, which
+      // would otherwise be the first sortable column header of the files table.
+      autoFocus: 'first-heading',
     });
   }
 

--- a/src/app/upload/features/user-upload-grants-list/user-upload-grants-list.ts
+++ b/src/app/upload/features/user-upload-grants-list/user-upload-grants-list.ts
@@ -15,6 +15,7 @@ import { StencilComponent } from '@app/shared/ui/stencil/stencil/stencil';
 import { UploadBoxState } from '@app/upload/models/box';
 import { GrantWithBoxInfo } from '@app/upload/models/grant';
 import { UploadBoxService } from '@app/upload/services/upload-box';
+import { UserUploadBoxDetailsDialogComponent } from '@app/upload/features/user-upload-box-details-dialog/user-upload-box-details-dialog';
 // eslint-disable-next-line boundaries/dependencies
 import { UploadWorkPackageDialogComponent } from '@app/work-packages/features/upload-work-package-dialog/upload-work-package-dialog';
 
@@ -54,6 +55,18 @@ export class UserUploadGrantsListComponent {
 
   /** ID of the box currently being submitted, to disable the button while in flight. */
   protected submittingBoxId = signal<string | null>(null);
+
+  /**
+   * Open a read-only dialog showing the details and files of the box.
+   * @param grant - the upload grant with box information
+   */
+  viewDetails(grant: GrantWithBoxInfo): void {
+    this.#dialog.open(UserUploadBoxDetailsDialogComponent, {
+      data: grant,
+      width: 'clamp(40em, 85vw, 64em)',
+      maxWidth: 'calc(100vw - 2rem)',
+    });
+  }
 
   /**
    * Open the upload token creation dialog for a selected upload grant.

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -1141,7 +1141,7 @@ export const datasetInformation: DatasetInformation = {
  */
 
 export const uploadBoxes: BoxRetrievalResults = {
-  count: 3,
+  count: 5,
   boxes: [
     {
       id: '0a36607a-b53f-49ed-bf3e-a5f2dbc68001',
@@ -1182,6 +1182,32 @@ export const uploadBoxes: BoxRetrievalResults = {
       storage_alias: 'TUE03',
       max_size: 8_246_337_208_320, // 7.5 TiB
     },
+    {
+      id: '0a36607a-b53f-49ed-bf3e-a5f2dbc68004',
+      version: 4,
+      state: UploadBoxState.open,
+      title: 'Research Data Upload Box 2 of John',
+      description: 'Upload box for proteomics files of study GHGAS12345678901235',
+      last_changed: '2025-02-04T09:00:00Z',
+      changed_by: 'doe@test.dev',
+      file_count: 15,
+      size: 64424509440, // 60 GiB
+      storage_alias: 'HD02',
+      max_size: 5_497_558_138_880, // 5 TiB
+    },
+    {
+      id: '0a36607a-b53f-49ed-bf3e-a5f2dbc68005',
+      version: 2,
+      state: UploadBoxState.open,
+      title: 'Research Data Upload Box 3 of John',
+      description: 'Upload box for imaging files of study GHGAS12345678901236',
+      last_changed: '2025-02-05T09:00:00Z',
+      changed_by: 'doe@test.dev',
+      file_count: 2,
+      size: 5368709120, // 5 GiB
+      storage_alias: 'TUE03',
+      max_size: 5_497_558_138_880, // 5 TiB
+    },
   ],
 };
 
@@ -1209,7 +1235,7 @@ export const uploadGrants: GrantWithBoxInfo[] = [
     id: 'grant-rs-002',
     user_id: 'doe@test.dev',
     iva_id: '32b50c92-489f-4418-ace8-e7552e3cf36d',
-    box_id: '0a36607a-b53f-49ed-bf3e-a5f2dbc68002',
+    box_id: '0a36607a-b53f-49ed-bf3e-a5f2dbc68004',
     created: '2026-01-03T00:00:00Z',
     valid_from: '2026-01-03',
     valid_until: '2026-12-31',
@@ -1225,7 +1251,7 @@ export const uploadGrants: GrantWithBoxInfo[] = [
     id: 'grant-rs-003',
     user_id: 'doe@test.dev',
     iva_id: null,
-    box_id: '0a36607a-b53f-49ed-bf3e-a5f2dbc68003',
+    box_id: '0a36607a-b53f-49ed-bf3e-a5f2dbc68005',
     created: '2026-01-05T00:00:00Z',
     valid_from: '2026-01-05',
     valid_until: '2026-12-31',
@@ -1537,6 +1563,63 @@ export const uploadBox3FileUploads: FileUploadWithAccession[] = Array.from(
     accession: `GHGAF1234567890${String(2200 + i).padStart(4, '0')}`,
   }),
 );
+
+// 15 files so the file table paginates (paginator shows for more than 10 files).
+export const uploadBox4FileUploads: FileUploadWithAccession[] = Array.from(
+  { length: 15 },
+  (_, i) => {
+    const state = (
+      i % 5 === 3 ? 'inbox' : i % 5 === 4 ? 'init' : 'interrogated'
+    ) as FileUploadWithAccession['state'];
+    const decrypted_size = (i + 1) * 536870912; // 0.5–7.5 GiB per file
+    return {
+      id: `f${String(i + 1).padStart(2, '0')}c36607a-b53f-49ed-bf3e-a5f2dbc68004`,
+      box_id: '0a36607a-b53f-49ed-bf3e-a5f2dbc68004',
+      alias: `sample_proteome_${String(i + 1).padStart(3, '0')}.raw`,
+      state,
+      state_updated: '2026-02-04T08:00:00Z',
+      storage_alias: 'HD02',
+      bucket_id: 'inbox-hd02',
+      decrypted_sha256:
+        state === 'interrogated' ? (i % 10).toString().repeat(64) : null,
+      decrypted_size,
+      encrypted_size: decrypted_size + 48000,
+      part_size: 16777216,
+      accession: null,
+    };
+  },
+);
+
+export const uploadBox5FileUploads: FileUploadWithAccession[] = [
+  {
+    id: 'f1d36607a-b53f-49ed-bf3e-a5f2dbc68005',
+    box_id: '0a36607a-b53f-49ed-bf3e-a5f2dbc68005',
+    alias: 'sample_image_001.tiff',
+    state: 'interrogated',
+    state_updated: '2026-02-05T08:00:00Z',
+    storage_alias: 'TUE03',
+    bucket_id: 'inbox-tue03',
+    decrypted_sha256: 'd'.repeat(64),
+    decrypted_size: 4294967296, // 4 GiB
+    encrypted_size: 4295000000,
+    part_size: 16777216,
+    accession: null,
+  },
+  {
+    id: 'f2d36607a-b53f-49ed-bf3e-a5f2dbc68005',
+    box_id: '0a36607a-b53f-49ed-bf3e-a5f2dbc68005',
+    alias: 'sample_image_002.tiff',
+    state: 'init',
+    state_updated: '2026-02-05T08:30:00Z',
+    storage_alias: 'TUE03',
+    bucket_id: 'inbox-tue03',
+    decrypted_sha256: null,
+    decrypted_size: 1073741824, // 1 GiB
+    encrypted_size: 1073780000,
+    part_size: 16777216,
+    accession: null,
+  },
+];
 
 /**
  * WPS API

--- a/src/mocks/responses.ts
+++ b/src/mocks/responses.ts
@@ -24,6 +24,8 @@ import {
   uploadBox1FileUploads,
   uploadBox2FileUploads,
   uploadBox3FileUploads,
+  uploadBox4FileUploads,
+  uploadBox5FileUploads,
   uploadBoxes,
   pediatricLeukemiaDatasetDetails,
   pediatricLeukemiaFileIds,
@@ -278,6 +280,10 @@ export const responses: { [endpoint: string]: ResponseValue } = {
     uploadBox2FileUploads,
   'GET /api/rs/upload-boxes/0a36607a-b53f-49ed-bf3e-a5f2dbc68003/uploads':
     uploadBox3FileUploads,
+  'GET /api/rs/upload-boxes/0a36607a-b53f-49ed-bf3e-a5f2dbc68004/uploads':
+    uploadBox4FileUploads,
+  'GET /api/rs/upload-boxes/0a36607a-b53f-49ed-bf3e-a5f2dbc68005/uploads':
+    uploadBox5FileUploads,
   'GET /api/rs/upload-boxes/*/uploads': [],
 
   // Delete a single file upload from a box
@@ -290,6 +296,8 @@ export const responses: { [endpoint: string]: ResponseValue } = {
   'GET /api/rs/upload-boxes/0a36607a-b53f-49ed-bf3e-a5f2dbc68001': uploadBoxes.boxes[0],
   'GET /api/rs/upload-boxes/0a36607a-b53f-49ed-bf3e-a5f2dbc68002': uploadBoxes.boxes[1],
   'GET /api/rs/upload-boxes/0a36607a-b53f-49ed-bf3e-a5f2dbc68003': uploadBoxes.boxes[2],
+  'GET /api/rs/upload-boxes/0a36607a-b53f-49ed-bf3e-a5f2dbc68004': uploadBoxes.boxes[3],
+  'GET /api/rs/upload-boxes/0a36607a-b53f-49ed-bf3e-a5f2dbc68005': uploadBoxes.boxes[4],
 
   // Unknown upload box (catch-all, must stay after nested routes above)
   'GET /api/rs/upload-boxes/*': 404,


### PR DESCRIPTION
Normal users can now inspect the metadata and files of upload boxes they own, directly from the account page. Previously this was only available to data stewards in the Upload Box Manager.

- Read-only details dialog: a new "View details" button on each row of the account page's upload box list opens a dialog showing the box metadata and its files. It's strictly read-only: no editing, locking, deleting, or file mapping.
- Reusable files table: extracted the file list into a shared upload-box-files-table component and refactored the steward detail view to use it, so both views share one implementation. The table is now sortable (by filename, status, size, upload date, accession) in addition to paginated; the steward's per-file delete action is preserved via inputs.
- Mock data: fixed an inconsistency where the user's grants reused the IDs of other stewards' locked/archived boxes; added two genuinely-open boxes for the demo user, one with 15 files to exercise sorting and pagination.