### PR TITLE
Fix issue with saving ticket ID in AR manager (GSI-2524)

### DIFF
--- a/src/app/access-requests/features/access-request-duration-edit/access-request-duration-edit.spec.ts
+++ b/src/app/access-requests/features/access-request-duration-edit/access-request-duration-edit.spec.ts
@@ -5,6 +5,7 @@
  */
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNativeDateAdapter } from '@angular/material/core';
 
 import { AccessRequestDurationEditComponent } from './access-request-duration-edit';
 
@@ -12,6 +13,39 @@ import { accessRequests } from '@app/../mocks/data';
 import { AccessRequestStatus } from '@app/access-requests/models/access-requests';
 import { ConfigService } from '@app/shared/services/config';
 import { localDateToContractIsoUtc } from '@app/shared/utils/date-formats';
+
+interface DurationEditInternals {
+  formModel: {
+    (): { fromDate: Date | null; untilDate: Date | null };
+    set: (value: { fromDate: Date | null; untilDate: Date | null }) => void;
+  };
+}
+
+/**
+ * Read the protected form model of the component under test.
+ * @param component - the component under test
+ * @returns the current form model
+ */
+function getFormModel(component: AccessRequestDurationEditComponent) {
+  return (component as unknown as DurationEditInternals).formModel();
+}
+
+/**
+ * Overwrite the protected form model of the component under test.
+ * @param component - the component under test
+ * @param fromDate - the start date to set
+ * @param untilDate - the end date to set
+ */
+function setFormModel(
+  component: AccessRequestDurationEditComponent,
+  fromDate: Date | null,
+  untilDate: Date | null,
+): void {
+  (component as unknown as DurationEditInternals).formModel.set({
+    fromDate,
+    untilDate,
+  });
+}
 
 /**
  * Mock the config service as needed by the access request duration edit component
@@ -28,7 +62,10 @@ describe('AccessRequestDurationEditComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      providers: [{ provide: ConfigService, useClass: MockConfigService }],
+      providers: [
+        provideNativeDateAdapter(),
+        { provide: ConfigService, useClass: MockConfigService },
+      ],
       imports: [AccessRequestDurationEditComponent],
     }).compileComponents();
 
@@ -60,14 +97,8 @@ describe('AccessRequestDurationEditComponent', () => {
       emitted = value as Map<string, string>;
     });
 
-    (
-      component as unknown as {
-        formModel: {
-          set: (value: { fromDate: Date | null; untilDate: Date | null }) => void;
-        };
-      }
-    ).formModel.set({ fromDate, untilDate });
-    component.changed();
+    component.open();
+    setFormModel(component, fromDate, untilDate);
     component.save();
 
     expect(emitted).toBeDefined();
@@ -75,5 +106,55 @@ describe('AccessRequestDurationEditComponent', () => {
     expect(emitted?.get('access_ends')).toBe(
       localDateToContractIsoUtc(untilDate, true),
     );
+  });
+
+  it('should not consider re-selecting the same dates a modification', () => {
+    component.open();
+    const { fromDate, untilDate } = getFormModel(component);
+
+    // pick the very same dates again, which yields new Date objects
+    component.onDateSelected(new Date(fromDate!), true);
+    component.onDateSelected(new Date(untilDate!), false);
+
+    expect(component.isModified()).toBe(false);
+  });
+
+  it('should report pending edits again after a cancelled edit', async () => {
+    const edits: boolean[] = [];
+    component.edited.subscribe(([, edited]) => edits.push(edited));
+
+    const laterDate = new Date(getFormModel(component).untilDate!);
+    laterDate.setDate(laterDate.getDate() - 1);
+
+    component.open();
+    component.onDateSelected(laterDate, false);
+    await fixture.whenStable();
+    expect(component.isModified()).toBe(true);
+
+    component.cancel();
+    await fixture.whenStable();
+    expect(component.isModified()).toBe(false);
+
+    component.open();
+    component.onDateSelected(laterDate, false);
+    await fixture.whenStable();
+
+    expect(component.isModified()).toBe(true);
+    expect(edits).toEqual([true, false, true]);
+  });
+
+  it('should restore only the cleared date to its default', () => {
+    component.open();
+    const initial = getFormModel(component);
+    const changedFrom = new Date(initial.fromDate!);
+    changedFrom.setDate(changedFrom.getDate() + 1);
+    component.onDateSelected(changedFrom, true);
+
+    // clearing the end date must not touch the start date
+    component.onDateSelected(null as unknown as Date, false);
+
+    const current = getFormModel(component);
+    expect(current.fromDate?.getTime()).toBe(changedFrom.getTime());
+    expect(current.untilDate?.getTime()).toBe(initial.untilDate?.getTime());
   });
 });

--- a/src/app/access-requests/features/access-request-duration-edit/access-request-duration-edit.ts
+++ b/src/app/access-requests/features/access-request-duration-edit/access-request-duration-edit.ts
@@ -8,6 +8,7 @@ import { DatePipe as CommonDatePipe } from '@angular/common';
 import {
   Component,
   computed,
+  effect,
   inject,
   input,
   OnInit,
@@ -30,6 +31,16 @@ import {
   DEFAULT_TIME_ZONE,
   localDateToContractIsoUtc,
 } from '@app/shared/utils/date-formats';
+
+/**
+ * Compare two nullable dates by their point in time, not by object identity.
+ * @param a - the first date
+ * @param b - the second date
+ * @returns true if both are null or both denote the same point in time
+ */
+function isSameTime(a: Date | null, b: Date | null): boolean {
+  return a === b || (a !== null && b !== null && a.getTime() === b.getTime());
+}
 
 /**
  * Editor for the duration of access requests.
@@ -64,7 +75,6 @@ export class AccessRequestDurationEditComponent implements OnInit {
   edited = output<[keyof AccessRequest, boolean]>();
 
   isOpen = signal<boolean>(false);
-  isModified = signal<boolean>(false);
 
   todayStart = new Date();
   todayEnd = new Date();
@@ -127,6 +137,18 @@ export class AccessRequestDurationEditComponent implements OnInit {
   protected untilDateError = computed(
     () => this.durationForm.untilDate().errors()[0]?.message ?? null,
   );
+
+  isModified = computed<boolean>(
+    () =>
+      this.isOpen() &&
+      (!isSameTime(this.formModel().fromDate, this.#defaultFromDate()) ||
+        !isSameTime(this.formModel().untilDate, this.#defaultUntilDate())),
+  );
+
+  /**
+   * Notify the parent whenever the pending-edit state of the duration changes.
+   */
+  #editedEffect = effect(() => this.edited.emit(['access_ends', this.isModified()]));
 
   constructor() {
     this.todayStart.setHours(0, 0, 0, 0);
@@ -207,23 +229,17 @@ export class AccessRequestDurationEditComponent implements OnInit {
         this.updateAccessStartRanges(selectedLocalDate);
         this.formModel.update((m) => ({ ...m, untilDate: selectedLocalDate }));
       }
-      this.changed();
     } else {
-      this.formModel.update((m) => ({ ...m, fromDate: this.#defaultFromDate() }));
-      this.changed();
+      // the date was cleared, so restore the default of the edited field
+      this.formModel.update((m) =>
+        isFromDate
+          ? { ...m, fromDate: this.#defaultFromDate() }
+          : { ...m, untilDate: this.#defaultUntilDate() },
+      );
     }
   };
 
   saveDisabled = computed<boolean>(() => !this.durationForm().valid());
-
-  changed = () => {
-    const wasModified = this.isModified();
-    const isModified = this.formModel().fromDate !== this.#defaultFromDate();
-    if (isModified !== wasModified) {
-      this.isModified.set(isModified);
-      this.edited.emit(['access_ends', isModified]);
-    }
-  };
 
   cancel = () => {
     if (this.isModified()) {
@@ -231,24 +247,18 @@ export class AccessRequestDurationEditComponent implements OnInit {
         fromDate: this.#defaultFromDate(),
         untilDate: this.#defaultUntilDate(),
       });
-      this.edited.emit(['access_ends', false]);
     }
     this.isOpen.set(false);
   };
 
   save = () => {
-    const { fromDate: selectedFrom, untilDate: selectedUntil } = this.formModel();
-    if (selectedFrom && selectedUntil) {
-      const fromISO = localDateToContractIsoUtc(selectedFrom);
-      const untilISO = localDateToContractIsoUtc(selectedUntil, true);
-      if (this.isModified()) {
-        const saveMap = new Map<keyof AccessRequest, string>();
-        saveMap.set('access_starts', fromISO);
-        saveMap.set('access_ends', untilISO);
-        this.saved.emit(saveMap);
-        this.edited.emit(['access_ends', false]);
-      }
-      this.isOpen.set(false);
+    const { fromDate, untilDate } = this.formModel();
+    if (fromDate && untilDate && this.isModified()) {
+      const saveMap = new Map<keyof AccessRequest, string>();
+      saveMap.set('access_starts', localDateToContractIsoUtc(fromDate));
+      saveMap.set('access_ends', localDateToContractIsoUtc(untilDate, true));
+      this.saved.emit(saveMap);
     }
+    this.isOpen.set(false);
   };
 }

--- a/src/app/access-requests/features/access-request-field-edit/access-request-field-edit.html
+++ b/src/app/access-requests/features/access-request-field-edit/access-request-field-edit.html
@@ -11,19 +11,9 @@
       <div class="flex items-center">
         <mat-form-field class="grow">
           @if (rows() > 1) {
-            <textarea
-              matInput
-              [formField]="fieldForm.field"
-              [rows]="rows()"
-              (input)="changed()"
-            ></textarea>
+            <textarea matInput [formField]="fieldForm.field" [rows]="rows()"></textarea>
           } @else {
-            <input
-              matInput
-              type="text"
-              [formField]="fieldForm.field"
-              (input)="changed()"
-            />
+            <input matInput type="text" [formField]="fieldForm.field" />
           }
         </mat-form-field>
         <mat-chip

--- a/src/app/access-requests/features/access-request-field-edit/access-request-field-edit.ts
+++ b/src/app/access-requests/features/access-request-field-edit/access-request-field-edit.ts
@@ -6,10 +6,11 @@
 
 import {
   Component,
-  OnInit,
   computed,
+  effect,
   inject,
   input,
+  OnInit,
   output,
   signal,
 } from '@angular/core';
@@ -59,7 +60,6 @@ export class AccessRequestFieldEditComponent implements OnInit {
   edited = output<[keyof AccessRequest, boolean]>();
 
   isOpen = signal<boolean>(false);
-  isModified = signal<boolean>(false);
 
   protected formModel = signal({ field: '' });
 
@@ -82,23 +82,28 @@ export class AccessRequestFieldEditComponent implements OnInit {
 
   #defaultValue = computed<string>(() => this.request()[this.name()] || '');
 
-  changed = () => {
-    if (this.name() === 'ticket_id') {
-      // if the field is prefixed with (parts of) the base ticket URL, remove that prefix
-      const baseUrl = this.#baseTicketUrl;
-      const value = this.formModel().field;
-      const i = value.lastIndexOf('/');
-      if (baseUrl && i >= 0 && baseUrl.endsWith(value.substring(0, i + 1))) {
-        this.fieldForm.field().value.set(value.substring(i + 1));
-        return;
-      }
+  isModified = computed<boolean>(
+    () => this.isOpen() && this.formModel().field !== this.#defaultValue(),
+  );
+
+  /**
+   * If a ticket ID was entered prefixed with (parts of) the base ticket URL,
+   * remove that prefix.
+   */
+  #normalizeTicketIdEffect = effect(() => {
+    if (this.name() !== 'ticket_id') return;
+    const value = this.formModel().field;
+    const baseUrl = this.#baseTicketUrl;
+    const i = value.lastIndexOf('/');
+    if (baseUrl && i >= 0 && baseUrl.endsWith(value.substring(0, i + 1))) {
+      this.fieldForm.field().value.set(value.substring(i + 1));
     }
-    const isModified = this.formModel().field !== this.#defaultValue();
-    if (isModified !== this.isModified()) {
-      this.isModified.set(isModified);
-      this.edited.emit([this.name(), isModified]);
-    }
-  };
+  });
+
+  /**
+   * Notify the parent whenever the pending-edit state of this field changes.
+   */
+  #editedEffect = effect(() => this.edited.emit([this.name(), this.isModified()]));
 
   /**
    * Populate the editable field with the values from the access request on component init.
@@ -113,20 +118,14 @@ export class AccessRequestFieldEditComponent implements OnInit {
 
   cancel = () => {
     if (this.isModified()) {
-      this.isModified.set(false);
       this.formModel.set({ field: this.#defaultValue() });
-      this.edited.emit([this.name(), false]);
     }
     this.isOpen.set(false);
   };
 
   save = () => {
-    const field = this.formModel().field;
     if (this.isModified()) {
-      this.isModified.set(false);
-      const name = this.name();
-      this.saved.emit(new Map([[name, field]]));
-      this.edited.emit([name, false]);
+      this.saved.emit(new Map([[this.name(), this.formModel().field]]));
     }
     this.isOpen.set(false);
   };

--- a/src/app/auth/features/confirm-totp/confirm-totp.html
+++ b/src/app/auth/features/confirm-totp/confirm-totp.html
@@ -18,7 +18,6 @@
       class="totp-input-style text-center sm:text-left"
       matInput
       [formField]="totpForm.code"
-      (input)="onInput($event)"
       autocomplete="one-time-code"
       aria-required="true"
     />

--- a/src/app/auth/features/confirm-totp/confirm-totp.spec.ts
+++ b/src/app/auth/features/confirm-totp/confirm-totp.spec.ts
@@ -53,43 +53,53 @@ describe('ConfirmTotpComponent', () => {
     await fixture.whenStable();
   });
 
+  /**
+   * Enter the given text into the rendered code input, like a user would.
+   * @param text - the raw text to enter
+   * @returns the code input element, after the form has settled
+   */
+  async function enterCode(text: string): Promise<HTMLInputElement> {
+    const input: HTMLInputElement = fixture.nativeElement.querySelector('input');
+    input.value = text;
+    input.dispatchEvent(new Event('input'));
+    await fixture.whenStable();
+    return input;
+  }
+
   it('should create', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should auto-submit on first complete valid input', () => {
+  it('should auto-submit on first complete valid input', async () => {
     const onSubmitSpy = vitest
       .spyOn(component, 'onSubmit')
       .mockResolvedValue(undefined);
-    const inputElement = document.createElement('input');
-    inputElement.value = '123456';
 
-    component.onInput({ target: inputElement } as unknown as Event);
+    const inputElement = await enterCode('123456');
 
     expect(inputElement.value).toBe('123456');
     expect(onSubmitSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('should not auto-submit while first input is incomplete', () => {
+  it('should not auto-submit while first input is incomplete', async () => {
     const onSubmitSpy = vitest
       .spyOn(component, 'onSubmit')
       .mockResolvedValue(undefined);
-    const inputElement = document.createElement('input');
-    inputElement.value = '123';
 
-    component.onInput({ target: inputElement } as unknown as Event);
+    await enterCode('123');
 
     expect(onSubmitSpy).not.toHaveBeenCalled();
   });
 
-  it('should clear verification error on input', () => {
-    const inputElement = document.createElement('input');
-    inputElement.value = '12ab34';
+  it('should clear verification error on input', async () => {
     (component as unknown as ConfirmTotpComponentInternals).verificationError.set(true);
 
-    component.onInput({ target: inputElement } as unknown as Event);
+    const inputElement = await enterCode('12ab34');
 
     expect(inputElement.value).toBe('1234');
+    expect(
+      (component as unknown as ConfirmTotpComponentInternals).totpForm.code().value(),
+    ).toBe('1234');
     expect(
       (component as unknown as ConfirmTotpComponentInternals).verificationError(),
     ).toBe(false);
@@ -106,10 +116,8 @@ describe('ConfirmTotpComponent', () => {
     const onSubmitSpy = vitest
       .spyOn(component, 'onSubmit')
       .mockResolvedValue(undefined);
-    const inputElement = document.createElement('input');
-    inputElement.value = '654321';
 
-    component.onInput({ target: inputElement } as unknown as Event);
+    await enterCode('654321');
 
     expect(onSubmitSpy).not.toHaveBeenCalled();
   });

--- a/src/app/auth/features/confirm-totp/confirm-totp.ts
+++ b/src/app/auth/features/confirm-totp/confirm-totp.ts
@@ -4,7 +4,14 @@
  * @license Apache-2.0
  */
 
-import { Component, computed, inject, signal } from '@angular/core';
+import {
+  Component,
+  computed,
+  effect,
+  inject,
+  linkedSignal,
+  signal,
+} from '@angular/core';
 import { form, FormField, maxLength, pattern, required } from '@angular/forms/signals';
 import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -39,7 +46,14 @@ export class ConfirmTotpComponent {
 
   #isProcessing = signal(false);
 
-  protected verificationError = signal(false);
+  /**
+   * Whether the last submitted code was rejected. Resets itself as soon as the
+   * user changes the code again.
+   */
+  protected verificationError = linkedSignal<string, boolean>({
+    source: () => this.totpForm.code().value(),
+    computation: () => false,
+  });
 
   allowNavigation = false; // used by canDeactivate guard
 
@@ -52,21 +66,20 @@ export class ConfirmTotpComponent {
   );
 
   /**
-   * Input handler for the TOTP code
-   * @param event The input event object
+   * Keep only the first 6 digits of the entered code.
    */
-  onInput(event: Event): void {
-    const target = event.target as HTMLInputElement;
-    const sanitized = target.value.replace(/\D/g, '').slice(0, 6);
-    target.value = sanitized;
-    this.totpForm.code().value.set(sanitized);
-    // Reset error state when user starts typing
-    this.verificationError.set(false);
-    // Auto-submit only once
-    if (!this.#previousSubmission() && !this.disabled()) {
-      void this.onSubmit();
-    }
-  }
+  #sanitizeCodeEffect = effect(() => {
+    const code = this.totpForm.code().value();
+    const sanitized = code.replace(/\D/g, '').slice(0, 6);
+    if (sanitized !== code) this.totpForm.code().value.set(sanitized);
+  });
+
+  /**
+   * Submit automatically, but only once, as soon as a complete code was entered.
+   */
+  #autoSubmitEffect = effect(() => {
+    if (!this.#previousSubmission() && !this.disabled()) void this.onSubmit();
+  });
 
   /**
    * Submit authentication code

--- a/src/app/ivas/features/verification-dialog/verification-dialog.html
+++ b/src/app/ivas/features/verification-dialog/verification-dialog.html
@@ -14,7 +14,6 @@
         class="text-center sm:text-left"
         matInput
         [formField]="codeForm.code"
-        (input)="onInput($event)"
       />
     </mat-form-field>
   </form>

--- a/src/app/ivas/features/verification-dialog/verification-dialog.spec.ts
+++ b/src/app/ivas/features/verification-dialog/verification-dialog.spec.ts
@@ -71,29 +71,41 @@ describe('VerificationDialogComponent', () => {
     vitest.useRealTimers();
   });
 
+  /**
+   * Enter the given text into the rendered code input, like a user would.
+   * @param text - the raw text to enter
+   * @returns the code input element, after the form has settled
+   */
+  async function enterCode(text: string): Promise<HTMLInputElement> {
+    const input: HTMLInputElement = fixture.nativeElement.querySelector('input');
+    input.value = text;
+    input.dispatchEvent(new Event('input'));
+    await fixture.whenStable();
+    return input;
+  }
+
   it('should create', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should sanitize input and auto-submit only on the first attempt', () => {
+  it('should sanitize input and auto-submit only on the first attempt', async () => {
     const onSubmitSpy = vitest
       .spyOn(component, 'onSubmit')
       .mockResolvedValue(undefined);
-    const inputElement = document.createElement('input');
-    inputElement.value = 'ab-12!c3';
 
-    component.onInput({ target: inputElement } as unknown as Event);
+    const inputElement = await enterCode('ab-12!c3');
 
     expect(inputElement.value).toBe('AB12C3');
+    expect(
+      (component as unknown as VerificationDialogInternals).codeForm.code().value(),
+    ).toBe('AB12C3');
     expect(onSubmitSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('should clear verification error when user types', () => {
-    const inputElement = document.createElement('input');
-    inputElement.value = 'abc12';
+  it('should clear verification error when user types', async () => {
     (component as unknown as VerificationDialogInternals).verificationError.set(true);
 
-    component.onInput({ target: inputElement } as unknown as Event);
+    await enterCode('abc12');
 
     expect(
       (component as unknown as VerificationDialogInternals).verificationError(),
@@ -130,10 +142,8 @@ describe('VerificationDialogComponent', () => {
     const onSubmitSpy = vitest
       .spyOn(component, 'onSubmit')
       .mockResolvedValue(undefined);
-    const inputElement = document.createElement('input');
-    inputElement.value = 'DEF456';
 
-    component.onInput({ target: inputElement } as unknown as Event);
+    await enterCode('DEF456');
 
     expect(onSubmitSpy).not.toHaveBeenCalled();
   });

--- a/src/app/ivas/features/verification-dialog/verification-dialog.ts
+++ b/src/app/ivas/features/verification-dialog/verification-dialog.ts
@@ -4,7 +4,14 @@
  * @license Apache-2.0
  */
 
-import { Component, computed, inject, signal } from '@angular/core';
+import {
+  Component,
+  computed,
+  effect,
+  inject,
+  linkedSignal,
+  signal,
+} from '@angular/core';
 import { form, FormField, maxLength, pattern, required } from '@angular/forms/signals';
 import { MatButtonModule } from '@angular/material/button';
 import {
@@ -64,25 +71,33 @@ export class VerificationDialogComponent {
       this.codeForm.code().value() === this.#previousSubmission(),
   );
 
-  protected verificationError = signal(false);
+  /**
+   * Whether the last submitted code was rejected. Resets itself as soon as the
+   * user changes the code again.
+   */
+  protected verificationError = linkedSignal<string, boolean>({
+    source: () => this.codeForm.code().value(),
+    computation: () => false,
+  });
 
   /**
-   * Input handler for the IVA verification code
-   * @param event The input event object
+   * Upper-case the entered code and keep only its first 6 alphanumeric characters.
    */
-  onInput(event: Event): void {
-    const target = event.target as HTMLInputElement;
-    const sanitized = target.value
+  #sanitizeCodeEffect = effect(() => {
+    const code = this.codeForm.code().value();
+    const sanitized = code
       .toUpperCase()
       .replace(/[^A-Z0-9]/g, '')
       .slice(0, 6);
-    target.value = sanitized;
-    this.codeForm.code().value.set(sanitized);
-    this.verificationError.set(false);
-    if (!this.#previousSubmission() && !this.disabled()) {
-      void this.onSubmit();
-    }
-  }
+    if (sanitized !== code) this.codeForm.code().value.set(sanitized);
+  });
+
+  /**
+   * Submit automatically, but only once, as soon as a complete code was entered.
+   */
+  #autoSubmitEffect = effect(() => {
+    if (!this.#previousSubmission() && !this.disabled()) void this.onSubmit();
+  });
 
   /**
    * Cancel the dialog


### PR DESCRIPTION
This PR fixes problems around stale form values read in DOM input handlers.

The FormField directive registers its own 'input' listener after the template listeners, so handlers reading the form model saw the value from before the keystroke, and model writes were overwritten again.

- access request field editor: derive isModified and the ticket ID URL stripping from the form value instead of an (input) handler
- access request duration editor: compare dates by time instead of identity, reset the edit state on cancel and save, and restore only the cleared date to its default
- TOTP and IVA code inputs: sanitize, reset the error and auto-submit  from the form value, removing the reliance on listener order
