### PR TITLE
Support backend pagination for uploaded files (GSI-2494)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,7 +15,8 @@
     "qrcode",
     "schemapack",
     "teardown",
-    "TOTP"
+    "TOTP",
+    "unpaginated"
   ],
   "cSpell.language": "en-GB",
   "editor.defaultFormatter": "esbenp.prettier-vscode",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,27 @@ This is the primary, tool-agnostic AI entrypoint for any coding agent working in
 - `src/mocks`: MSW handlers with static API/auth responses
 - `tests`: end-to-end tests
 
+## API mocking philosophy
+
+The MSW layer in `src/mocks` serves **static, pre-made responses only**. Do not write
+mock handlers that contain backend logic.
+
+- Reimplementing backend behaviour (filtering, pagination, sorting, validation,
+  computed fields) duplicates work that already exists in the services, and the copy
+  inevitably drifts from the real implementation. Tests then pass against a fiction
+  and give a false sense of security. Real end-to-end coverage against actual backend
+  is done in the archive test bed.
+- Add fixtures to `src/mocks/data.ts` and map them to endpoints in
+  `src/mocks/responses.ts`. `createHandlersForResponses` in `src/mocks/handlers.ts` is
+  the only handler generator; keep it generic.
+- For endpoints that vary by query string, register one entry per request the app
+  actually makes, including the query parameters:
+  `'GET /api/rs/upload-boxes/<id>/uploads?skip=0&limit=10': someStaticPage`. The
+  handler picks the entry matching the most parameters, so a parameterless entry acts
+  as the fallback. See the upload box `uploads` entries for a worked example.
+- Deriving one fixture from another at module load (slicing an array into pages, for
+  example) is fine — that is authoring data, not simulating a backend at request time.
+
 ## Repo commands (pnpm)
 
 This repo uses `pnpm` (not npm) for dependency installation and scripts.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,11 +53,19 @@ mock handlers that contain backend logic.
   the only handler generator; keep it generic.
 - For endpoints that vary by query string, register one entry per request the app
   actually makes, including the query parameters:
-  `'GET /api/rs/upload-boxes/<id>/uploads?skip=0&limit=10': someStaticPage`. The
-  handler picks the entry matching the most parameters, so a parameterless entry acts
-  as the fallback. See the upload box `uploads` entries for a worked example.
+  `'GET /api/ars/access-requests?dataset_id=<id>&*': someStaticResponse`. The handler
+  picks the entry matching the most parameters, so a parameterless entry acts as the
+  fallback.
 - Deriving one fixture from another at module load (slicing an array into pages, for
   example) is fine — that is authoring data, not simulating a backend at request time.
+- Paginated list endpoints are the one exception, since sorting and pagination are a
+  convention shared by all of them rather than per-endpoint logic. A fixture with an
+  `items` array registered _without_ `skip`/`limit` in its key is treated as the
+  complete collection: the handler sorts it by `sort` (comma-separated fields, leading
+  `-` for descending) and then applies `skip`/`limit`. Register the whole collection,
+  not per-request pages — sorting must precede slicing, so an already-paged fixture
+  cannot be sorted correctly. Do not extend this to filtering, validation, or computed
+  fields.
 
 ## Repo commands (pnpm)
 

--- a/src/app/upload/features/upload-box-files-table/upload-box-files-table.html
+++ b/src/app/upload/features/upload-box-files-table/upload-box-files-table.html
@@ -1,5 +1,14 @@
 <div class="overflow-auto">
-  <table mat-table matSort [dataSource]="dataSource" class="w-full">
+  <table
+    mat-table
+    matSort
+    matSortDisableClear
+    [matSortActive]="sortActive()"
+    [matSortDirection]="sortDirection()"
+    (matSortChange)="sortChange.emit($event)"
+    [dataSource]="files()"
+    class="w-full"
+  >
     <ng-container matColumnDef="alias">
       <th mat-header-cell *matHeaderCellDef mat-sort-header>Filename</th>
       <td mat-cell *matCellDef="let file">{{ file.alias }}</td>
@@ -61,6 +70,10 @@
   <mat-paginator
     showFirstLastButtons
     class="sticky left-0"
+    [length]="totalCount()"
+    [pageIndex]="pageIndex()"
+    [pageSize]="pageSize()"
+    (page)="page.emit($event)"
     aria-label="Select page of files"
   ></mat-paginator>
 }

--- a/src/app/upload/features/upload-box-files-table/upload-box-files-table.html
+++ b/src/app/upload/features/upload-box-files-table/upload-box-files-table.html
@@ -6,7 +6,7 @@
     [matSortActive]="sortActive()"
     [matSortDirection]="sortDirection()"
     (matSortChange)="sortChange.emit($event)"
-    [dataSource]="files()"
+    [dataSource]="pageFiles()"
     class="w-full"
   >
     <ng-container matColumnDef="alias">

--- a/src/app/upload/features/upload-box-files-table/upload-box-files-table.spec.ts
+++ b/src/app/upload/features/upload-box-files-table/upload-box-files-table.spec.ts
@@ -5,6 +5,8 @@
  */
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { PageEvent } from '@angular/material/paginator';
+import { Sort } from '@angular/material/sort';
 import { UploadBoxState } from '@app/upload/models/box';
 import { FileUploadWithAccession } from '@app/upload/models/file-upload';
 import { screen, within } from '@testing-library/angular';
@@ -48,6 +50,7 @@ const files: FileUploadWithAccession[] = [
  * @param inputs.loading - whether the file list is still loading
  * @param inputs.showDelete - whether to show the delete column
  * @param inputs.deletable - predicate deciding which files are deletable
+ * @param inputs.totalCount - the total number of files across all pages
  * @returns the created fixture
  */
 async function createComponent(inputs: {
@@ -56,6 +59,7 @@ async function createComponent(inputs: {
   loading?: boolean;
   showDelete?: boolean;
   deletable?: (file: FileUploadWithAccession) => boolean;
+  totalCount?: number;
 }): Promise<ComponentFixture<UploadBoxFilesTableComponent>> {
   await TestBed.configureTestingModule({
     imports: [UploadBoxFilesTableComponent],
@@ -63,6 +67,7 @@ async function createComponent(inputs: {
   const fixture = TestBed.createComponent(UploadBoxFilesTableComponent);
   fixture.componentRef.setInput('files', inputs.files);
   fixture.componentRef.setInput('boxState', inputs.boxState);
+  fixture.componentRef.setInput('totalCount', inputs.totalCount ?? inputs.files.length);
   if (inputs.loading !== undefined) {
     fixture.componentRef.setInput('loading', inputs.loading);
   }
@@ -117,7 +122,7 @@ describe('UploadBoxFilesTableComponent', () => {
     expect(emitted[0].alias).toBe('alpha.txt');
   });
 
-  it('should sort the files by a column when its header is clicked', async () => {
+  it('should request a new sort order instead of reordering the page itself', async () => {
     const fixture = await createComponent({
       files: [
         makeFile({ id: 'a', alias: 'gamma.txt' }),
@@ -133,12 +138,56 @@ describe('UploadBoxFilesTableComponent', () => {
         .slice(1)
         .map((row) => within(row).getAllByRole('cell')[0].textContent?.trim());
 
-    expect(aliasOrder()).toEqual(['gamma.txt', 'alpha.txt', 'beta.txt']);
+    const sorts: Sort[] = [];
+    fixture.componentInstance.sortChange.subscribe((sort) => sorts.push(sort));
 
+    // The table is sorted by alias ascending by default, so the first click on
+    // the filename header asks the server for the descending order.
     screen.getByRole('columnheader', { name: /Filename/i }).click();
     await fixture.whenStable();
 
-    expect(aliasOrder()).toEqual(['alpha.txt', 'beta.txt', 'gamma.txt']);
+    expect(sorts).toEqual([{ active: 'alias', direction: 'desc' }]);
+    // The page itself is served by the backend and must stay as delivered.
+    expect(aliasOrder()).toEqual(['gamma.txt', 'alpha.txt', 'beta.txt']);
+  });
+
+  it('should request a new sort order when the accession header is clicked', async () => {
+    const fixture = await createComponent({
+      files: [makeFile({ state: 'archived', accession: 'GHGAF001' })],
+      boxState: UploadBoxState.archived,
+    });
+
+    const sorts: Sort[] = [];
+    fixture.componentInstance.sortChange.subscribe((sort) => sorts.push(sort));
+
+    screen.getByRole('columnheader', { name: /Accession/i }).click();
+    await fixture.whenStable();
+
+    expect(sorts).toEqual([{ active: 'accession', direction: 'asc' }]);
+  });
+
+  it('should hide the paginator when all files fit on one page', async () => {
+    await createComponent({ files, boxState: UploadBoxState.open });
+    expect(screen.queryByLabelText('Select page of files')).not.toBeInTheDocument();
+  });
+
+  it('should request another page when the paginator is used', async () => {
+    const fixture = await createComponent({
+      files,
+      boxState: UploadBoxState.open,
+      totalCount: 25,
+    });
+    expect(screen.getByLabelText('Select page of files')).toBeInTheDocument();
+
+    const pages: PageEvent[] = [];
+    fixture.componentInstance.page.subscribe((event) => pages.push(event));
+
+    screen.getByLabelText('Next page').click();
+    await fixture.whenStable();
+
+    expect(pages).toHaveLength(1);
+    expect(pages[0].pageIndex).toBe(1);
+    expect(pages[0].pageSize).toBe(10);
   });
 
   it('should show a loading placeholder while the file list is loading', async () => {

--- a/src/app/upload/features/upload-box-files-table/upload-box-files-table.spec.ts
+++ b/src/app/upload/features/upload-box-files-table/upload-box-files-table.spec.ts
@@ -37,7 +37,7 @@ function makeFile(
   };
 }
 
-const files: FileUploadWithAccession[] = [
+const pageFiles: FileUploadWithAccession[] = [
   makeFile({ id: 'f1', alias: 'alpha.txt', state: 'init' }),
   makeFile({ id: 'f2', alias: 'beta.txt', state: 'interrogated' }),
 ];
@@ -45,7 +45,7 @@ const files: FileUploadWithAccession[] = [
 /**
  * Render the component with the given inputs.
  * @param inputs - the signal inputs to set
- * @param inputs.files - the file uploads to display
+ * @param inputs.pageFiles - the file uploads on the page to display
  * @param inputs.boxState - the state of the box the files belong to
  * @param inputs.loading - whether the file list is still loading
  * @param inputs.showDelete - whether to show the delete column
@@ -54,7 +54,7 @@ const files: FileUploadWithAccession[] = [
  * @returns the created fixture
  */
 async function createComponent(inputs: {
-  files: FileUploadWithAccession[];
+  pageFiles: FileUploadWithAccession[];
   boxState: UploadBoxState;
   loading?: boolean;
   showDelete?: boolean;
@@ -65,9 +65,12 @@ async function createComponent(inputs: {
     imports: [UploadBoxFilesTableComponent],
   }).compileComponents();
   const fixture = TestBed.createComponent(UploadBoxFilesTableComponent);
-  fixture.componentRef.setInput('files', inputs.files);
+  fixture.componentRef.setInput('pageFiles', inputs.pageFiles);
   fixture.componentRef.setInput('boxState', inputs.boxState);
-  fixture.componentRef.setInput('totalCount', inputs.totalCount ?? inputs.files.length);
+  fixture.componentRef.setInput(
+    'totalCount',
+    inputs.totalCount ?? inputs.pageFiles.length,
+  );
   if (inputs.loading !== undefined) {
     fixture.componentRef.setInput('loading', inputs.loading);
   }
@@ -83,14 +86,14 @@ async function createComponent(inputs: {
 
 describe('UploadBoxFilesTableComponent', () => {
   it('should render the file names', async () => {
-    await createComponent({ files, boxState: UploadBoxState.open });
+    await createComponent({ pageFiles, boxState: UploadBoxState.open });
     expect(screen.getByText('alpha.txt')).toBeInTheDocument();
     expect(screen.getByText('beta.txt')).toBeInTheDocument();
   });
 
   it('should not show a delete column unless enabled', async () => {
     await createComponent({
-      files,
+      pageFiles,
       boxState: UploadBoxState.open,
       deletable: () => true,
     });
@@ -99,7 +102,7 @@ describe('UploadBoxFilesTableComponent', () => {
 
   it('should show delete buttons only for deletable files when enabled', async () => {
     await createComponent({
-      files,
+      pageFiles,
       boxState: UploadBoxState.open,
       showDelete: true,
       deletable: (file) => file.state === 'init',
@@ -110,7 +113,7 @@ describe('UploadBoxFilesTableComponent', () => {
 
   it('should emit deleteFile when a delete button is clicked', async () => {
     const fixture = await createComponent({
-      files,
+      pageFiles,
       boxState: UploadBoxState.open,
       showDelete: true,
       deletable: () => true,
@@ -124,7 +127,7 @@ describe('UploadBoxFilesTableComponent', () => {
 
   it('should request a new sort order instead of reordering the page itself', async () => {
     const fixture = await createComponent({
-      files: [
+      pageFiles: [
         makeFile({ id: 'a', alias: 'gamma.txt' }),
         makeFile({ id: 'b', alias: 'alpha.txt' }),
         makeFile({ id: 'c', alias: 'beta.txt' }),
@@ -153,7 +156,7 @@ describe('UploadBoxFilesTableComponent', () => {
 
   it('should request a new sort order when the accession header is clicked', async () => {
     const fixture = await createComponent({
-      files: [makeFile({ state: 'archived', accession: 'GHGAF001' })],
+      pageFiles: [makeFile({ state: 'archived', accession: 'GHGAF001' })],
       boxState: UploadBoxState.archived,
     });
 
@@ -167,13 +170,13 @@ describe('UploadBoxFilesTableComponent', () => {
   });
 
   it('should hide the paginator when all files fit on one page', async () => {
-    await createComponent({ files, boxState: UploadBoxState.open });
+    await createComponent({ pageFiles, boxState: UploadBoxState.open });
     expect(screen.queryByLabelText('Select page of files')).not.toBeInTheDocument();
   });
 
   it('should request another page when the paginator is used', async () => {
     const fixture = await createComponent({
-      files,
+      pageFiles,
       boxState: UploadBoxState.open,
       totalCount: 25,
     });
@@ -192,7 +195,7 @@ describe('UploadBoxFilesTableComponent', () => {
 
   it('should show a loading placeholder while the file list is loading', async () => {
     await createComponent({
-      files: [],
+      pageFiles: [],
       boxState: UploadBoxState.open,
       loading: true,
     });
@@ -202,7 +205,7 @@ describe('UploadBoxFilesTableComponent', () => {
 
   it('should show an empty placeholder once loaded with no files', async () => {
     await createComponent({
-      files: [],
+      pageFiles: [],
       boxState: UploadBoxState.open,
       loading: false,
     });
@@ -212,7 +215,7 @@ describe('UploadBoxFilesTableComponent', () => {
 
   it('should show the accession column for archived boxes', async () => {
     await createComponent({
-      files: [
+      pageFiles: [
         makeFile({ alias: 'gamma.txt', state: 'archived', accession: 'GHGAF001' }),
       ],
       boxState: UploadBoxState.archived,

--- a/src/app/upload/features/upload-box-files-table/upload-box-files-table.ts
+++ b/src/app/upload/features/upload-box-files-table/upload-box-files-table.ts
@@ -27,10 +27,10 @@ import { FileUploadStatePipe } from '@app/upload/pipes/file-upload-state-pipe';
 /**
  * Presentational, paginated table of the file uploads in an upload box.
  *
- * Pagination and sorting are driven by the server: `files` holds a single page
- * as delivered by the RS, and the paginator and sort headers only report the
- * requested page and order via the `page` and `sortChange` outputs. The parent
- * is responsible for fetching the matching page.
+ * Pagination and sorting are driven by the server: `pageFiles` holds a single
+ * page as delivered by the RS, and the paginator and sort headers only report
+ * the requested page and order via the `page` and `sortChange` outputs. The
+ * parent is responsible for fetching the matching page.
  *
  * The visible columns depend on the box state: archived boxes show the assigned
  * accession, other boxes show the upload status. When `showDelete` is set, an
@@ -53,8 +53,8 @@ import { FileUploadStatePipe } from '@app/upload/pipes/file-upload-state-pipe';
   templateUrl: './upload-box-files-table.html',
 })
 export class UploadBoxFilesTableComponent {
-  /** The file uploads of the currently shown page. */
-  files = input.required<FileUploadWithAccession[]>();
+  /** The file uploads of the currently shown page, not the whole collection. */
+  pageFiles = input.required<FileUploadWithAccession[]>();
 
   /** The state of the box the files belong to (controls the visible columns). */
   boxState = input.required<UploadBoxState>();

--- a/src/app/upload/features/upload-box-files-table/upload-box-files-table.ts
+++ b/src/app/upload/features/upload-box-files-table/upload-box-files-table.ts
@@ -5,12 +5,12 @@
  */
 
 import { DatePipe as CommonDatePipe } from '@angular/common';
-import { Component, computed, effect, input, output, viewChild } from '@angular/core';
+import { Component, computed, input, output } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
-import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
-import { MatSort, MatSortModule } from '@angular/material/sort';
-import { MatTableDataSource, MatTableModule } from '@angular/material/table';
+import { MatPaginatorModule, PageEvent } from '@angular/material/paginator';
+import { MatSortModule, Sort, SortDirection } from '@angular/material/sort';
+import { MatTableModule } from '@angular/material/table';
 import { DatePipe } from '@app/shared/pipes/date-pipe';
 import { ParseBytes } from '@app/shared/pipes/parse-bytes-pipe';
 import {
@@ -18,11 +18,19 @@ import {
   FRIENDLY_DATE_FORMAT,
 } from '@app/shared/utils/date-formats';
 import { UploadBoxState } from '@app/upload/models/box';
-import { FileUploadWithAccession } from '@app/upload/models/file-upload';
+import {
+  DEFAULT_UPLOADS_PAGE_SIZE,
+  FileUploadWithAccession,
+} from '@app/upload/models/file-upload';
 import { FileUploadStatePipe } from '@app/upload/pipes/file-upload-state-pipe';
 
 /**
  * Presentational, paginated table of the file uploads in an upload box.
+ *
+ * Pagination and sorting are driven by the server: `files` holds a single page
+ * as delivered by the RS, and the paginator and sort headers only report the
+ * requested page and order via the `page` and `sortChange` outputs. The parent
+ * is responsible for fetching the matching page.
  *
  * The visible columns depend on the box state: archived boxes show the assigned
  * accession, other boxes show the upload status. When `showDelete` is set, an
@@ -45,11 +53,26 @@ import { FileUploadStatePipe } from '@app/upload/pipes/file-upload-state-pipe';
   templateUrl: './upload-box-files-table.html',
 })
 export class UploadBoxFilesTableComponent {
-  /** The file uploads to display. */
+  /** The file uploads of the currently shown page. */
   files = input.required<FileUploadWithAccession[]>();
 
   /** The state of the box the files belong to (controls the visible columns). */
   boxState = input.required<UploadBoxState>();
+
+  /** The total number of file uploads in the box, across all pages. */
+  totalCount = input<number>(0);
+
+  /** The zero-based index of the currently shown page. */
+  pageIndex = input<number>(0);
+
+  /** The number of file uploads requested per page. */
+  pageSize = input<number>(DEFAULT_UPLOADS_PAGE_SIZE);
+
+  /** The column the files are currently sorted by. */
+  sortActive = input<string>('alias');
+
+  /** The direction the files are currently sorted in. */
+  sortDirection = input<SortDirection>('asc');
 
   /**
    * Whether the file list is still being loaded. Controls the empty-table
@@ -70,6 +93,12 @@ export class UploadBoxFilesTableComponent {
   /** Emitted when the delete button of a file is clicked. */
   deleteFile = output<FileUploadWithAccession>();
 
+  /** Emitted when a different page or page size is requested. */
+  page = output<PageEvent>();
+
+  /** Emitted when a different sort order is requested. */
+  sortChange = output<Sort>();
+
   /** Human-readable date format for the upload timestamp. */
   readonly friendlyDateFormat = FRIENDLY_DATE_FORMAT;
 
@@ -87,51 +116,12 @@ export class UploadBoxFilesTableComponent {
     return columns;
   });
 
-  /** Whether to show the paginator (only useful for larger file lists). */
-  showPaginator = computed<boolean>(() => this.files().length > 10);
-
-  /** MatTableDataSource for paginated and sortable file uploads. */
-  dataSource = new MatTableDataSource<FileUploadWithAccession>();
-
-  private readonly paginator = viewChild(MatPaginator);
-  private readonly sort = viewChild(MatSort);
-
-  #syncFilesEffect = effect(() => {
-    this.dataSource.data = this.files();
-  });
-
-  #assignPaginatorEffect = effect(() => {
-    const paginator = this.paginator();
-    if (paginator) {
-      this.dataSource.paginator = paginator;
-    }
-  });
-
-  #assignSortEffect = effect(() => {
-    const sort = this.sort();
-    if (sort) {
-      this.dataSource.sort = sort;
-    }
-  });
-
   /**
-   * Wire up sorting that reads the value backing each visible column, since the
-   * column names do not match the file properties one-to-one.
+   * Whether to show the paginator (only useful for larger file lists). The
+   * threshold is the total number of files rather than the page size, so that
+   * choosing a larger page size can never hide the paginator.
    */
-  constructor() {
-    this.dataSource.sortingDataAccessor = (file, column) => {
-      switch (column) {
-        case 'size':
-          return file.decrypted_size;
-        case 'uploaded':
-          return file.state_updated;
-        case 'status':
-          return file.state;
-        case 'accession':
-          return file.accession ?? '';
-        default:
-          return file.alias;
-      }
-    };
-  }
+  showPaginator = computed<boolean>(
+    () => this.totalCount() > DEFAULT_UPLOADS_PAGE_SIZE,
+  );
 }

--- a/src/app/upload/features/upload-box-manager-detail/upload-box-manager-detail.html
+++ b/src/app/upload/features/upload-box-manager-detail/upload-box-manager-detail.html
@@ -206,7 +206,7 @@
           <p><strong>Files:</strong></p>
           @if (box.file_count > 0) {
             <app-upload-box-files-table
-              [files]="fileUploads()"
+              [pageFiles]="pageFiles()"
               [boxState]="box.state"
               [loading]="filesLoading()"
               [totalCount]="filesTotalCount()"

--- a/src/app/upload/features/upload-box-manager-detail/upload-box-manager-detail.html
+++ b/src/app/upload/features/upload-box-manager-detail/upload-box-manager-detail.html
@@ -209,10 +209,17 @@
               [files]="fileUploads()"
               [boxState]="box.state"
               [loading]="filesLoading()"
+              [totalCount]="filesTotalCount()"
+              [pageIndex]="filesPageIndex()"
+              [pageSize]="filesPageSize()"
+              [sortActive]="filesSortState().column"
+              [sortDirection]="filesSortState().direction"
               [showDelete]="box.state === 'open'"
               [deletable]="canDeleteFileFn"
               deleteEventLabel="Upload Box Manager Detail Delete File Clicked"
               (deleteFile)="deleteFile($event)"
+              (page)="onFilesPage($event)"
+              (sortChange)="onFilesSort($event)"
             />
           } @else {
             <p class="text-warning mt-2">This upload box is still empty.</p>

--- a/src/app/upload/features/upload-box-manager-detail/upload-box-manager-detail.spec.ts
+++ b/src/app/upload/features/upload-box-manager-detail/upload-box-manager-detail.spec.ts
@@ -4,7 +4,7 @@
  * @license Apache-2.0
  */
 
-import { signal } from '@angular/core';
+import { computed, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialog } from '@angular/material/dialog';
 import { ActivatedRoute, provideRouter } from '@angular/router';
@@ -15,7 +15,10 @@ import { MetadataService } from '@app/metadata/services/metadata';
 import { NavigationTrackingService } from '@app/shared/services/navigation';
 import { NotificationService } from '@app/shared/services/notification';
 import { ResearchDataUploadBox, UploadBoxState } from '@app/upload/models/box';
-import { FileUploadWithAccession } from '@app/upload/models/file-upload';
+import {
+  DEFAULT_UPLOADS_PAGE_SIZE,
+  FileUploadWithAccession,
+} from '@app/upload/models/file-upload';
 import { UploadGrant } from '@app/upload/models/grant';
 import { StudyService } from '@app/upload/services/study';
 import { UploadBoxService } from '@app/upload/services/upload-box';
@@ -52,10 +55,22 @@ class MockUploadBoxService {
   };
 
   boxFileUploads = {
-    value: this.#fileUploadsList.asReadonly(),
     isLoading: () => false,
     error: () => undefined,
   };
+
+  allBoxFileUploads = {
+    isLoading: () => false,
+    error: () => undefined,
+  };
+
+  boxFiles = this.#fileUploadsList.asReadonly();
+  boxFilesTotalCount = computed<number>(() => this.#fileUploadsList().length);
+  boxFilesSkip = signal<number>(0);
+  boxFilesLimit = signal<number>(DEFAULT_UPLOADS_PAGE_SIZE);
+  boxFilesSortState = signal({ column: 'alias', direction: 'asc' as const });
+
+  allBoxFiles = this.#fileUploadsList.asReadonly();
 
   storageLabels = {
     value: () => ({ TUE01: 'Tübingen 1' }) as Record<string, string>,
@@ -66,6 +81,9 @@ class MockUploadBoxService {
   loadStorageLabels = vitest.fn();
   loadBoxGrants = vitest.fn();
   loadFileUploadsForBox = vitest.fn();
+  loadAllFileUploadsForBox = vitest.fn();
+  paginateFileUploads = vitest.fn();
+  sortFileUploadsByColumn = vitest.fn();
   addUploadGrant = vitest.fn();
   submitFileMapping = vitest.fn(() => of(undefined));
   archiveUploadBox = vitest.fn(() => of(undefined));

--- a/src/app/upload/features/upload-box-manager-detail/upload-box-manager-detail.ts
+++ b/src/app/upload/features/upload-box-manager-detail/upload-box-manager-detail.ts
@@ -195,7 +195,7 @@ export class UploadBoxManagerDetailComponent implements OnInit {
   });
 
   /** The file uploads on the currently shown page of this box. */
-  fileUploads = computed<FileUploadWithAccession[]>(() =>
+  pageFiles = computed<FileUploadWithAccession[]>(() =>
     this.#uploadBoxService.boxFiles(),
   );
 

--- a/src/app/upload/features/upload-box-manager-detail/upload-box-manager-detail.ts
+++ b/src/app/upload/features/upload-box-manager-detail/upload-box-manager-detail.ts
@@ -19,6 +19,8 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatDialog } from '@angular/material/dialog';
 import { MatIcon } from '@angular/material/icon';
+import { PageEvent } from '@angular/material/paginator';
+import { Sort } from '@angular/material/sort';
 import { MatTableModule } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { Router, RouterLink } from '@angular/router';
@@ -192,15 +194,50 @@ export class UploadBoxManagerDetailComponent implements OnInit {
     }));
   });
 
-  /** The file uploads contained in this box. */
+  /** The file uploads on the currently shown page of this box. */
   fileUploads = computed<FileUploadWithAccession[]>(() =>
-    this.#uploadBoxService.boxFileUploads.value(),
+    this.#uploadBoxService.boxFiles(),
   );
+
+  /** The total number of file uploads in this box, across all pages. */
+  filesTotalCount = this.#uploadBoxService.boxFilesTotalCount;
+
+  /** The number of file uploads shown per page. */
+  filesPageSize = this.#uploadBoxService.boxFilesLimit;
+
+  /** The zero-based index of the currently shown page of file uploads. */
+  filesPageIndex = computed<number>(() => {
+    const pageSize = this.filesPageSize();
+    if (!pageSize) return 0;
+    return Math.floor(this.#uploadBoxService.boxFilesSkip() / pageSize);
+  });
+
+  /** The column and direction the file uploads are currently sorted by. */
+  filesSortState = this.#uploadBoxService.boxFilesSortState;
 
   /** Whether the box's file list is still being loaded. */
   filesLoading = computed<boolean>(() =>
     this.#uploadBoxService.boxFileUploads.isLoading(),
   );
+
+  /**
+   * Request a different page of file uploads from the server.
+   * @param event - the page event emitted by the paginator
+   */
+  onFilesPage(event: PageEvent): void {
+    this.#uploadBoxService.paginateFileUploads(
+      event.pageSize,
+      event.pageIndex * event.pageSize,
+    );
+  }
+
+  /**
+   * Request the file uploads in a different order from the server.
+   * @param sort - the sort event emitted by the table headers
+   */
+  onFilesSort(sort: Sort): void {
+    this.#uploadBoxService.sortFileUploadsByColumn(sort.active, sort.direction);
+  }
 
   /** Whether a box state change (lock or reopen) is currently in flight. */
   isChangingState = signal<boolean>(false);

--- a/src/app/upload/features/upload-box-mapping/upload-box-mapping.spec.ts
+++ b/src/app/upload/features/upload-box-mapping/upload-box-mapping.spec.ts
@@ -127,14 +127,16 @@ const TEST_BOX_FILES: FileUploadWithAccession[] = [
  * Minimal mock of UploadBoxService for mapping component tests.
  */
 class MockUploadBoxService {
-  #boxFileUploads = signal<FileUploadWithAccession[]>([]);
+  #allBoxFiles = signal<FileUploadWithAccession[]>([]);
 
-  boxFileUploads = {
-    value: this.#boxFileUploads.asReadonly(),
+  allBoxFileUploads = {
     isLoading: () => false,
     error: () => undefined,
   };
 
+  allBoxFiles = this.#allBoxFiles.asReadonly();
+
+  loadAllFileUploadsForBox = vitest.fn();
   submitFileMapping = vitest.fn();
   archiveUploadBox = vitest.fn();
 
@@ -143,7 +145,7 @@ class MockUploadBoxService {
    * @param files - file uploads for the current box
    */
   setBoxFileUploads(files: FileUploadWithAccession[]): void {
-    this.#boxFileUploads.set(files);
+    this.#allBoxFiles.set(files);
   }
 }
 

--- a/src/app/upload/features/upload-box-mapping/upload-box-mapping.ts
+++ b/src/app/upload/features/upload-box-mapping/upload-box-mapping.ts
@@ -276,16 +276,24 @@ export class UploadBoxMappingComponent implements OnInit {
   /** Whether metadata files are still loading */
   metadataFilesLoading = computed(() => this.#metadataFilesOrNull() === null);
 
-  /** Files in the upload box (excluding deleted and failed ones) */
+  /**
+   * Files in the upload box (excluding deleted and failed ones).
+   *
+   * Mapping needs every file of the box at once — for auto-matching, for the
+   * autocomplete, for the unmapped counts and for the submitted payload — so this
+   * reads the complete list rather than the paginated one used by the file table.
+   * The service walks through as many pages as the box needs, so this covers
+   * boxes of any size.
+   */
   boxFiles = computed<FileUploadWithAccession[]>(() =>
-    this.#uploadBoxService.boxFileUploads
-      .value()
+    this.#uploadBoxService
+      .allBoxFiles()
       .filter((file) => file.state !== 'cancelled' && file.state !== 'failed'),
   );
 
   /** Whether upload box files are still loading */
   boxFilesLoading = computed<boolean>(() =>
-    this.#uploadBoxService.boxFileUploads.isLoading(),
+    this.#uploadBoxService.allBoxFileUploads.isLoading(),
   );
 
   // Derived mappings
@@ -567,6 +575,7 @@ export class UploadBoxMappingComponent implements OnInit {
   /** @inheritdoc */
   ngOnInit(): void {
     this.#studyService.loadStudies();
+    this.#uploadBoxService.loadAllFileUploadsForBox(this.box().id);
     const snapshot = this.#mappingStateService.snapshotFor(this.box().id);
     if (snapshot) {
       this.selectedStudyId.set(snapshot.studyId);

--- a/src/app/upload/features/upload-box-mapping/upload-box-metadata-alignment.spec.ts
+++ b/src/app/upload/features/upload-box-mapping/upload-box-metadata-alignment.spec.ts
@@ -62,13 +62,14 @@ const VALID_METADATA = {
  * Minimal mock of UploadBoxService for alignment component tests.
  */
 class MockUploadBoxService {
-  #boxFileUploads = signal<FileUploadWithAccession[]>(TEST_BOX_FILES);
+  #allBoxFiles = signal<FileUploadWithAccession[]>(TEST_BOX_FILES);
 
-  boxFileUploads = {
-    value: this.#boxFileUploads.asReadonly(),
+  allBoxFileUploads = {
     isLoading: () => false,
     error: () => undefined,
   };
+
+  allBoxFiles = this.#allBoxFiles.asReadonly();
 }
 
 /**

--- a/src/app/upload/features/upload-box-mapping/upload-box-metadata-alignment.ts
+++ b/src/app/upload/features/upload-box-mapping/upload-box-metadata-alignment.ts
@@ -41,16 +41,22 @@ export class UploadBoxMetadataAlignmentComponent {
   /** The name of the currently loaded metadata file, if any */
   fileName = signal<string | undefined>(undefined);
 
-  /** Files in the upload box (excluding deleted and failed ones) */
+  /**
+   * Files in the upload box (excluding deleted and failed ones).
+   *
+   * The alignment is computed against the whole box, so this reads the complete
+   * file list loaded by the parent mapping component rather than the paginated
+   * one backing the file table.
+   */
   boxFiles = computed<FileUploadWithAccession[]>(() =>
-    this.#uploadBoxService.boxFileUploads
-      .value()
+    this.#uploadBoxService
+      .allBoxFiles()
       .filter((file) => file.state !== 'cancelled' && file.state !== 'failed'),
   );
 
   /** Whether upload box files are still loading */
   boxFilesLoading = computed<boolean>(() =>
-    this.#uploadBoxService.boxFileUploads.isLoading(),
+    this.#uploadBoxService.allBoxFileUploads.isLoading(),
   );
 
   /** The alignment result for the currently loaded metadata, if any */

--- a/src/app/upload/features/user-upload-box-details-dialog/user-upload-box-details-dialog.html
+++ b/src/app/upload/features/user-upload-box-details-dialog/user-upload-box-details-dialog.html
@@ -37,7 +37,7 @@
         <p class="mb-2"><strong>Files:</strong></p>
         @if (box.file_count > 0) {
           <app-upload-box-files-table
-            [files]="files()"
+            [pageFiles]="pageFiles()"
             [boxState]="box.state"
             [loading]="filesLoading()"
             [totalCount]="filesTotalCount()"

--- a/src/app/upload/features/user-upload-box-details-dialog/user-upload-box-details-dialog.html
+++ b/src/app/upload/features/user-upload-box-details-dialog/user-upload-box-details-dialog.html
@@ -40,6 +40,13 @@
             [files]="files()"
             [boxState]="box.state"
             [loading]="filesLoading()"
+            [totalCount]="filesTotalCount()"
+            [pageIndex]="filesPageIndex()"
+            [pageSize]="filesPageSize()"
+            [sortActive]="filesSortState().column"
+            [sortDirection]="filesSortState().direction"
+            (page)="onFilesPage($event)"
+            (sortChange)="onFilesSort($event)"
           />
         } @else {
           <p class="text-warning">This upload box is still empty.</p>

--- a/src/app/upload/features/user-upload-box-details-dialog/user-upload-box-details-dialog.spec.ts
+++ b/src/app/upload/features/user-upload-box-details-dialog/user-upload-box-details-dialog.spec.ts
@@ -4,11 +4,14 @@
  * @license Apache-2.0
  */
 
-import { signal } from '@angular/core';
+import { computed, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { ResearchDataUploadBox, UploadBoxState } from '@app/upload/models/box';
-import { FileUploadWithAccession } from '@app/upload/models/file-upload';
+import {
+  DEFAULT_UPLOADS_PAGE_SIZE,
+  FileUploadWithAccession,
+} from '@app/upload/models/file-upload';
 import { GrantWithBoxInfo } from '@app/upload/models/grant';
 import { UploadBoxService } from '@app/upload/services/upload-box';
 import { screen } from '@testing-library/angular';
@@ -67,13 +70,20 @@ class MockUploadBoxService {
   };
 
   boxFileUploads = {
-    value: this.#files.asReadonly(),
     isLoading: this.#filesLoading.asReadonly(),
     error: () => undefined,
   };
 
+  boxFiles = this.#files.asReadonly();
+  boxFilesTotalCount = computed<number>(() => this.#files().length);
+  boxFilesSkip = signal<number>(0);
+  boxFilesLimit = signal<number>(DEFAULT_UPLOADS_PAGE_SIZE);
+  boxFilesSortState = signal({ column: 'alias', direction: 'asc' as const });
+
   loadUploadBox = vitest.fn();
   loadFileUploadsForBox = vitest.fn();
+  paginateFileUploads = vitest.fn();
+  sortFileUploadsByColumn = vitest.fn();
 
   /**
    * Test helper: set the loaded box.

--- a/src/app/upload/features/user-upload-box-details-dialog/user-upload-box-details-dialog.ts
+++ b/src/app/upload/features/user-upload-box-details-dialog/user-upload-box-details-dialog.ts
@@ -7,6 +7,8 @@
 import { Component, computed, effect, inject } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
+import { PageEvent } from '@angular/material/paginator';
+import { Sort } from '@angular/material/sort';
 import { Capitalise } from '@app/shared/pipes/capitalise-pipe';
 import { ParseBytes } from '@app/shared/pipes/parse-bytes-pipe';
 import { StencilComponent } from '@app/shared/ui/stencil/stencil/stencil';
@@ -63,23 +65,59 @@ export class UserUploadBoxDetailsDialogComponent {
   protected hasError = computed<boolean>(() => !this.box() && !!this.#box.error());
 
   /**
-   * The files contained in the box. Filtered by the box's file upload box ID so
-   * files left over from a previously opened box are never shown while the fresh
-   * list is loading. Each file references the underlying file upload box via its
-   * `box_id`, which is the `file_upload_box_id` of the research box, not its `id`.
+   * The files on the currently shown page of the box. Filtered by the box's file
+   * upload box ID so files left over from a previously opened box are never shown
+   * while the fresh page is loading. Each file references the underlying file
+   * upload box via its `box_id`, which is the `file_upload_box_id` of the research
+   * box, not its `id`.
    */
   protected files = computed<FileUploadWithAccession[]>(() => {
     const fileUploadBoxId = this.box()?.file_upload_box_id;
     if (!fileUploadBoxId) return [];
-    return this.#uploadBoxService.boxFileUploads
-      .value()
+    return this.#uploadBoxService
+      .boxFiles()
       .filter((file) => file.box_id === fileUploadBoxId);
   });
+
+  /** The total number of files in the box, across all pages. */
+  protected filesTotalCount = this.#uploadBoxService.boxFilesTotalCount;
+
+  /** The number of files shown per page. */
+  protected filesPageSize = this.#uploadBoxService.boxFilesLimit;
+
+  /** The zero-based index of the currently shown page of files. */
+  protected filesPageIndex = computed<number>(() => {
+    const pageSize = this.filesPageSize();
+    if (!pageSize) return 0;
+    return Math.floor(this.#uploadBoxService.boxFilesSkip() / pageSize);
+  });
+
+  /** The column and direction the files are currently sorted by. */
+  protected filesSortState = this.#uploadBoxService.boxFilesSortState;
 
   /** Whether the box's file list is still being loaded. */
   protected filesLoading = computed<boolean>(() =>
     this.#uploadBoxService.boxFileUploads.isLoading(),
   );
+
+  /**
+   * Request a different page of files from the server.
+   * @param event - the page event emitted by the paginator
+   */
+  protected onFilesPage(event: PageEvent): void {
+    this.#uploadBoxService.paginateFileUploads(
+      event.pageSize,
+      event.pageIndex * event.pageSize,
+    );
+  }
+
+  /**
+   * Request the files in a different order from the server.
+   * @param sort - the sort event emitted by the table headers
+   */
+  protected onFilesSort(sort: Sort): void {
+    this.#uploadBoxService.sortFileUploadsByColumn(sort.active, sort.direction);
+  }
 
   /** Load the box files once the box is available and known to be non-empty. */
   #loadFilesEffect = effect(() => {

--- a/src/app/upload/features/user-upload-box-details-dialog/user-upload-box-details-dialog.ts
+++ b/src/app/upload/features/user-upload-box-details-dialog/user-upload-box-details-dialog.ts
@@ -71,7 +71,7 @@ export class UserUploadBoxDetailsDialogComponent {
    * upload box via its `box_id`, which is the `file_upload_box_id` of the research
    * box, not its `id`.
    */
-  protected files = computed<FileUploadWithAccession[]>(() => {
+  protected pageFiles = computed<FileUploadWithAccession[]>(() => {
     const fileUploadBoxId = this.box()?.file_upload_box_id;
     if (!fileUploadBoxId) return [];
     return this.#uploadBoxService

--- a/src/app/upload/models/file-upload.ts
+++ b/src/app/upload/models/file-upload.ts
@@ -63,3 +63,83 @@ export interface FileUploadWithAccession {
   /** The accession number assigned to this file */
   accession: string | null;
 }
+
+/**
+ * A page of file uploads for an upload box, plus the total unpaginated count,
+ * as returned by the paginated `/upload-boxes/{id}/uploads` endpoint of the RS.
+ */
+export interface BoxUploadsPage {
+  /** The file uploads on this page, in the requested sort order */
+  items: FileUploadWithAccession[];
+  /** The total number of file uploads in the box (unpaginated) */
+  total_count: number;
+}
+
+/** An empty page of file uploads, used as default value for the resources */
+export const emptyBoxUploadsPage: BoxUploadsPage = { items: [], total_count: 0 };
+
+/** Default number of file uploads requested per page (the backend default) */
+export const DEFAULT_UPLOADS_PAGE_SIZE = 10;
+
+/**
+ * The largest page size the RS accepts for the file uploads endpoint. Also used
+ * as the page size when the complete file list of a box is requested at once.
+ */
+export const MAX_UPLOADS_PAGE_SIZE = 1000;
+
+/**
+ * Mapping from the columns of the file uploads table to the field names the RS
+ * accepts in the `sort` query parameter. Columns absent here are not sortable on
+ * the server and must not offer a sort header, since sorting a single page in the
+ * browser would order only the visible rows while looking authoritative.
+ */
+export const FileUploadSortFields: Record<string, string> = {
+  alias: 'alias',
+  status: 'state',
+  size: 'decrypted_size',
+  uploaded: 'state_updated',
+  accession: 'accession',
+};
+
+/** Sort direction of the file uploads table (matches Material's SortDirection) */
+export type FileUploadSortDirection = 'asc' | 'desc' | '';
+
+/** The order the RS falls back to when no sort parameter is given */
+const DEFAULT_UPLOADS_SORT_COLUMN = 'alias';
+
+/**
+ * Translate a sorted table column into the `sort` query parameter of the RS.
+ * @param column - the sorted column of the file uploads table
+ * @param direction - the direction the column is sorted in
+ * @returns the sort specification, or undefined for the default server order
+ */
+export function fileUploadSortSpec(
+  column: string,
+  direction: FileUploadSortDirection,
+): string | undefined {
+  const field = FileUploadSortFields[column];
+  if (!field || !direction) return undefined;
+  return direction === 'desc' ? `-${field}` : field;
+}
+
+/**
+ * Translate a `sort` query parameter back into the table column and direction,
+ * so the sort headers reflect the order the server actually applied.
+ * @param spec - the sort specification, or undefined for the default server order
+ * @returns the sorted column and its direction
+ */
+export function fileUploadSortState(spec: string | undefined): {
+  column: string;
+  direction: FileUploadSortDirection;
+} {
+  const direction: FileUploadSortDirection = spec?.startsWith('-') ? 'desc' : 'asc';
+  const field = spec?.replace(/^-/, '');
+  const column = field
+    ? Object.keys(FileUploadSortFields).find(
+        (key) => FileUploadSortFields[key] === field,
+      )
+    : undefined;
+  return column
+    ? { column, direction }
+    : { column: DEFAULT_UPLOADS_SORT_COLUMN, direction: 'asc' };
+}

--- a/src/app/upload/services/upload-box.spec.ts
+++ b/src/app/upload/services/upload-box.spec.ts
@@ -19,6 +19,12 @@ import {
   UploadBoxState,
   UploadBoxVirtualFilter,
 } from '../models/box';
+import {
+  BoxUploadsPage,
+  DEFAULT_UPLOADS_PAGE_SIZE,
+  FileUploadWithAccession,
+  MAX_UPLOADS_PAGE_SIZE,
+} from '../models/file-upload';
 import { GrantWithBoxInfo, UploadGrant } from '../models/grant';
 import { UploadBoxService } from './upload-box';
 
@@ -817,26 +823,243 @@ describe('UploadBoxService', () => {
 
   describe('loadFileUploadsForBox', () => {
     const BOX_ID = '0a36607a-b53f-49ed-bf3e-a5f2dbc68001';
+    const UPLOADS_URL = `http://mock.dev/rs/upload-boxes/${encodeURIComponent(BOX_ID)}/uploads`;
 
-    it('should request file uploads filtered by box id', async () => {
+    const FILE: FileUploadWithAccession = {
+      id: 'file-1',
+      box_id: 'b0f11e00-0000-4000-8000-a5f2dbc68001',
+      alias: 'alpha.txt',
+      state: 'interrogated',
+      state_updated: '2026-01-01T00:00:00Z',
+      storage_alias: 'TUE01',
+      bucket_id: 'inbox-tue01',
+      decrypted_sha256: null,
+      decrypted_size: 1024,
+      encrypted_size: 2048,
+      part_size: 512,
+      accession: null,
+    };
+
+    /**
+     * Flush the pending request for a page of file uploads.
+     * @param page - the page to respond with
+     * @returns the query parameters of the flushed request
+     */
+    async function flushUploads(page: BoxUploadsPage): Promise<URLSearchParams> {
+      const req = httpMock.expectOne((request) => request.url === UPLOADS_URL);
+      expect(req.request.method).toBe('GET');
+      const params = new URLSearchParams(req.request.params.toString());
+      req.flush(page);
+      await Promise.resolve();
+      return params;
+    }
+
+    it('should request the first page of file uploads for the box', async () => {
       service.loadFileUploadsForBox(BOX_ID);
       testBed.tick();
 
-      const req = httpMock.expectOne(
-        `http://mock.dev/rs/upload-boxes/${encodeURIComponent(BOX_ID)}/uploads`,
-      );
-      expect(req.request.method).toBe('GET');
-      req.flush([]);
+      const params = await flushUploads({ items: [FILE], total_count: 42 });
 
+      expect(params.get('skip')).toBe('0');
+      expect(params.get('limit')).toBe(String(DEFAULT_UPLOADS_PAGE_SIZE));
+      expect(params.has('sort')).toBe(false);
+
+      expect(service.boxFiles()).toEqual([FILE]);
+      expect(service.boxFilesTotalCount()).toBe(42);
+    });
+
+    it('should request another page when paginated', async () => {
+      service.loadFileUploadsForBox(BOX_ID);
+      testBed.tick();
+      await flushUploads({ items: [FILE], total_count: 42 });
+
+      service.paginateFileUploads(25, 50);
+      testBed.tick();
+      const params = await flushUploads({ items: [], total_count: 42 });
+
+      expect(params.get('skip')).toBe('50');
+      expect(params.get('limit')).toBe('25');
+      expect(service.boxFilesSkip()).toBe(50);
+      expect(service.boxFilesLimit()).toBe(25);
+    });
+
+    it('should cap the page size at the maximum the backend accepts', async () => {
+      service.loadFileUploadsForBox(BOX_ID);
+      testBed.tick();
+      await flushUploads({ items: [], total_count: 0 });
+
+      service.paginateFileUploads(5000, 0);
+      testBed.tick();
+      const params = await flushUploads({ items: [], total_count: 0 });
+
+      expect(params.get('limit')).toBe(String(MAX_UPLOADS_PAGE_SIZE));
+    });
+
+    it('should send the sort order and return to the first page when sorting', async () => {
+      service.loadFileUploadsForBox(BOX_ID);
+      testBed.tick();
+      await flushUploads({ items: [], total_count: 42 });
+
+      service.paginateFileUploads(DEFAULT_UPLOADS_PAGE_SIZE, 20);
+      testBed.tick();
+      await flushUploads({ items: [], total_count: 42 });
+
+      service.sortFileUploadsByColumn('size', 'desc');
+      testBed.tick();
+      const params = await flushUploads({ items: [], total_count: 42 });
+
+      expect(params.get('sort')).toBe('-decrypted_size');
+      expect(params.get('skip')).toBe('0');
+      expect(service.boxFilesSortState()).toEqual({
+        column: 'size',
+        direction: 'desc',
+      });
+    });
+
+    it('should sort by the accession shown for archived boxes', async () => {
+      service.loadFileUploadsForBox(BOX_ID);
+      testBed.tick();
+      await flushUploads({ items: [], total_count: 42 });
+
+      service.sortFileUploadsByColumn('accession', 'asc');
+      testBed.tick();
+      const params = await flushUploads({ items: [], total_count: 42 });
+
+      expect(params.get('sort')).toBe('accession');
+      expect(service.boxFilesSortState()).toEqual({
+        column: 'accession',
+        direction: 'asc',
+      });
+    });
+
+    it('should reset pagination and sorting when switching to another box', async () => {
+      service.loadFileUploadsForBox(BOX_ID);
+      testBed.tick();
+      await flushUploads({ items: [], total_count: 42 });
+
+      service.paginateFileUploads(25, 50);
+      service.sortFileUploadsByColumn('alias', 'desc');
+      testBed.tick();
+      await flushUploads({ items: [], total_count: 42 });
+
+      const OTHER_BOX_ID = '0a36607a-b53f-49ed-bf3e-a5f2dbc68002';
+      service.loadFileUploadsForBox(OTHER_BOX_ID);
+      testBed.tick();
+
+      const req = httpMock.expectOne(
+        (request) =>
+          request.url ===
+          `http://mock.dev/rs/upload-boxes/${encodeURIComponent(OTHER_BOX_ID)}/uploads`,
+      );
+      const params = new URLSearchParams(req.request.params.toString());
+      req.flush({ items: [], total_count: 0 });
       await Promise.resolve();
 
-      expect(service.boxFileUploads.value()).toEqual([]);
+      expect(params.get('skip')).toBe('0');
+      expect(params.get('limit')).toBe(String(DEFAULT_UPLOADS_PAGE_SIZE));
+      expect(params.has('sort')).toBe(false);
     });
 
     it('should not request file uploads when no box id has been set', () => {
       testBed.tick();
       // httpMock.verify() in afterEach ensures no unexpected requests were made
-      expect(service.boxFileUploads.value()).toEqual([]);
+      expect(service.boxFiles()).toEqual([]);
+      expect(service.boxFilesTotalCount()).toBe(0);
+    });
+  });
+
+  describe('loadAllFileUploadsForBox', () => {
+    const BOX_ID = '0a36607a-b53f-49ed-bf3e-a5f2dbc68001';
+    const UPLOADS_URL = `http://mock.dev/rs/upload-boxes/${encodeURIComponent(BOX_ID)}/uploads`;
+
+    /**
+     * Build a page of distinct file uploads.
+     * @param count - the number of file uploads on the page
+     * @param offset - the index the aliases and IDs start at
+     * @returns the file uploads of the page
+     */
+    function makeFiles(count: number, offset = 0): FileUploadWithAccession[] {
+      return Array.from({ length: count }, (_, index) => ({
+        id: `file-${offset + index}`,
+        box_id: 'b0f11e00-0000-4000-8000-a5f2dbc68001',
+        alias: `file-${offset + index}.txt`,
+        state: 'interrogated' as const,
+        state_updated: '2026-01-01T00:00:00Z',
+        storage_alias: 'TUE01',
+        bucket_id: 'inbox-tue01',
+        decrypted_sha256: null,
+        decrypted_size: 1024,
+        encrypted_size: 2048,
+        part_size: 512,
+        accession: null,
+      }));
+    }
+
+    /**
+     * Flush the pending request for a page of the complete file list.
+     * @param page - the page to respond with
+     * @returns the query parameters of the flushed request
+     */
+    async function flushPage(page: BoxUploadsPage): Promise<URLSearchParams> {
+      const req = httpMock.expectOne((request) => request.url === UPLOADS_URL);
+      const params = new URLSearchParams(req.request.params.toString());
+      req.flush(page);
+      // Two microtask turns: one for the HTTP promise, one for the loader loop.
+      await Promise.resolve();
+      await Promise.resolve();
+      return params;
+    }
+
+    it('should request the complete file list with the maximum page size', async () => {
+      service.loadAllFileUploadsForBox(BOX_ID);
+      testBed.tick();
+
+      const files = makeFiles(3);
+      const params = await flushPage({ items: files, total_count: 3 });
+
+      expect(params.get('skip')).toBe('0');
+      expect(params.get('limit')).toBe(String(MAX_UPLOADS_PAGE_SIZE));
+      expect(service.allBoxFiles()).toEqual(files);
+    });
+
+    it('should walk through all pages of a box larger than one page', async () => {
+      service.loadAllFileUploadsForBox(BOX_ID);
+      testBed.tick();
+
+      const totalCount = 2 * MAX_UPLOADS_PAGE_SIZE + 5;
+      const firstPage = makeFiles(MAX_UPLOADS_PAGE_SIZE);
+      const secondPage = makeFiles(MAX_UPLOADS_PAGE_SIZE, MAX_UPLOADS_PAGE_SIZE);
+      const thirdPage = makeFiles(5, 2 * MAX_UPLOADS_PAGE_SIZE);
+
+      const first = await flushPage({ items: firstPage, total_count: totalCount });
+      expect(first.get('skip')).toBe('0');
+
+      const second = await flushPage({ items: secondPage, total_count: totalCount });
+      expect(second.get('skip')).toBe(String(MAX_UPLOADS_PAGE_SIZE));
+
+      const third = await flushPage({ items: thirdPage, total_count: totalCount });
+      expect(third.get('skip')).toBe(String(2 * MAX_UPLOADS_PAGE_SIZE));
+
+      // httpMock.verify() in afterEach ensures no further page was requested.
+      expect(service.allBoxFiles()).toHaveLength(totalCount);
+      expect(service.allBoxFiles()).toEqual([
+        ...firstPage,
+        ...secondPage,
+        ...thirdPage,
+      ]);
+    });
+
+    it('should stop walking when a page comes back empty despite a higher count', async () => {
+      service.loadAllFileUploadsForBox(BOX_ID);
+      testBed.tick();
+
+      const files = makeFiles(2);
+      await flushPage({ items: files, total_count: 99 });
+      // The backend claims more files than it delivers; the walk must not loop
+      // forever on the same offset.
+      await flushPage({ items: [], total_count: 99 });
+
+      expect(service.allBoxFiles()).toEqual(files);
     });
   });
 });

--- a/src/app/upload/services/upload-box.ts
+++ b/src/app/upload/services/upload-box.ts
@@ -5,10 +5,10 @@
  */
 
 import { HttpClient, HttpParams, httpResource } from '@angular/common/http';
-import { computed, inject, Service, signal } from '@angular/core';
+import { computed, inject, resource, Service, signal } from '@angular/core';
 import { AuthService } from '@app/auth/services/auth';
 import { ConfigService } from '@app/shared/services/config';
-import { map, Observable, tap } from 'rxjs';
+import { firstValueFrom, fromEvent, map, Observable, takeUntil, tap } from 'rxjs';
 import { AccessionMapRequest } from '../models/accession-map';
 import {
   BoxRetrievalResults,
@@ -18,7 +18,16 @@ import {
   UploadBoxFilter,
   UploadBoxState,
 } from '../models/box';
-import { FileUploadWithAccession } from '../models/file-upload';
+import {
+  BoxUploadsPage,
+  DEFAULT_UPLOADS_PAGE_SIZE,
+  emptyBoxUploadsPage,
+  FileUploadSortDirection,
+  fileUploadSortSpec,
+  fileUploadSortState,
+  FileUploadWithAccession,
+  MAX_UPLOADS_PAGE_SIZE,
+} from '../models/file-upload';
 import {
   GrantId,
   GrantWithBoxInfo,
@@ -46,7 +55,16 @@ export class UploadBoxService {
   #uploadBoxesFilter = signal<UploadBoxFilter | undefined>(undefined);
   #loadSingleBox = signal<string>('');
   #loadGrantsForBox = signal<string>('');
+
+  // Query state for the paginated file uploads of a single box. The RS serves
+  // this endpoint page by page, so skip, limit and sort are sent to the server
+  // instead of being applied to a fully loaded list in the browser.
   #loadFileUploadsForBox = signal<string>('');
+  #fileUploadsSkip = signal<number>(0);
+  #fileUploadsLimit = signal<number>(DEFAULT_UPLOADS_PAGE_SIZE);
+  #fileUploadsSort = signal<string | undefined>(undefined);
+
+  #loadAllFileUploadsForBox = signal<string>('');
 
   #emptyBoxResults: BoxRetrievalResults = {
     count: 0,
@@ -103,15 +121,106 @@ export class UploadBoxService {
   );
 
   /**
-   * Resource for loading file uploads for a specific box.
+   * Build the request for a page of file uploads of a box.
+   * @param boxId - the ID of the upload box
+   * @param skip - the number of file uploads to skip
+   * @param limit - the maximum number of file uploads to return
+   * @param sort - the comma-separated sort specification, if any
+   * @returns the HTTP resource request for the requested page
    */
-  boxFileUploads = httpResource<FileUploadWithAccession[]>(
+  #fileUploadsRequest(boxId: string, skip: number, limit: number, sort?: string) {
+    const params: Record<string, string | number> = { skip, limit };
+    if (sort) params['sort'] = sort;
+    return {
+      url: `${this.#boxesUrl}/${encodeURIComponent(boxId)}/uploads`,
+      params,
+    };
+  }
+
+  /**
+   * Resource for loading one page of file uploads for a specific box.
+   *
+   * Pagination and sorting happen on the server: the current page and sort order
+   * are part of the request, so changing them refetches instead of reslicing a
+   * locally cached list.
+   */
+  boxFileUploads = httpResource<BoxUploadsPage>(
     () => {
       const boxId = this.#loadFileUploadsForBox();
       if (!boxId) return undefined;
-      return `${this.#boxesUrl}/${encodeURIComponent(boxId)}/uploads`;
+      return this.#fileUploadsRequest(
+        boxId,
+        this.#fileUploadsSkip(),
+        this.#fileUploadsLimit(),
+        this.#fileUploadsSort(),
+      );
     },
-    { defaultValue: [] },
+    { defaultValue: emptyBoxUploadsPage },
+  );
+
+  /**
+   * Resource for loading the complete list of file uploads for a specific box.
+   *
+   * Used by consumers that must reason about all files at once (file mapping and
+   * metadata alignment) rather than showing them page by page. Since the RS caps
+   * the page size, this walks through as many pages as the box needs, so boxes of
+   * any size are covered in full. It is therefore a plain `resource` rather than
+   * an `httpResource`, which could only issue a single request.
+   */
+  allBoxFileUploads = resource<FileUploadWithAccession[], string | undefined>({
+    params: () => this.#loadAllFileUploadsForBox() || undefined,
+    loader: async ({ params: boxId, abortSignal }) => {
+      const files: FileUploadWithAccession[] = [];
+      let totalCount = 0;
+      do {
+        const { url, params } = this.#fileUploadsRequest(
+          boxId,
+          files.length,
+          MAX_UPLOADS_PAGE_SIZE,
+        );
+        // Unsubscribing on abort cancels the in-flight request, so navigating
+        // away mid-walk does not keep fetching pages nobody waits for.
+        const page = await firstValueFrom(
+          this.#http
+            .get<BoxUploadsPage>(url, { params })
+            .pipe(takeUntil(fromEvent(abortSignal, 'abort'))),
+        );
+        totalCount = page.total_count;
+        files.push(...page.items);
+        // Guard against a page that reports more files than it ever delivers,
+        // which would otherwise keep requesting the same offset forever.
+        if (!page.items.length) break;
+      } while (files.length < totalCount);
+      return files;
+    },
+    defaultValue: [],
+  });
+
+  /** The file uploads on the currently loaded page. */
+  boxFiles = computed<FileUploadWithAccession[]>(() =>
+    this.boxFileUploads.error() ? [] : this.boxFileUploads.value().items,
+  );
+
+  /** The total number of file uploads in the box the current page belongs to. */
+  boxFilesTotalCount = computed<number>(() =>
+    this.boxFileUploads.error() ? 0 : this.boxFileUploads.value().total_count,
+  );
+
+  /** The number of file uploads currently skipped for pagination. */
+  boxFilesSkip = computed<number>(() => this.#fileUploadsSkip());
+
+  /** The current page size for the paginated file uploads. */
+  boxFilesLimit = computed<number>(() => this.#fileUploadsLimit());
+
+  /** The current sort specification for the paginated file uploads, if any. */
+  boxFilesSort = computed<string | undefined>(() => this.#fileUploadsSort());
+
+  /** The sorted column and direction of the paginated file uploads. */
+  boxFilesSortState = computed(() => fileUploadSortState(this.#fileUploadsSort()));
+
+  /** The complete list of file uploads of the box loaded via `loadAllFileUploadsForBox`. */
+  allBoxFiles = computed<FileUploadWithAccession[]>(() =>
+    this.allBoxFileUploads.error() ? [] : this.allBoxFileUploads.value(),
   );
 
   /**
@@ -226,11 +335,57 @@ export class UploadBoxService {
   }
 
   /**
-   * Trigger loading of file uploads for a specific box.
+   * Trigger loading of the first page of file uploads for a specific box.
+   * Switching to a different box resets pagination and sorting, so the caller
+   * never inherits the page position of a previously inspected box.
    * @param boxId - the ID of the upload box
    */
   loadFileUploadsForBox(boxId: string): void {
+    if (this.#loadFileUploadsForBox() !== boxId) {
+      this.#fileUploadsSkip.set(0);
+      this.#fileUploadsLimit.set(DEFAULT_UPLOADS_PAGE_SIZE);
+      this.#fileUploadsSort.set(undefined);
+    }
     this.#loadFileUploadsForBox.set(boxId);
+  }
+
+  /**
+   * Request a different page of the file uploads of the currently loaded box.
+   * @param limit - the page size
+   * @param skip - the number of file uploads to skip
+   */
+  paginateFileUploads(limit: number, skip: number): void {
+    this.#fileUploadsLimit.set(Math.min(limit, MAX_UPLOADS_PAGE_SIZE));
+    this.#fileUploadsSkip.set(skip);
+  }
+
+  /**
+   * Change the sort order of the file uploads of the currently loaded box and
+   * jump back to the first page, since the previous offset is meaningless in the
+   * new order.
+   * @param sort - comma-separated `FileUpload` field names, each optionally
+   *   prefixed with "-" for descending order, or undefined for the default order
+   */
+  sortFileUploads(sort: string | undefined): void {
+    this.#fileUploadsSort.set(sort || undefined);
+    this.#fileUploadsSkip.set(0);
+  }
+
+  /**
+   * Sort the file uploads of the currently loaded box by a table column.
+   * @param column - the sorted column of the file uploads table
+   * @param direction - the direction the column is sorted in
+   */
+  sortFileUploadsByColumn(column: string, direction: FileUploadSortDirection): void {
+    this.sortFileUploads(fileUploadSortSpec(column, direction));
+  }
+
+  /**
+   * Trigger loading of the complete file upload list for a specific box.
+   * @param boxId - the ID of the upload box
+   */
+  loadAllFileUploadsForBox(boxId: string): void {
+    this.#loadAllFileUploadsForBox.set(boxId);
   }
 
   /**
@@ -543,12 +698,18 @@ export class UploadBoxService {
       ]),
     );
 
-    if (!this.boxFileUploads.error()) {
-      const updated = this.boxFileUploads.value().map((f) => {
+    const applyAccessions = (files: FileUploadWithAccession[]) =>
+      files.map((f) => {
         const accession = accessionByBoxFileId.get(f.id);
         return accession !== undefined ? { ...f, accession } : f;
       });
-      this.boxFileUploads.value.set(updated);
+
+    if (!this.boxFileUploads.error()) {
+      const page = this.boxFileUploads.value();
+      this.boxFileUploads.value.set({ ...page, items: applyAccessions(page.items) });
+    }
+    if (!this.allBoxFileUploads.error()) {
+      this.allBoxFileUploads.value.set(applyAccessions(this.allBoxFileUploads.value()));
     }
 
     this.#updateUploadBoxLocally(boxId, { version: request.box_version });
@@ -595,11 +756,21 @@ export class UploadBoxService {
    * @param file - the deleted file upload
    */
   #deleteFileUploadLocally(boxId: string, file: FileUploadWithAccession): void {
-    if (!this.boxFileUploads.error()) {
-      this.boxFileUploads.value.set(
-        this.boxFileUploads.value().filter((f) => f.id !== file.id),
-      );
+    // The file list is paginated on the server, so simply dropping the file from
+    // the cached page would leave that page short and shift all following pages
+    // by one, hiding a file. Refetch the affected pages instead. If the deleted
+    // file was the only one on the last page, step back so the paginator does not
+    // end up beyond the end of the list.
+    const totalCount = this.boxFilesTotalCount();
+    const limit = this.#fileUploadsLimit();
+    const skip = this.#fileUploadsSkip();
+    if (skip > 0 && skip >= totalCount - 1) {
+      this.#fileUploadsSkip.set(Math.max(0, skip - limit));
+    } else {
+      this.boxFileUploads.reload();
     }
+    this.allBoxFileUploads.reload();
+
     const apply = (box: ResearchDataUploadBox): ResearchDataUploadBox => ({
       ...box,
       file_count: Math.max(0, box.file_count - 1),

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -1552,6 +1552,27 @@ export const uploadBox2FileUploads: FileUploadWithAccession[] = [
 ];
 
 /**
+ * Build the upload timestamp for one of the generated file uploads of a box.
+ *
+ * The uploads of a box are spread over two consecutive days, and deliberately not
+ * in the same order as the file aliases, so that sorting the file table by upload
+ * time gives a visibly different order than sorting it by file name.
+ * @param index - the index of the file within the box
+ * @param count - the number of files in the box
+ * @param firstDay - the ISO date (YYYY-MM-DD) of the first of the two days
+ * @returns the ISO timestamp at which the file finished uploading
+ */
+function uploadedAt(index: number, count: number, firstDay: string): string {
+  // 11 is coprime with both box sizes, so this permutes the files without repeats.
+  const slot = (index * 11) % count;
+  const perDay = Math.ceil(count / 2);
+  const uploaded = new Date(`${firstDay}T08:00:00Z`);
+  uploaded.setUTCDate(uploaded.getUTCDate() + Math.floor(slot / perDay));
+  uploaded.setUTCMinutes(uploaded.getUTCMinutes() + (slot % perDay) * 25);
+  return `${uploaded.toISOString().slice(0, 19)}Z`;
+}
+
+/**
  * RS file uploads for box 3 (archived, 28 files)
  */
 export const uploadBox3FileUploads: FileUploadWithAccession[] = Array.from(
@@ -1561,7 +1582,7 @@ export const uploadBox3FileUploads: FileUploadWithAccession[] = Array.from(
     box_id: 'b0f11e00-0000-4000-8000-a5f2dbc68003',
     alias: `archived_sample_${String(i + 1).padStart(3, '0')}.fastq.gz`,
     state: 'archived' as FileUploadWithAccession['state'],
-    state_updated: '2025-06-01T10:00:00Z',
+    state_updated: uploadedAt(i, 28, '2025-06-01'),
     storage_alias: 'TUE03',
     bucket_id: 'inbox-tue03',
     decrypted_sha256: (i % 10).toString().repeat(64),
@@ -1585,7 +1606,7 @@ export const uploadBox4FileUploads: FileUploadWithAccession[] = Array.from(
       box_id: 'b0f11e00-0000-4000-8000-a5f2dbc68004',
       alias: `sample_proteome_${String(i + 1).padStart(3, '0')}.raw`,
       state,
-      state_updated: '2026-02-04T08:00:00Z',
+      state_updated: uploadedAt(i, 15, '2026-02-04'),
       storage_alias: 'HD02',
       bucket_id: 'inbox-hd02',
       decrypted_sha256:
@@ -1630,83 +1651,37 @@ export const uploadBox5FileUploads: FileUploadWithAccession[] = [
 ];
 
 /**
- * The `/upload-boxes/{id}/uploads` endpoint is paginated and sorted by the RS and
- * answers with a page of file uploads plus the total unpaginated count. The
- * fixtures below are the pre-computed responses for the specific requests the
- * portal makes against the mocked boxes; `responses.ts` maps each query string to
- * one of them. Deriving them from the file lists above only avoids spelling out
- * the same files several times — the mock does not paginate or sort at runtime.
- * @param files - all file uploads of the box, in the order the RS would return them
- * @param skip - the number of file uploads the request skips
- * @param limit - the page size the request asks for
- * @returns the page response for that request
+ * Build the complete file upload collection of an upload box.
+ *
+ * The `/upload-boxes/{id}/uploads` endpoint is paginated and sorted by the RS, so
+ * these fixtures hold every file of a box in the RS default order (by alias). The
+ * mock handler derives whatever page and sort order a request asks for from them,
+ * which is why there is one fixture per box rather than one per request.
+ * @param files - all file uploads of the box
+ * @returns the complete collection response for that box
  */
-function uploadsPage(
-  files: FileUploadWithAccession[],
-  skip = 0,
-  limit = 10,
-): BoxUploadsPage {
-  return { items: files.slice(skip, skip + limit), total_count: files.length };
+function uploadsCollection(files: FileUploadWithAccession[]): BoxUploadsPage {
+  const items = [...files].sort((left, right) => left.alias.localeCompare(right.alias));
+  return { items, total_count: items.length };
 }
 
-/**
- * Order file uploads by alias, the default order of the RS.
- * @param files - the file uploads of a box
- * @returns the file uploads ordered by ascending alias
- */
-function byAlias(files: FileUploadWithAccession[]): FileUploadWithAccession[] {
-  return [...files].sort((left, right) => left.alias.localeCompare(right.alias));
-}
+/** The response for upload boxes without any file uploads */
+export const emptyUploadsCollection: BoxUploadsPage = { items: [], total_count: 0 };
 
-/**
- * Order file uploads by descending alias.
- * @param files - the file uploads of a box
- * @returns the file uploads ordered by descending alias
- */
-function byAliasDesc(files: FileUploadWithAccession[]): FileUploadWithAccession[] {
-  return byAlias(files).reverse();
-}
+/** File uploads of box 1 (open, 4 files) */
+export const uploadBox1Uploads = uploadsCollection(uploadBox1FileUploads);
 
-/** The empty page returned for upload boxes without any file uploads */
-export const emptyUploadsPage: BoxUploadsPage = { items: [], total_count: 0 };
+/** File uploads of box 2 (locked, 15 files, used by the mapping tool) */
+export const uploadBox2Uploads = uploadsCollection(uploadBox2FileUploads);
 
-/** Pages of file uploads for box 1 (open, 4 files) */
-export const uploadBox1UploadsPage1 = uploadsPage(byAlias(uploadBox1FileUploads));
-export const uploadBox1UploadsAll = uploadsPage(
-  byAlias(uploadBox1FileUploads),
-  0,
-  1000,
-);
+/** File uploads of box 3 (archived, 28 files, i.e. three pages) */
+export const uploadBox3Uploads = uploadsCollection(uploadBox3FileUploads);
 
-/** Pages of file uploads for box 2 (locked, 15 files, used by the mapping tool) */
-export const uploadBox2UploadsPage1 = uploadsPage(byAlias(uploadBox2FileUploads));
-export const uploadBox2UploadsPage2 = uploadsPage(byAlias(uploadBox2FileUploads), 10);
-export const uploadBox2UploadsAll = uploadsPage(
-  byAlias(uploadBox2FileUploads),
-  0,
-  1000,
-);
+/** File uploads of box 4 (open, 15 files) */
+export const uploadBox4Uploads = uploadsCollection(uploadBox4FileUploads);
 
-/** Pages of file uploads for box 3 (archived, 28 files) */
-export const uploadBox3UploadsPage1 = uploadsPage(byAlias(uploadBox3FileUploads));
-export const uploadBox3UploadsPage2 = uploadsPage(byAlias(uploadBox3FileUploads), 10);
-export const uploadBox3UploadsPage3 = uploadsPage(byAlias(uploadBox3FileUploads), 20);
-
-/**
- * The only file upload page mocked in a non-default sort order, needed by the e2e
- * test asserting that sorting reorders the whole box rather than the loaded page.
- * Sorting is otherwise not mocked — see the note in `responses.ts`.
- */
-export const uploadBox3UploadsDescPage1 = uploadsPage(
-  byAliasDesc(uploadBox3FileUploads),
-);
-
-/** Pages of file uploads for box 4 (open, 15 files) */
-export const uploadBox4UploadsPage1 = uploadsPage(byAlias(uploadBox4FileUploads));
-export const uploadBox4UploadsPage2 = uploadsPage(byAlias(uploadBox4FileUploads), 10);
-
-/** Pages of file uploads for box 5 (open, 2 files) */
-export const uploadBox5UploadsPage1 = uploadsPage(byAlias(uploadBox5FileUploads));
+/** File uploads of box 5 (open, 2 files) */
+export const uploadBox5Uploads = uploadsCollection(uploadBox5FileUploads);
 
 /**
  * WPS API

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -15,7 +15,10 @@ import { SearchResults } from '@app/metadata/models/search-results';
 import { Study } from '@app/metadata/models/study';
 import { BaseStorageLabels } from '@app/metadata/models/well-known-values';
 import { BoxRetrievalResults, UploadBoxState } from '@app/upload/models/box';
-import { FileUploadWithAccession } from '@app/upload/models/file-upload';
+import {
+  BoxUploadsPage,
+  FileUploadWithAccession,
+} from '@app/upload/models/file-upload';
 import { GrantWithBoxInfo } from '@app/upload/models/grant';
 import { FileIdMap, Study as RsStudy } from '@app/upload/models/study';
 import { DatasetWithExpiration } from '@app/work-packages/models/dataset';
@@ -1625,6 +1628,85 @@ export const uploadBox5FileUploads: FileUploadWithAccession[] = [
     accession: null,
   },
 ];
+
+/**
+ * The `/upload-boxes/{id}/uploads` endpoint is paginated and sorted by the RS and
+ * answers with a page of file uploads plus the total unpaginated count. The
+ * fixtures below are the pre-computed responses for the specific requests the
+ * portal makes against the mocked boxes; `responses.ts` maps each query string to
+ * one of them. Deriving them from the file lists above only avoids spelling out
+ * the same files several times — the mock does not paginate or sort at runtime.
+ * @param files - all file uploads of the box, in the order the RS would return them
+ * @param skip - the number of file uploads the request skips
+ * @param limit - the page size the request asks for
+ * @returns the page response for that request
+ */
+function uploadsPage(
+  files: FileUploadWithAccession[],
+  skip = 0,
+  limit = 10,
+): BoxUploadsPage {
+  return { items: files.slice(skip, skip + limit), total_count: files.length };
+}
+
+/**
+ * Order file uploads by alias, the default order of the RS.
+ * @param files - the file uploads of a box
+ * @returns the file uploads ordered by ascending alias
+ */
+function byAlias(files: FileUploadWithAccession[]): FileUploadWithAccession[] {
+  return [...files].sort((left, right) => left.alias.localeCompare(right.alias));
+}
+
+/**
+ * Order file uploads by descending alias.
+ * @param files - the file uploads of a box
+ * @returns the file uploads ordered by descending alias
+ */
+function byAliasDesc(files: FileUploadWithAccession[]): FileUploadWithAccession[] {
+  return byAlias(files).reverse();
+}
+
+/** The empty page returned for upload boxes without any file uploads */
+export const emptyUploadsPage: BoxUploadsPage = { items: [], total_count: 0 };
+
+/** Pages of file uploads for box 1 (open, 4 files) */
+export const uploadBox1UploadsPage1 = uploadsPage(byAlias(uploadBox1FileUploads));
+export const uploadBox1UploadsAll = uploadsPage(
+  byAlias(uploadBox1FileUploads),
+  0,
+  1000,
+);
+
+/** Pages of file uploads for box 2 (locked, 15 files, used by the mapping tool) */
+export const uploadBox2UploadsPage1 = uploadsPage(byAlias(uploadBox2FileUploads));
+export const uploadBox2UploadsPage2 = uploadsPage(byAlias(uploadBox2FileUploads), 10);
+export const uploadBox2UploadsAll = uploadsPage(
+  byAlias(uploadBox2FileUploads),
+  0,
+  1000,
+);
+
+/** Pages of file uploads for box 3 (archived, 28 files) */
+export const uploadBox3UploadsPage1 = uploadsPage(byAlias(uploadBox3FileUploads));
+export const uploadBox3UploadsPage2 = uploadsPage(byAlias(uploadBox3FileUploads), 10);
+export const uploadBox3UploadsPage3 = uploadsPage(byAlias(uploadBox3FileUploads), 20);
+
+/**
+ * The only file upload page mocked in a non-default sort order, needed by the e2e
+ * test asserting that sorting reorders the whole box rather than the loaded page.
+ * Sorting is otherwise not mocked — see the note in `responses.ts`.
+ */
+export const uploadBox3UploadsDescPage1 = uploadsPage(
+  byAliasDesc(uploadBox3FileUploads),
+);
+
+/** Pages of file uploads for box 4 (open, 15 files) */
+export const uploadBox4UploadsPage1 = uploadsPage(byAlias(uploadBox4FileUploads));
+export const uploadBox4UploadsPage2 = uploadsPage(byAlias(uploadBox4FileUploads), 10);
+
+/** Pages of file uploads for box 5 (open, 2 files) */
+export const uploadBox5UploadsPage1 = uploadsPage(byAlias(uploadBox5FileUploads));
 
 /**
  * WPS API

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -11,6 +11,92 @@ import { umamiHandlers } from './umami';
 
 const DELAY = 0; // delay in seconds for testing
 
+/** A list response carrying its entries in an `items` array */
+type Collection = { items: unknown[]; total_count?: number };
+
+/**
+ * Check whether a static response is a list response with an `items` array.
+ * @param response - the static response to check
+ * @returns whether the response is a collection
+ */
+function isCollection(response: ResponseValue): response is Collection {
+  return (
+    typeof response === 'object' &&
+    response !== null &&
+    Array.isArray((response as Collection).items)
+  );
+}
+
+/**
+ * Compare two entries of a collection by a single field.
+ *
+ * Entries without a value for the field sort last, numbers compare numerically
+ * and everything else compares as a string.
+ * @param left - the first entry
+ * @param right - the second entry
+ * @param field - the name of the field to compare by
+ * @returns a negative number, zero, or a positive number for ordering
+ */
+function compareByField(left: unknown, right: unknown, field: string): number {
+  const leftValue = (left as Record<string, unknown>)[field];
+  const rightValue = (right as Record<string, unknown>)[field];
+  if (leftValue == null || rightValue == null) {
+    if (leftValue == rightValue) return 0;
+    return leftValue == null ? 1 : -1;
+  }
+  if (typeof leftValue === 'number' && typeof rightValue === 'number') {
+    return leftValue - rightValue;
+  }
+  return String(leftValue).localeCompare(String(rightValue));
+}
+
+/**
+ * Derive the requested window of a complete collection response.
+ *
+ * This is the one piece of backend behaviour the mocks reproduce, because it is
+ * a convention shared by all paginated list endpoints rather than logic specific
+ * to any one of them: entries are sorted by the comma-separated field names in
+ * `sort` (a leading dash denotes descending order), the total count is reported
+ * before pagination, and `skip` and `limit` then select the page. Sorting has to
+ * happen before slicing, which is why the mock cannot simply reorder a response
+ * that is already a page.
+ * @param collection - the complete collection to derive the window from
+ * @param params - the query parameters of the request
+ * @returns the collection response for the requested window
+ */
+function windowOfCollection(
+  collection: Collection,
+  params: URLSearchParams,
+): Collection {
+  let items = collection.items;
+
+  const sort = params.get('sort');
+  if (sort) {
+    const specs = sort
+      .split(',')
+      .map((spec) => spec.trim())
+      .filter(Boolean);
+    items = [...items].sort((left, right) => {
+      for (const spec of specs) {
+        const descending = spec.startsWith('-');
+        const field = descending ? spec.slice(1) : spec;
+        const result = compareByField(left, right, field);
+        if (result) return descending ? -result : result;
+      }
+      return 0;
+    });
+  }
+
+  const total_count = items.length;
+  const skip = Number(params.get('skip')) || 0;
+  const limit = params.get('limit');
+  if (skip || limit !== null) {
+    items = items.slice(skip, limit === null ? undefined : skip + Number(limit));
+  }
+
+  return { ...collection, items, total_count };
+}
+
 /**
  * Create request handlers for the given responses
  *
@@ -117,6 +203,26 @@ function createHandlersForResponses(responses: {
       }
       if (Object.keys(responseMap).length > 1) {
         console.debug('Using mock data for params', paramString);
+      }
+      // Paginated list endpoints all share one convention (`sort`, `skip` and
+      // `limit` over an `items` array), so instead of registering a fixture per
+      // page and per sort order, a single fixture holding the whole collection is
+      // narrowed down to whatever the request asks for. This is deliberately not
+      // conditional on a `sort` parameter being present: the same code path also
+      // implements plain pagination, and skipping it for unsorted requests would
+      // return every entry on the first page.
+      //
+      // The exemption for entries that pin `skip` or `limit` in their key is what
+      // lets an endpoint stay fully static: such a fixture is a canned window
+      // rather than a complete collection, and narrowing it again would paginate
+      // twice and report a total count of just that window.
+      const matchedParams = new URLSearchParams(paramString ?? '');
+      if (
+        isCollection(response) &&
+        !matchedParams.has('skip') &&
+        !matchedParams.has('limit')
+      ) {
+        response = windowOfCollection(response, new URL(request.url).searchParams);
       }
       let status = 200;
       if (typeof response === 'number') {

--- a/src/mocks/responses.ts
+++ b/src/mocks/responses.ts
@@ -21,11 +21,19 @@ import {
   searchResults,
   storageLabels,
   studyData,
-  uploadBox1FileUploads,
-  uploadBox2FileUploads,
-  uploadBox3FileUploads,
-  uploadBox4FileUploads,
-  uploadBox5FileUploads,
+  emptyUploadsPage,
+  uploadBox1UploadsAll,
+  uploadBox1UploadsPage1,
+  uploadBox2UploadsAll,
+  uploadBox2UploadsPage1,
+  uploadBox2UploadsPage2,
+  uploadBox3UploadsDescPage1,
+  uploadBox3UploadsPage1,
+  uploadBox3UploadsPage2,
+  uploadBox3UploadsPage3,
+  uploadBox4UploadsPage1,
+  uploadBox4UploadsPage2,
+  uploadBox5UploadsPage1,
   uploadBoxes,
   pediatricLeukemiaDatasetDetails,
   pediatricLeukemiaFileIds,
@@ -273,18 +281,48 @@ export const responses: { [endpoint: string]: ResponseValue } = {
   // Fetch all upload boxes
   'GET /api/rs/upload-boxes': uploadBoxes,
 
-  // Fetch file uploads for a specific box
-  'GET /api/rs/upload-boxes/0a36607a-b53f-49ed-bf3e-a5f2dbc68001/uploads':
-    uploadBox1FileUploads,
-  'GET /api/rs/upload-boxes/0a36607a-b53f-49ed-bf3e-a5f2dbc68002/uploads':
-    uploadBox2FileUploads,
-  'GET /api/rs/upload-boxes/0a36607a-b53f-49ed-bf3e-a5f2dbc68003/uploads':
-    uploadBox3FileUploads,
-  'GET /api/rs/upload-boxes/0a36607a-b53f-49ed-bf3e-a5f2dbc68004/uploads':
-    uploadBox4FileUploads,
-  'GET /api/rs/upload-boxes/0a36607a-b53f-49ed-bf3e-a5f2dbc68005/uploads':
-    uploadBox5FileUploads,
-  'GET /api/rs/upload-boxes/*/uploads': [],
+  // Fetch a page of file uploads for a specific box. The RS paginates and sorts
+  // this endpoint, so there is one pre-made response per request the portal makes:
+  // `limit=10` pages back the file table, `limit=1000` the complete list the
+  // mapping tool needs.
+  //
+  // Only pagination is mocked. Sorting is not: the sole `sort` entry below exists
+  // for the e2e test that checks sorting reorders the whole box instead of just
+  // the loaded page. Every other sort request falls back to the entry matching the
+  // most parameters, i.e. the unsorted page, so clicking a sort header against the
+  // mock backend re-fetches the same rows. That is expected — add a fixture for a
+  // specific sort order if a test needs one, rather than sorting in the handler.
+  'GET /api/rs/upload-boxes/0a36607a-b53f-49ed-bf3e-a5f2dbc68001/uploads?skip=0&limit=10':
+    uploadBox1UploadsPage1,
+  'GET /api/rs/upload-boxes/0a36607a-b53f-49ed-bf3e-a5f2dbc68001/uploads?skip=0&limit=1000':
+    uploadBox1UploadsAll,
+
+  'GET /api/rs/upload-boxes/0a36607a-b53f-49ed-bf3e-a5f2dbc68002/uploads?skip=0&limit=10':
+    uploadBox2UploadsPage1,
+  'GET /api/rs/upload-boxes/0a36607a-b53f-49ed-bf3e-a5f2dbc68002/uploads?skip=10&limit=10':
+    uploadBox2UploadsPage2,
+  'GET /api/rs/upload-boxes/0a36607a-b53f-49ed-bf3e-a5f2dbc68002/uploads?skip=0&limit=1000':
+    uploadBox2UploadsAll,
+
+  'GET /api/rs/upload-boxes/0a36607a-b53f-49ed-bf3e-a5f2dbc68003/uploads?skip=0&limit=10':
+    uploadBox3UploadsPage1,
+  'GET /api/rs/upload-boxes/0a36607a-b53f-49ed-bf3e-a5f2dbc68003/uploads?skip=10&limit=10':
+    uploadBox3UploadsPage2,
+  'GET /api/rs/upload-boxes/0a36607a-b53f-49ed-bf3e-a5f2dbc68003/uploads?skip=20&limit=10':
+    uploadBox3UploadsPage3,
+  // The one mocked sort order (see above), used by the pagination e2e test.
+  'GET /api/rs/upload-boxes/0a36607a-b53f-49ed-bf3e-a5f2dbc68003/uploads?skip=0&limit=10&sort=-alias':
+    uploadBox3UploadsDescPage1,
+
+  'GET /api/rs/upload-boxes/0a36607a-b53f-49ed-bf3e-a5f2dbc68004/uploads?skip=0&limit=10':
+    uploadBox4UploadsPage1,
+  'GET /api/rs/upload-boxes/0a36607a-b53f-49ed-bf3e-a5f2dbc68004/uploads?skip=10&limit=10':
+    uploadBox4UploadsPage2,
+
+  'GET /api/rs/upload-boxes/0a36607a-b53f-49ed-bf3e-a5f2dbc68005/uploads?skip=0&limit=10':
+    uploadBox5UploadsPage1,
+
+  'GET /api/rs/upload-boxes/*/uploads': emptyUploadsPage,
 
   // Delete a single file upload from a box
   'DELETE /api/rs/upload-boxes/*/uploads/*': 204,

--- a/src/mocks/responses.ts
+++ b/src/mocks/responses.ts
@@ -21,19 +21,12 @@ import {
   searchResults,
   storageLabels,
   studyData,
-  emptyUploadsPage,
-  uploadBox1UploadsAll,
-  uploadBox1UploadsPage1,
-  uploadBox2UploadsAll,
-  uploadBox2UploadsPage1,
-  uploadBox2UploadsPage2,
-  uploadBox3UploadsDescPage1,
-  uploadBox3UploadsPage1,
-  uploadBox3UploadsPage2,
-  uploadBox3UploadsPage3,
-  uploadBox4UploadsPage1,
-  uploadBox4UploadsPage2,
-  uploadBox5UploadsPage1,
+  emptyUploadsCollection,
+  uploadBox1Uploads,
+  uploadBox2Uploads,
+  uploadBox3Uploads,
+  uploadBox4Uploads,
+  uploadBox5Uploads,
   uploadBoxes,
   pediatricLeukemiaDatasetDetails,
   pediatricLeukemiaFileIds,
@@ -281,48 +274,22 @@ export const responses: { [endpoint: string]: ResponseValue } = {
   // Fetch all upload boxes
   'GET /api/rs/upload-boxes': uploadBoxes,
 
-  // Fetch a page of file uploads for a specific box. The RS paginates and sorts
-  // this endpoint, so there is one pre-made response per request the portal makes:
-  // `limit=10` pages back the file table, `limit=1000` the complete list the
-  // mapping tool needs.
-  //
-  // Only pagination is mocked. Sorting is not: the sole `sort` entry below exists
-  // for the e2e test that checks sorting reorders the whole box instead of just
-  // the loaded page. Every other sort request falls back to the entry matching the
-  // most parameters, i.e. the unsorted page, so clicking a sort header against the
-  // mock backend re-fetches the same rows. That is expected — add a fixture for a
-  // specific sort order if a test needs one, rather than sorting in the handler.
-  'GET /api/rs/upload-boxes/0a36607a-b53f-49ed-bf3e-a5f2dbc68001/uploads?skip=0&limit=10':
-    uploadBox1UploadsPage1,
-  'GET /api/rs/upload-boxes/0a36607a-b53f-49ed-bf3e-a5f2dbc68001/uploads?skip=0&limit=1000':
-    uploadBox1UploadsAll,
-
-  'GET /api/rs/upload-boxes/0a36607a-b53f-49ed-bf3e-a5f2dbc68002/uploads?skip=0&limit=10':
-    uploadBox2UploadsPage1,
-  'GET /api/rs/upload-boxes/0a36607a-b53f-49ed-bf3e-a5f2dbc68002/uploads?skip=10&limit=10':
-    uploadBox2UploadsPage2,
-  'GET /api/rs/upload-boxes/0a36607a-b53f-49ed-bf3e-a5f2dbc68002/uploads?skip=0&limit=1000':
-    uploadBox2UploadsAll,
-
-  'GET /api/rs/upload-boxes/0a36607a-b53f-49ed-bf3e-a5f2dbc68003/uploads?skip=0&limit=10':
-    uploadBox3UploadsPage1,
-  'GET /api/rs/upload-boxes/0a36607a-b53f-49ed-bf3e-a5f2dbc68003/uploads?skip=10&limit=10':
-    uploadBox3UploadsPage2,
-  'GET /api/rs/upload-boxes/0a36607a-b53f-49ed-bf3e-a5f2dbc68003/uploads?skip=20&limit=10':
-    uploadBox3UploadsPage3,
-  // The one mocked sort order (see above), used by the pagination e2e test.
-  'GET /api/rs/upload-boxes/0a36607a-b53f-49ed-bf3e-a5f2dbc68003/uploads?skip=0&limit=10&sort=-alias':
-    uploadBox3UploadsDescPage1,
-
-  'GET /api/rs/upload-boxes/0a36607a-b53f-49ed-bf3e-a5f2dbc68004/uploads?skip=0&limit=10':
-    uploadBox4UploadsPage1,
-  'GET /api/rs/upload-boxes/0a36607a-b53f-49ed-bf3e-a5f2dbc68004/uploads?skip=10&limit=10':
-    uploadBox4UploadsPage2,
-
-  'GET /api/rs/upload-boxes/0a36607a-b53f-49ed-bf3e-a5f2dbc68005/uploads?skip=0&limit=10':
-    uploadBox5UploadsPage1,
-
-  'GET /api/rs/upload-boxes/*/uploads': emptyUploadsPage,
+  // Fetch file uploads for a specific box. This endpoint is paginated and sorted
+  // by the RS, so the fixtures are the complete file list of each box and the
+  // handler derives the requested page and sort order from them (registering them
+  // without skip or limit is what opts them into that). Any page and any sort
+  // order therefore works without a fixture per request.
+  'GET /api/rs/upload-boxes/0a36607a-b53f-49ed-bf3e-a5f2dbc68001/uploads':
+    uploadBox1Uploads,
+  'GET /api/rs/upload-boxes/0a36607a-b53f-49ed-bf3e-a5f2dbc68002/uploads':
+    uploadBox2Uploads,
+  'GET /api/rs/upload-boxes/0a36607a-b53f-49ed-bf3e-a5f2dbc68003/uploads':
+    uploadBox3Uploads,
+  'GET /api/rs/upload-boxes/0a36607a-b53f-49ed-bf3e-a5f2dbc68004/uploads':
+    uploadBox4Uploads,
+  'GET /api/rs/upload-boxes/0a36607a-b53f-49ed-bf3e-a5f2dbc68005/uploads':
+    uploadBox5Uploads,
+  'GET /api/rs/upload-boxes/*/uploads': emptyUploadsCollection,
 
   // Delete a single file upload from a box
   'DELETE /api/rs/upload-boxes/*/uploads/*': 204,

--- a/tests/admin-pages/upload-box-manager.spec.ts
+++ b/tests/admin-pages/upload-box-manager.spec.ts
@@ -145,6 +145,11 @@ test('paginates and sorts the file list on the server', async ({ adminPage: page
   await filesTable.getByRole('columnheader', { name: 'Filename' }).click();
   await expect(firstFile()).toHaveText('archived_sample_028.fastq.gz');
   await expect(paginator).toContainText('1 – 10 of 28');
+
+  // Archived boxes show the accession instead of the upload status, and it is
+  // sorted by the backend like any other column.
+  await filesTable.getByRole('columnheader', { name: 'Accession' }).click();
+  await expect(firstFile()).toHaveText('archived_sample_001.fastq.gz');
 });
 
 test('validates required fields in the create upload box dialog', async ({

--- a/tests/admin-pages/upload-box-manager.spec.ts
+++ b/tests/admin-pages/upload-box-manager.spec.ts
@@ -121,6 +121,32 @@ test('displays error message when upload box not found', async ({
   await expect(page).toHaveURL('/upload-box-manager');
 });
 
+test('paginates and sorts the file list on the server', async ({ adminPage: page }) => {
+  // An archived box holding 28 files, i.e. three pages of ten.
+  await page.goto('/upload-box-manager/0a36607a-b53f-49ed-bf3e-a5f2dbc68003');
+  await expectTitle(page, 'Upload Box Details');
+
+  const filesTable = page.locator('app-upload-box-files-table table');
+  const firstFile = () => filesTable.locator('tbody tr td').first();
+
+  await expect(firstFile()).toHaveText('archived_sample_001.fastq.gz');
+  await expect(filesTable.locator('tbody tr')).toHaveCount(10);
+
+  const paginator = page.getByLabel('Select page of files');
+  await expect(paginator).toContainText('1 – 10 of 28');
+
+  // Only the requested page is fetched, so the next page must come from the server.
+  await paginator.getByRole('button', { name: 'Next page' }).click();
+  await expect(firstFile()).toHaveText('archived_sample_011.fastq.gz');
+  await expect(paginator).toContainText('11 – 20 of 28');
+
+  // Sorting is applied across the whole box, not just within the current page,
+  // and returns to the first page.
+  await filesTable.getByRole('columnheader', { name: 'Filename' }).click();
+  await expect(firstFile()).toHaveText('archived_sample_028.fastq.gz');
+  await expect(paginator).toContainText('1 – 10 of 28');
+});
+
 test('validates required fields in the create upload box dialog', async ({
   adminPage: page,
 }) => {


### PR DESCRIPTION
The RS endpoint `GET /upload-boxes/{id}/uploads` is now paginated and sorted. Uploaded files are therefore paginated on the server instead of in the browser.

This PR assumes the backend gains the ability to sort by accession, and I already created a [PR](https://github.com/ghga-de/ghga-registry-service/pull/25) to add this to RS.

- `UploadBoxService`: `boxFileUploads` is keyed on skip/limit/sort signals and refetches on change; the file table emits page/sort events instead of reordering rows itself.
- Mapping and metadata alignment need the whole box at once, so they use a separate `allBoxFileUploads` resource that walks pages until complete (the endpoint caps `limit` at 1000).
- Deleting a file refetches instead of patching the cached page, which would have shifted the following pages and hidden a file.
- Mocks: `createHandlersForResponses` now derives the requested window from fixtures registered as complete collections, so no fixture per page or sort order is needed.