### PR TITLE
Align and improve Dockerfiles (GSI-2421)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,31 +22,30 @@ RUN jq '{name, version, type}' package.json > ./package.json.run
 # extract js-yaml and its dependencies for runtime
 RUN mkdir -p /tmp/runtime-deps && \
     cp -rL node_modules/js-yaml /tmp/runtime-deps/
+# create config.js, group-writable so it can be written at runtime under any UID
+RUN touch ./dist/data-portal/browser/config.js \
+ && chmod g+w ./dist/data-portal/browser ./dist/data-portal/browser/config.js
 
 # RUNNER: a container to run the service
 FROM base AS runner
-RUN adduser -D appuser
-WORKDIR /home/appuser
-USER appuser
-# install dist directory and run script
-COPY --from=builder /service/dist/data-portal/browser ./dist
-# install static web server
-COPY --from=builder /usr/local/bin/static-web-server /usr/local/bin
-# copy the base package.json with name and version
-COPY --from=builder /service/package.json.run ./package.json
-# install run script
-COPY run.js ./run.mjs
-# copy runtime dependencies (js-yaml with resolved symlinks)
-COPY --from=builder /tmp/runtime-deps/js-yaml ./node_modules/js-yaml
-# install configuration files
-COPY data-portal.default.yaml .
-COPY sws.toml .
-USER root
+ARG UID=1000
+WORKDIR /app
 # remove npm and corepack to trim the image and avoid outdated dependencies
-RUN rm -rf /usr/local/lib/node_modules /home/appuser/.cache /root/.cache
-# make some dirs and files writeable for the appuser
-RUN touch ./dist/config.js && chown appuser ./dist ./dist/config.js ./package.json
-USER appuser
+RUN rm -rf /usr/local/lib/node_modules /root/.cache /root/.npm
+# install dist directory and run script
+COPY --chown=${UID}:0 --from=builder /service/dist/data-portal/browser ./dist
+# install static web server
+COPY --from=builder /usr/local/bin/static-web-server /usr/local/bin/static-web-server
+# copy the base package.json with name and version
+COPY --chown=${UID}:0 --from=builder /service/package.json.run ./package.json
+# install run script
+COPY --chown=${UID}:0 run.js ./run.mjs
+# copy runtime dependencies (js-yaml with resolved symlinks)
+COPY --chown=${UID}:0 --from=builder /tmp/runtime-deps/js-yaml ./node_modules/js-yaml
+# install configuration files
+COPY --chown=${UID}:0 data-portal.default.yaml .
+COPY --chown=${UID}:0 sws.toml .
+USER ${UID}
 
 ENTRYPOINT ["node"]
-CMD ["/home/appuser/run.mjs"]
+CMD ["/app/run.mjs"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,24 +6,26 @@ RUN apk upgrade --no-cache --available
 
 # BUILDER: a container to build the service dist directory
 FROM base AS builder
+SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 # install pnpm via corepack
 RUN corepack enable && corepack prepare pnpm@11.9.0 --activate
-# install static web server
-RUN apk add --no-cache curl jq sudo which
-RUN curl --proto '=https' --tlsv1.2 -sSfL https://get.static-web-server.net | sed "s/cp -ax/cp -a/g" | sh
+# install static web server (curl/jq/sudo/which are build-only, intentionally unpinned)
+# hadolint ignore=DL3018
+RUN apk add --no-cache curl jq sudo which \
+ && curl --proto '=https' --tlsv1.2 -sSfL https://get.static-web-server.net | sed "s/cp -ax/cp -a/g" | sh
 # build the service
 WORKDIR /service
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN HUSKY=0 CI=true pnpm install --frozen-lockfile
 COPY . .
 RUN pnpm build
-# create base package.json with just name and version
-RUN jq '{name, version, type}' package.json > ./package.json.run
-# extract js-yaml and its dependencies for runtime
-RUN mkdir -p /tmp/runtime-deps && \
-    cp -rL node_modules/js-yaml /tmp/runtime-deps/
-# create config.js, group-writable so it can be written at runtime under any UID
-RUN touch ./dist/data-portal/browser/config.js \
+# prepare runtime artifacts: base package.json with just name and version,
+# js-yaml (symlinks resolved) for runtime, and a group-writable config.js
+# (writable at runtime under any UID)
+RUN jq '{name, version, type}' package.json > ./package.json.run \
+ && mkdir -p /tmp/runtime-deps \
+ && cp -rL node_modules/js-yaml /tmp/runtime-deps/ \
+ && touch ./dist/data-portal/browser/config.js \
  && chmod g+w ./dist/data-portal/browser ./dist/data-portal/browser/config.js
 
 # RUNNER: a container to run the service

--- a/Dockerfile.dhi
+++ b/Dockerfile.dhi
@@ -4,28 +4,32 @@
 ARG BASE=dhi.io/node:24-alpine3.23
 
 # BUILDER: a container to build the service dist directory
+# hadolint ignore=DL3006
 FROM ${BASE}-sfw-ent-dev AS builder
+SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 # install pnpm via corepack
 RUN corepack enable && corepack prepare pnpm@11.9.0 --activate
-# install static web server
-RUN apk add --no-cache curl jq sudo which && mkdir -p /usr/local/bin
-RUN curl --proto '=https' --tlsv1.2 -sSfL https://get.static-web-server.net | sed "s/cp -ax/cp -a/g" | sed 's/_clibtype="gnu"/_clibtype="musl"/' | sh
+# install static web server (curl/jq/sudo/which are build-only, intentionally unpinned)
+# hadolint ignore=DL3018
+RUN apk add --no-cache curl jq sudo which && mkdir -p /usr/local/bin \
+ && curl --proto '=https' --tlsv1.2 -sSfL https://get.static-web-server.net | sed "s/cp -ax/cp -a/g" | sed 's/_clibtype="gnu"/_clibtype="musl"/' | sh
 # build the service
 WORKDIR /service
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN HUSKY=0 CI=true pnpm install --frozen-lockfile
 COPY . .
 RUN pnpm build
-# create base package.json with just name and version
-RUN jq '{name, version, type}' package.json > ./package.json.run
-# extract js-yaml and its dependencies for runtime
-RUN mkdir -p /tmp/runtime-deps && \
-    cp -rL node_modules/js-yaml /tmp/runtime-deps/
-# create config.js, group-writable so it can be written at runtime under any UID
-RUN touch ./dist/data-portal/browser/config.js \
+# prepare runtime artifacts: base package.json with just name and version,
+# js-yaml (symlinks resolved) for runtime, and a group-writable config.js
+# (writable at runtime under any UID)
+RUN jq '{name, version, type}' package.json > ./package.json.run \
+ && mkdir -p /tmp/runtime-deps \
+ && cp -rL node_modules/js-yaml /tmp/runtime-deps/ \
+ && touch ./dist/data-portal/browser/config.js \
  && chmod g+w ./dist/data-portal/browser ./dist/data-portal/browser/config.js
 
 # RUNNER: a container to run the service
+# hadolint ignore=DL3006
 FROM ${BASE} AS runner
 ARG UID=1000
 WORKDIR /app

--- a/Dockerfile.dhi
+++ b/Dockerfile.dhi
@@ -21,26 +21,27 @@ RUN jq '{name, version, type}' package.json > ./package.json.run
 # extract js-yaml and its dependencies for runtime
 RUN mkdir -p /tmp/runtime-deps && \
     cp -rL node_modules/js-yaml /tmp/runtime-deps/
-# create empty config.js so it can be copied to the runner with correct ownership
-RUN touch ./dist/data-portal/browser/config.js
+# create config.js, group-writable so it can be written at runtime under any UID
+RUN touch ./dist/data-portal/browser/config.js \
+ && chmod g+w ./dist/data-portal/browser ./dist/data-portal/browser/config.js
 
 # RUNNER: a container to run the service
 FROM ${BASE} AS runner
 ARG UID=1000
 WORKDIR /app
 # install dist directory and run script
-COPY --chown=${UID}:${UID} --from=builder /service/dist/data-portal/browser ./dist
+COPY --chown=${UID}:0 --from=builder /service/dist/data-portal/browser ./dist
 # install static web server
 COPY --from=builder /usr/local/bin/static-web-server /usr/local/bin/static-web-server
 # copy the base package.json with name and version
-COPY --chown=${UID}:${UID} --from=builder /service/package.json.run ./package.json
+COPY --chown=${UID}:0 --from=builder /service/package.json.run ./package.json
 # install run script
-COPY --chown=${UID}:${UID} run.js ./run.mjs
+COPY --chown=${UID}:0 run.js ./run.mjs
 # copy runtime dependencies (js-yaml with resolved symlinks)
-COPY --chown=${UID}:${UID} --from=builder /tmp/runtime-deps/js-yaml ./node_modules/js-yaml
+COPY --chown=${UID}:0 --from=builder /tmp/runtime-deps/js-yaml ./node_modules/js-yaml
 # install configuration files
-COPY --chown=${UID}:${UID} data-portal.default.yaml .
-COPY --chown=${UID}:${UID} sws.toml .
+COPY --chown=${UID}:0 data-portal.default.yaml .
+COPY --chown=${UID}:0 sws.toml .
 USER ${UID}
 
 ENTRYPOINT ["node"]


### PR DESCRIPTION
The DHI image crashed on startup under Kubernetes with `EACCES: permission denied, open 'dist/config.js'`. `config.js` is rewritten on every container start, but it was owned `1000:1000` mode `644`, so it was only writable when the process ran as UID 1000. Clusters that assign an arbitrary UID (e.g. OpenShift) run with GID 0, so the write failed.

Changes:

- Bake `config.js` owned `1000:0` and group-writable (`664`) in both builders, so the write succeeds as UID 1000, as an arbitrary UID with GID 0, or as a pinned `runAsUser: 1000`.
- Align both runner stages: numeric `USER 1000` (drop the custom `appuser`), `WORKDIR /app`, `--chown=${UID}:0` on all copied artifacts.
- Fix pre-existing hadolint warnings (pipefail, consolidated RUNs, documented ignores). `hadolint` now passes clean.

Tested by building both images and running under `docker run` (UID 1000), `--user 99999:0`
(arbitrary UID + GID 0, simulating k8s), and `--user 99999:99999` (negative control, correctly still fails). `config.js` served correctly via `curl` in the first two.
